### PR TITLE
Release 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [0.7.0]
+
 ### Changed
 
 - Set indentation to 4 spaces to match PEP8 standard (#246)
@@ -104,11 +106,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - Events in Web Component indicating whether Mission Zero criteria have been met (#113)
 
-[Unreleased]: https://github.com/RaspberryPiFoundation/editor-ui/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/RaspberryPiFoundation/editor-ui/compare/v0.7.0...HEAD
 [0.1.0]: https://github.com/RaspberryPiFoundation/editor-ui/releases/tag/v0.1.0
 [0.2.0]: https://github.com/RaspberryPiFoundation/editor-ui/releases/tag/v0.2.0
 [0.3.0]: https://github.com/RaspberryPiFoundation/editor-ui/releases/tag/v0.3.0
 [0.4.0]: https://github.com/RaspberryPiFoundation/editor-ui/releases/tag/v0.4.0
 [0.5.0]: https://github.com/RaspberryPiFoundation/editor-ui/releases/tag/v0.5.0
 [0.6.0]: https://github.com/RaspberryPiFoundation/editor-ui/releases/tag/v0.6.0
+[0.6.0]: https://github.com/RaspberryPiFoundation/editor-ui/releases/tag/v0.7.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raspberrypifoundation/editor-ui",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "dependencies": {
     "@babel/core": "^7.17.10",


### PR DESCRIPTION
- Set indentation to 4 spaces to match PEP8 standard (#246)
- Update Github workflow not to strip dots from the git ref, and remove test dependency for main and ref deploys (#244)