### PR TITLE
Small buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Message prompting users to login or save if they make non-autosaved changes (#291)
 - Unit tests for the autosave trigger (#291)
 - Project not found and access denied modals shown on project loading error (#298)
+- Styling for skinny buttons (#303)
 
 ## Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Message prompting users to login or save if they make non-autosaved changes (#291)
 - Unit tests for the autosave trigger (#291)
 - Project not found and access denied modals shown on project loading error (#298)
-- Styling for skinny buttons (#303)
+- Styling for small buttons (#303)
 
 ## Changed
 

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -5,7 +5,7 @@ import { confirmAlert } from 'react-confirm-alert';
 import 'react-confirm-alert/src/react-confirm-alert.css';
 
 const Button = (props) => {
-  const { className, onClickHandler, ButtonIcon, buttonImage, buttonImageAltText, buttonText, disabled, confirmText } = props;
+  const { className, onClickHandler, ButtonIcon, buttonImage, buttonImageAltText, buttonText, buttonOuter, disabled, confirmText } = props;
 
   var buttonClass="btn"
   buttonClass = (className ? buttonClass += ` ${className}`: buttonClass)
@@ -30,13 +30,23 @@ const Button = (props) => {
     });
   }
 
-  return (
+  const button = (
     <button className={buttonClass} disabled={disabled} onClick={onButtonClick}>
       { buttonImage ? <img src={buttonImage} alt={buttonImageAltText}/> : null }
       { ButtonIcon ? <ButtonIcon /> : null }
-      { buttonText ? <span>{buttonText}</span> : null }
+      { buttonText ? <span>{buttonText} </span> : null }
     </button>
-  )
+  );
+
+  if (buttonOuter) {
+    return (
+      <div className='btn-outer'>
+        {button}
+      </div>
+    )
+  }
+
+  return button;
 };
 
 export default Button;

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -31,7 +31,7 @@ const Button = (props) => {
   }
 
   const button = (
-    <button className={buttonClass} disabled={disabled} onClick={onButtonClick}>
+    <button className={buttonClass} disabled={disabled} onClick={buttonOuter ? null : onButtonClick}>
       { buttonImage ? <img src={buttonImage} alt={buttonImageAltText}/> : null }
       { ButtonIcon ? <ButtonIcon /> : null }
       { buttonText ? <span>{buttonText}</span> : null }
@@ -40,7 +40,7 @@ const Button = (props) => {
 
   if (buttonOuter) {
     return (
-      <div className='btn-outer'>
+      <div className='btn-outer' onClick={onButtonClick}>
         {button}
       </div>
     )

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -34,7 +34,7 @@ const Button = (props) => {
     <button className={buttonClass} disabled={disabled} onClick={onButtonClick}>
       { buttonImage ? <img src={buttonImage} alt={buttonImageAltText}/> : null }
       { ButtonIcon ? <ButtonIcon /> : null }
-      { buttonText ? <span>{buttonText} </span> : null }
+      { buttonText ? <span>{buttonText}</span> : null }
     </button>
   );
 

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -58,6 +58,12 @@
   text-decoration: none;
   width: fit-content;
 
+  &:disabled {
+    background-color: $rpf-darkmode-grey32;
+    color: $rpf-white;
+    cursor: default;
+  }
+
   &:focus-visible {
     border: 3px solid $rpf-brand-raspberry;
     outline: none;
@@ -67,14 +73,28 @@
     margin-right: var(--spacing-1);
   }
 
-  &:disabled {
-    background-color: $rpf-darkmode-grey32;
-    color: $rpf-white;
-    cursor: default;
-  }
-
   &--small {
     padding: var(--spacing-four);
+  }
+
+  .btn-outer {
+    background: transparent;
+    cursor: pointer;
+    padding: var(--spacing-eight) 0;
+  
+    &:focus-visible {
+      outline: none;
+  
+      .btn {
+        border: 3px solid $rpf-brand-raspberry;
+      }
+    }
+  }
+  
+  .font-size-large {
+    .btn svg {
+      margin-right: var(--spacing-2);
+    }
   }
 
   // Variants
@@ -112,26 +132,6 @@
         fill: $rpi-grey-70;
       }
     }
-  }
-}
-
-.btn-outer {
-  background: transparent;
-  cursor: pointer;
-  padding: var(--spacing-eight) 0;
-
-  &:focus-visible {
-    outline: none;
-
-    .btn {
-      border: 3px solid $rpf-brand-raspberry;
-    }
-  }
-}
-
-.font-size-large {
-  .btn svg {
-    margin-right: var(--spacing-2);
   }
 }
 

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -45,7 +45,28 @@
 .btn-outer {
   background: transparent;
   cursor: pointer;
-  padding: 6px 0px;
+  padding: var(--spacing-eight) 0;
+
+  &:active {
+    .btn--primary {
+      background-color: $rpf-teal-tint-25;
+    }
+  }
+
+  &:hover {
+    .btn--primary {
+      background-color: $rpf-teal-shade-20;
+    }
+  }
+
+  &:focus-visible {
+    outline: none;
+
+    .btn--primary {
+      background-color: $rpf-teal;
+      border: 3px solid $rpf-brand-raspberry;
+    }
+  }
 }
 
 .btn {

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -77,26 +77,6 @@
     padding: var(--spacing-four);
   }
 
-  .btn-outer {
-    background: transparent;
-    cursor: pointer;
-    padding: var(--spacing-eight) 0;
-  
-    &:focus-visible {
-      outline: none;
-  
-      .btn {
-        border: 3px solid $rpf-brand-raspberry;
-      }
-    }
-  }
-  
-  .font-size-large {
-    .btn svg {
-      margin-right: var(--spacing-2);
-    }
-  }
-
   // Variants
   &--primary {
     $colours: $rpf-teal, $rpf-teal-tint-25, $rpf-teal-tint-75, $rpi-grey-70, $rpf-teal, $rpf-teal-shade-20;
@@ -132,6 +112,26 @@
         fill: $rpi-grey-70;
       }
     }
+  }
+}
+
+.btn-outer {
+  background: transparent;
+  cursor: pointer;
+  padding: var(--spacing-eight) 0;
+
+  &:focus-visible {
+    outline: none;
+
+    .btn {
+      border: 3px solid $rpf-brand-raspberry;
+    }
+  }
+}
+
+.font-size-large {
+  .btn svg {
+    margin-right: var(--spacing-2);
   }
 }
 

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -80,7 +80,7 @@
   }
 
   &--small {
-    padding: 4px;
+    padding: var(--spacing-four);
   }
 
   // Variants

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -42,6 +42,12 @@
   }
 }
 
