### PR TITLE
Fix null from the hidden codemirror img

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Renaming project, adding new file or renaming file always triggers autosave (#368)
 - Use `HtmlRunner` for `html` projects (#378)
 - Accessibility Fixes (#373, #382, #383)
+- Add `visibility: hidden` to the codemirror `cm-widgetBuffer` (#384)
 
 ## [0.12.0] - 2023-01-27
 

--- a/src/components/Editor/EditorPanel/EditorPanel.js
+++ b/src/components/Editor/EditorPanel/EditorPanel.js
@@ -96,6 +96,7 @@ const EditorPanel = ({
     const hiddenImages = view.contentDOM.getElementsByClassName('cm-widgetBuffer');
     for (let img of hiddenImages) {
       img.setAttribute('alt', null)
+      img.style.visibility = 'hidden'
     }
 
     return () => {


### PR DESCRIPTION
- Adds a `visibility: hidden` to the hidden img tag from code mirror to stop the alt text showing in the editor

Before: 
![Screenshot 2023-02-28 at 13 52 30](https://user-images.githubusercontent.com/14238047/221874074-74aec9b8-ebc6-4e13-bc89-53e95f081f7b.png)

After: 
![Screenshot 2023-02-28 at 13 52 13](https://user-images.githubusercontent.com/14238047/221874100-1feba66f-9957-477d-b425-878931ac037d.png)
