### PR TITLE
Don't trigger code run on page load

### DIFF
--- a/src/components/EmbeddedViewer/EmbeddedViewer.js
+++ b/src/components/EmbeddedViewer/EmbeddedViewer.js
@@ -15,7 +15,6 @@ const EmbeddedViewer = (props) => {
 
   useEffect(() => {
     dispatch(setEmbedded());
-    dispatch(triggerCodeRun());
   }, []);
 
   return projectLoaded === true ? (


### PR DESCRIPTION
We won't auto start code running on the embedded player as autorun can be annoying for the user.