+.btn-outer {
+  background: transparent;
+  cursor: pointer;
+  padding: 6px 0px;
+}
+
 .btn {
   align-items: center;
   border-radius: 8px;
@@ -71,6 +77,10 @@
     background-color: $rpf-darkmode-grey32;
     color: $rpf-white;
     cursor: default;
+  }
+
+  &--small {
+    padding: 4px;
   }
 
   // Variants

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -17,7 +17,7 @@
     }
   }
 
-  &:active {
+  &:active, .btn-outer:active & {
     background-color: $active-bg;
     @content;
   }
@@ -31,41 +31,14 @@
     }
   }
 
-  &:focus-visible {
+  &:focus-visible, .btn-outer:focus-visible & {
     background-color: $focus-bg;
     @content;
   }
   
-  &:hover {
+  &:hover, .btn-outer:hover & {
     background-color: $hover-bg;
     @content;
-  }
-}
-
-.btn-outer {
-  background: transparent;
-  cursor: pointer;
-  padding: var(--spacing-eight) 0;
-
-  &:active {
-    .btn--primary {
-      background-color: $rpf-teal-tint-25;
-    }
-  }
-
-  &:hover {
-    .btn--primary {
-      background-color: $rpf-teal-shade-20;
-    }
-  }
-
-  &:focus-visible {
-    outline: none;
-
-    .btn--primary {
-      background-color: $rpf-teal;
-      border: 3px solid $rpf-brand-raspberry;
-    }
   }
 }
 
@@ -105,7 +78,6 @@
   }
 
   // Variants
-
   &--primary {
     $colours: $rpf-teal, $rpf-teal-tint-25, $rpf-teal-tint-75, $rpi-grey-70, $rpf-teal, $rpf-teal-shade-20;
     @include button-styling($colours...);
@@ -143,6 +115,20 @@
   }
 }
 
