### PR TITLE
Add embedded route

### DIFF
--- a/src/components/Editor/Hooks/useEmbeddedMode.js
+++ b/src/components/Editor/Hooks/useEmbeddedMode.js
@@ -1,0 +1,14 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux'
+import { setEmbedded } from '../EditorSlice'
+
+export const useEmbeddedMode = (embed = false) => {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    if (embed) {
+      dispatch(setEmbedded());
+    }
+  }, []);
+};

--- a/src/components/Editor/Project/Project.js
+++ b/src/components/Editor/Project/Project.js
@@ -19,6 +19,7 @@ import { remixProject, updateProject } from '../../../utils/apiCallHandler';
 
 const Project = () => {
   const project = useSelector((state) => state.editor.project);
+  const embedded = useSelector((state) => state.editor.isEmbedded);
   const dispatch = useDispatch();
   let history = useHistory()
   const stateAuth = useSelector(state => state.auth);
@@ -59,23 +60,25 @@ const Project = () => {
 
   return (
     <div className='proj'>
-      <div className='proj-header'>
-        <div>
-          <h1>{project.name}</h1>
-          { project.parent ? (
-          <p>Remixed from <a href={host+'/'+project.project_type+'/'+project.parent.identifier}>{project.parent.name}</a></p>
-         ) : null }
+      { embedded !== true ? (
+        <div className='proj-header'>
+          <div>
+            <h1>{project.name}</h1>
+            { project.parent ? (
+            <p>Remixed from <a href={host+'/'+project.project_type+'/'+project.parent.identifier}>{project.parent.name}</a></p>
+          ) : null }
+          </div>
+          <div className='proj-controls'>
+            { project.identifier && (
+              user !== null ? (
+              <>
+                {project.user_id === user.profile.user ? (<Button onClickHandler={onClickSave} buttonText="Save Project" />) : (<Button onClickHandler={onClickRemix} buttonText="Remix Project" />)}
+              </>
+              ) : null
+            )}
+          </div>
         </div>
-        <div className='proj-controls'>
-          { project.identifier && (
-            user !== null ? (
-            <>
-              {project.user_id === user.profile.user ? (<Button onClickHandler={onClickSave} buttonText="Save Project" />) : (<Button onClickHandler={onClickRemix} buttonText="Remix Project" />)}
-            </>
-            ) : null
-          )}
-        </div>
-      </div>
+      ) : null }
       <div>
         <RunnerControls/>
       </div>

--- a/src/components/Editor/ProjectComponentLoader/ProjectComponentLoader.js
+++ b/src/components/Editor/ProjectComponentLoader/ProjectComponentLoader.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useSelector } from 'react-redux'
 import { useProject } from '../Hooks/useProject'
+import { useEmbeddedMode } from '../Hooks/useEmbeddedMode'
 import Project from '../Project/Project'
 
 const DEFAULT_PROJECT_TYPE = 'python'
@@ -9,8 +10,11 @@ const ProjectComponentLoader = (props) => {
   const projectLoaded = useSelector((state) => state.editor.projectLoaded);
   const projectIdentifier = props.match.params.identifier;
   const projectType = props.match.params.projectType || DEFAULT_PROJECT_TYPE;
-  
-  useProject(projectType, projectIdentifier)
+  const embedded = props.embedded || false;
+
+  useEmbeddedMode(embedded);
+  useProject(projectType, projectIdentifier);
+
 
   return projectLoaded === true ? (
     <>

--- a/src/components/EmbeddedViewer/EmbeddedViewer.js
+++ b/src/components/EmbeddedViewer/EmbeddedViewer.js
@@ -1,21 +1,17 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import './EmbeddedViewer.css';
-import React, { useEffect } from 'react';
-import { useSelector, useDispatch } from 'react-redux'
+import React from 'react';
+import { useSelector } from 'react-redux'
 import { useProject } from '../Editor/Hooks/useProject'
+import { useEmbeddedMode } from '../Editor/Hooks/useEmbeddedMode'
 import PythonRunner from '../Editor/Runners/PythonRunner/PythonRunner'
 import EmbeddedControls from './EmbeddedControls/EmbeddedControls'
-import { setEmbedded } from '../Editor/EditorSlice'
 
 const EmbeddedViewer = (props) => {
   const projectLoaded = useSelector((state) => state.editor.projectLoaded);
   const projectIdentifier = props.match.params.identifier;
-  const dispatch = useDispatch();
   useProject('python', projectIdentifier);
-
-  useEffect(() => {
-    dispatch(setEmbedded());
-  }, []);
+  useEmbeddedMode(true);
 
   return projectLoaded === true ? (
     <>

--- a/src/components/Routes.js
+++ b/src/components/Routes.js
@@ -30,11 +30,15 @@ const Routes = () => (
         path="/:projectType"
         component={ProjectComponentLoader}
       />
-
       <Route
         exact
         path="/:projectType/:identifier"
         component={ProjectComponentLoader}
+      />
+      <Route
+        exact
+        path="/embedded/:projectType/:identifier"
+        render={(props) => <ProjectComponentLoader {...props} embedded={true} />}
       />
       <Route
         exact


### PR DESCRIPTION
Adds an `/embedded/` route to allow embedding projects in an iframe and show the project code as well as the runner.
e.g. `/embedded/python/python-hello-starter`

- Adds hook to set embedded mode
- Hides some UI when in embedded mode (login, save/remix, project title etc)

This is a quick implementation for the ESA demo this week. We can look at moving some of the UI into components and rendering appropriately instead of using conditionals at a later point.