### PR TITLE
Minor NGINX tweak to allow paths for heroku deployments

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -35,5 +35,9 @@ http {
 		client_max_body_size <%= ENV['NGINX_CLIENT_MAX_BODY_SIZE'] || 1 %>M;
 
 		root /app/build; # path to your app
+
+		location / {
+			try_files $uri /index.html;  
+		}
 	}
 }


### PR DESCRIPTION
I've manually deployed this to staging to hopefully (🤞) unblock @loiswells97 

What it does:
- tries to load the $uri path
- if unsuccessful return to `index.html`

Not sure if that's the behaviour you want but it's a little code to open up all available react router paths