+.btn-outer {
+  background: transparent;
+  cursor: pointer;
+  padding: var(--spacing-eight) 0;
+
+  &:focus-visible {
+    outline: none;
+
+    .btn {
+      border: 3px solid $rpf-brand-raspberry;
+    }
+  }
+}
+
 .font-size-large {
   .btn svg {
     margin-right: var(--spacing-2);
@@ -150,6 +136,50 @@
 }
 
 .--dark {
+  .btn-outer {
+    &:hover {
+      .btn--primary {
+        background-color: $rpf-teal-tint-25;
+      }
+
+      .btn--secondary {
+        background-color: $rpf-darkmode-grey22;
+      }
+
+      .btn--tertiary {
+        background-color: inherit;
+      }
+    }
+
+    &:active {
+      .btn--primary {
+        background-color: $rpf-teal-tint-75;
+      }
+
+      .btn--secondary {
+        background-color: $rpf-darkmode-grey22;
+      }
+
+      .btn--tertiary {
+        background-color: inherit;
+      }
+    }
+
+    &:focus-visible {
+      .btn--primary {
+        background-color: $rpf-teal-tint-50;
+      }
+
+      .btn--secondary {
+        background-color: $rpf-darkmode-grey32;
+      }
+
+      .btn--tertiary {
+        background-color: inherit;
+      }
+    }
+  }
+
   .btn--primary {
     $colours: $rpf-teal-tint-50, $rpf-teal-tint-75, $rpf-darkmode-grey80, $rpf-darkmode-grey22, $rpf-teal-tint-50, $rpf-teal-tint-25;
     @include button-styling($colours...);

--- a/src/components/Editor/NewComponentButton/NewComponentButton.js
+++ b/src/components/Editor/NewComponentButton/NewComponentButton.js
@@ -40,8 +40,8 @@ const NewComponentButton = () => {
     }
 
     return (
-      <div className={`--${theme}`}>
-        <Button buttonText={t('filePane.newFileButton')} ButtonIcon={NewFileIcon} onClickHandler={showModal} className="btn--primary proj-new-component-button" />
+      <div className={`--${theme} btn-outer `}>
+        <Button buttonText={t('filePane.newFileButton')} ButtonIcon={NewFileIcon} onClickHandler={showModal} className="btn--primary btn--small proj-new-component-button" />
 
         <Modal
           isOpen={modalIsOpen}

--- a/src/components/Editor/NewComponentButton/NewComponentButton.js
+++ b/src/components/Editor/NewComponentButton/NewComponentButton.js
@@ -40,8 +40,8 @@ const NewComponentButton = () => {
     }
 
     return (
-      <div className={`--${theme} btn-outer `}>
-        <Button buttonText={t('filePane.newFileButton')} ButtonIcon={NewFileIcon} onClickHandler={showModal} className="btn--primary btn--small proj-new-component-button" />
+      <div className={`--${theme}`}>
+        <Button buttonText={t('filePane.newFileButton')} ButtonIcon={NewFileIcon} buttonOuter onClickHandler={showModal} className="btn--primary btn--small proj-new-component-button" />
 
         <Modal
           isOpen={modalIsOpen}

--- a/src/components/Editor/NewComponentButton/NewComponentButton.js
+++ b/src/components/Editor/NewComponentButton/NewComponentButton.js
@@ -9,7 +9,6 @@ import Button from '../../Button/Button'
 import NameErrorMessage from '../ErrorMessage/NameErrorMessage';
 import { CloseIcon, NewFileIcon } from '../../../Icons';
 import { validateFileName } from '../../../utils/componentNameValidation';
-import { useCookies } from 'react-cookie';
 import { useTranslation } from 'react-i18next';
 
 const NewComponentButton = () => {

--- a/src/components/Editor/NewComponentButton/NewComponentButton.js
+++ b/src/components/Editor/NewComponentButton/NewComponentButton.js
@@ -20,10 +20,6 @@ const NewComponentButton = () => {
     const projectComponents = useSelector((state) => state.editor.project.components);
     const componentNames = projectComponents.map(component => `${component.name}.${component.extension}`)
 
-    const [cookies] = useCookies(['fontSize', 'theme'])
-    const isDarkMode = cookies.theme==="dark" || (!cookies.theme && window.matchMedia("(prefers-color-scheme:dark)").matches)
-    const theme = isDarkMode ? "dark" : "light"
-
     const closeModal = () => setIsOpen(false);
     const showModal = () => {
       dispatch(setNameError(""));
@@ -40,7 +36,7 @@ const NewComponentButton = () => {
     }
 
     return (
-      <div className={`--${theme}`}>
+      <div>
         <Button buttonText={t('filePane.newFileButton')} ButtonIcon={NewFileIcon} buttonOuter onClickHandler={showModal} className="btn--primary btn--small proj-new-component-button" />
 
         <Modal

--- a/src/editor-spacing.scss
+++ b/src/editor-spacing.scss
@@ -1,3 +1,5 @@
 :root, :host {
-  --spacing-half: calc(0.5rem * var(--spacing-multiplier))
+  --spacing-half: calc(0.5rem * var(--spacing-multiplier));
+  --spacing-eight: calc(var(--spacing-1) / 1.25);
+  --spacing-four: calc(var(--spacing-eight) / 2);
 }


### PR DESCRIPTION
- Refactors the button component to accept a buttonOuter prop
- Removed the theme from the NewComponentButton as pulls styles from the app class
- Styling for the small button, with larger hit area

-----
To use the `btn--small` in the future just need to pass the `buttonOuter` to the `Button` and `btn--small` class

-----
Video as no review app:

https://user-images.githubusercontent.com/14238047/209164727-63b36ed7-754f-4d1d-8d80-b240cb63f9f7.mov

