### PR TITLE
release for v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [0.12.0] - 2023-01-27
 ### Changed
 
 - Simplified the URL structure to replace project type (#347)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ## [0.12.0] - 2023-01-27
+
 ### Changed
 
 - Simplified the URL structure to replace project type (#347)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -235,7 +235,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - Events in Web Component indicating whether Mission Zero criteria have been met (#113)
 
-[Unreleased]: https://github.com/RaspberryPiFoundation/editor-ui/compare/v0.11.0...HEAD
+[Unreleased]: https://github.com/RaspberryPiFoundation/editor-ui/compare/v0.12.0...HEAD
+[0.12.0]: https://github.com/RaspberryPiFoundation/editor-ui/releases/tag/v0.12.0
 [0.11.0]: https://github.com/RaspberryPiFoundation/editor-ui/releases/tag/v0.11.0
 [0.10.0]: https://github.com/RaspberryPiFoundation/editor-ui/releases/tag/v0.10.0
 [0.9.0]: https://github.com/RaspberryPiFoundation/editor-ui/releases/tag/v0.9.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raspberrypifoundation/editor-ui",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "private": true,
   "dependencies": {
     "@babel/core": "^7.17.10",


### PR DESCRIPTION
### Changed

- Simplified the URL structure to replace project type (#347)
- Upgrade `react-router` to `v6`
- Bump json5 from 1.0.1 to 1.0.2 (#321)

### Fixed

- Show `p5` error messages in the user interface (#346)
- Get review apps working (#351)