### PR TITLE
Tab discrepancy fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Use `HtmlRunner` for `html` projects (#378)
 - Accessibility Fixes (#373, #382, #383)
 - Add `visibility: hidden` to the codemirror `cm-widgetBuffer` (#384)
+- Height discrepancy of the tab containers (#385)
 
 ## [0.12.0] - 2023-01-27
 

--- a/src/tabs.scss
+++ b/src/tabs.scss
@@ -97,6 +97,7 @@ $spacing-four: calc($spacing-eight / 2);
 
     &__tab-container {
       display: flex;
+      height: 50px;
     }
   
     &__tab-list {


### PR DESCRIPTION
After increasing the hit area on the output toggle there is now a 2px difference between the heights of the tab container. Have added a `height: 50px` so that they stay the same height of `51px` (50px + 1px border)

**The bug:** 
See bug on staging: https://staging-editor.raspberrypi.org/ 
The text input is `49px` and the output is `51px`
![Screenshot 2023-02-28 at 14 33 00](https://user-images.githubusercontent.com/14238047/221884583-ea2a02f5-e341-4ede-81cc-67b2c9bcd507.png)
![Screenshot 2023-02-28 at 14 33 04](https://user-images.githubusercontent.com/14238047/221884603-ab5c12e7-4fc2-443d-a2be-0a4b5900f4a4.png)
