### PR TITLE
Add sentry tracing for GraphQL and Routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Updated privacy policy link to use the child friendly privacy policy (#397)
 - Update URL structure to include locale (#407)
+- Update Sentry configuration to allow distributed tracing (#411)
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@sentry/react": "7.16.0",
     "@sentry/tracing": "7.16.0",
     "@szhsin/react-menu": "^3.2.0",
+    "apollo-link-sentry": "^3.2.3",
     "axios": "^0.24.0",
     "codemirror": "^6.0.1",
     "date-fns": "^2.29.3",

--- a/src/components/AppRoutes.js
+++ b/src/components/AppRoutes.js
@@ -1,5 +1,7 @@
 import { React, Fragment } from 'react'
 import { Route, Routes, Navigate, useParams } from 'react-router-dom'
+import * as Sentry from "@sentry/react";
+
 import i18n from 'i18next';
 import ProjectComponentLoader from './Editor/ProjectComponentLoader/ProjectComponentLoader'
 import ProjectIndex from './ProjectIndex/ProjectIndex'
@@ -16,8 +18,10 @@ const ProjectsRedirect = () => {
   return <Navigate replace to={`/en/projects/${identifier}`} />
 }
 
+const SentryRoutes = Sentry.withSentryReactRouterV6Routing(Routes)
+
 const AppRoutes = () => (
-  <Routes>
+  <SentryRoutes>
     <Route
       path="/auth/callback"
       element={<Callback/>}
@@ -57,7 +61,7 @@ const AppRoutes = () => (
     { localeRedirects.map(link => {
       return <Route key={link} path={link} element={<Navigate replace to={`/en${link}`} />} />
     }) }
-  </Routes>
+  </SentryRoutes>
 )
 
 export default AppRoutes

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
-import * as Sentry from '@sentry/react'
-import { BrowserTracing } from '@sentry/tracing';
-import { SentryLink, excludeGraphQLFetch } from 'apollo-link-sentry';
+
+import { SentryLink } from 'apollo-link-sentry';
+
 import './index.css';
+import './sentry';
 import App from './App';
 import './i18n';
 import { ApolloLink, ApolloProvider, ApolloClient, createHttpLink } from '@apollo/client';
@@ -14,16 +15,6 @@ import store from './app/store';
 import userManager from './utils/userManager';
 import apolloCache from './utils/apolloCache';
 import { CookiesProvider } from 'react-cookie';
-
-Sentry.init({
-  dsn: process.env.REACT_APP_SENTRY_DSN,
-  integrations: [new BrowserTracing({
-    tracePropagationTargets: [process.env.REACT_APP_API_ENDPOINT, /\//],
-  })],
-  environment: process.env.REACT_APP_SENTRY_ENV,
-  beforeBreadcrumb: excludeGraphQLFetch,
-  tracesSampleRate: 0.8,
-})
 
 const apiEndpointLink = createHttpLink({ uri: process.env.REACT_APP_API_ENDPOINT + '/graphql' });
 const apiAuthLink = setContext((_, { headers }) => {

--- a/src/sentry.js
+++ b/src/sentry.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { useLocation, useNavigationType, createRoutesFromChildren, matchRoutes } from "react-router-dom";
+
+import * as Sentry from '@sentry/react'
+import { BrowserTracing } from '@sentry/tracing';
+import { excludeGraphQLFetch } from 'apollo-link-sentry';
+
+Sentry.init({
+  dsn: process.env.REACT_APP_SENTRY_DSN,
+  integrations: [
+    new BrowserTracing({
+      routingInstrumentation: Sentry.reactRouterV6Instrumentation(
+        React.useEffect,
+        useLocation,
+        useNavigationType,
+        createRoutesFromChildren,
+        matchRoutes,
+      ),
+      tracePropagationTargets: [process.env.REACT_APP_API_ENDPOINT, /\//],
+    }),
+  ],
+  environment: process.env.REACT_APP_SENTRY_ENV,
+  beforeBreadcrumb: excludeGraphQLFetch,
+  tracesSampleRate: 0.8,
+})
+
+console.log("there")

--- a/src/sentry.js
+++ b/src/sentry.js
@@ -23,5 +23,3 @@ Sentry.init({
   beforeBreadcrumb: excludeGraphQLFetch,
   tracesSampleRate: 0.8,
 })
-
-console.log("there")

--- a/yarn.lock
+++ b/yarn.lock
@@ -2525,13 +2525,14 @@
     tslib "^1.9.3"
 
 "@sentry/browser@^7.17.3":
-  version "7.17.3"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.17.3.tgz#4e67b2d8d90df11b37f29061fec3259eedca0a4a"
-  integrity sha512-Oi7ZNMzCbUXaWwkFcwXIWhfNiTy8s0EukoaKzwSdIhU5pLH9HFizXMl/qrBdxC6keTtckTwS9c+w2xDnqln1fg==
+  version "7.43.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.43.0.tgz#335f23ae020fc5be9aec2a89f65022e0e93d915f"
+  integrity sha512-NlRkBYKb9o5IQdGY8Ktps19Hz9RdSuqS1tlLC7Sjr+MqZqSHmhKq8MWJKciRynxBeMbeGt0smExi9BqpVQdCEg==
   dependencies:
-    "@sentry/core" "7.17.3"
-    "@sentry/types" "7.17.3"
-    "@sentry/utils" "7.17.3"
+    "@sentry/core" "7.43.0"
+    "@sentry/replay" "7.43.0"
+    "@sentry/types" "7.43.0"
+    "@sentry/utils" "7.43.0"
     tslib "^1.9.3"
 
 "@sentry/core@7.16.0":
@@ -2543,13 +2544,13 @@
     "@sentry/utils" "7.16.0"
     tslib "^1.9.3"
 
-"@sentry/core@7.17.3":
-  version "7.17.3"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.17.3.tgz#2b45c0507f1ef7018335b9bb61ed6b3f16accfad"
-  integrity sha512-PSboa9aOVnvZU+C6/shKlHUA7zjAl6z5BKRHF8mEljEYql6bh0HfJJKXtBHMz1sWnmzMa/qABSKLpnP5ZQlJNw==
+"@sentry/core@7.43.0":
+  version "7.43.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.43.0.tgz#c78e79399172738c96e3b388244258153c49215f"
+  integrity sha512-zvMZgEi7ptLBwDnd+xR/u4zdSe5UzS4S3ZhoemdQrn1PxsaVySD/ptyzLoGSZEABqlRxGHnQrZ78MU1hUDvKuQ==
   dependencies:
-    "@sentry/types" "7.17.3"
-    "@sentry/utils" "7.17.3"
+    "@sentry/types" "7.43.0"
+    "@sentry/utils" "7.43.0"
     tslib "^1.9.3"
 
 "@sentry/react@7.16.0":
@@ -2562,6 +2563,15 @@
     "@sentry/utils" "7.16.0"
     hoist-non-react-statics "^3.3.2"
     tslib "^1.9.3"
+
+"@sentry/replay@7.43.0":
+  version "7.43.0"
+  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-7.43.0.tgz#c77d5c6c4a3921cf67a58b69302ec4ea5eaa7fbe"
+  integrity sha512-2dGJS6p8uG1JZ7x/A3FyqnILTkXarbvfR+o1lC7z9lu34Wx0ZBeU2in/S2YHNGAE6XvfsePq3ya/s7LaNkk4qQ==
+  dependencies:
+    "@sentry/core" "7.43.0"
+    "@sentry/types" "7.43.0"
+    "@sentry/utils" "7.43.0"
 
 "@sentry/tracing@7.16.0":
   version "7.16.0"
@@ -2578,10 +2588,10 @@
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.16.0.tgz#79c06ada153a84feb949fa49b1c9d15f91decd79"
   integrity sha512-i6D+OK6d0l/k+VQvRp/Pt21WkDEgVBUIZq+sOkEZJczbcfexVdXKeXXoYTD2vYuFq8Yy28fzlsZaKI+NoH94yQ==
 
-"@sentry/types@7.17.3":
-  version "7.17.3"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.17.3.tgz#ec66ea7b6881ae243255546680722488e7ff23bf"
-  integrity sha512-+buEJo/4TKErjwF8Tq3XXKFZx4Utpvqs52e7i7Sur2qfyBNwRgBILceQvdnzw86JNZT2myeYmrfVbsaxAk7ilA==
+"@sentry/types@7.43.0":
+  version "7.43.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.43.0.tgz#e621257601e9db2a39cdd3bd75e67fe338ed51eb"
+  integrity sha512-5XxCWqYWJNoS+P6Ie2ZpUDxLRCt7FTEzmlQkCdjW6MFWOX26hAbF/wEuOTYAFKZXMIXOz0Egofik1e8v1Cg6/A==
 
 "@sentry/utils@7.16.0":
   version "7.16.0"
@@ -2591,12 +2601,12 @@
     "@sentry/types" "7.16.0"
     tslib "^1.9.3"
 
-"@sentry/utils@7.17.3":
-  version "7.17.3"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.17.3.tgz#aafa67ed372f00be2e1bb490fa62d9d2d06a4c2f"
-  integrity sha512-Sd7BwVn6IClvaXbZaj/LnEcrMm8yjQtZkTVSrM2Vlv1lLeaH61JxSAFU6QntF+f/cCfZ7wSdNhWOfW3qZJ7t3Q==
+"@sentry/utils@7.43.0":
+  version "7.43.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.43.0.tgz#ad16efb86b94ffe6dca2ed2b299d5230ba6d815b"
+  integrity sha512-f78YfMLcgNU7+suyWFCuQhQlneXXMS+egb0EFZh7iU7kANUPRX5T4b+0C+fwaPm5gA6XfGYskr4ZnzQJLOlSqg==
   dependencies:
-    "@sentry/types" "7.17.3"
+    "@sentry/types" "7.43.0"
     tslib "^1.9.3"
 
 "@sinclair/typebox@^0.24.1":
@@ -3785,6 +3795,16 @@ anymatch@^3.0.0, anymatch@^3.0.3, anymatch@^3.1.2, anymatch@~3.1.2:
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
+
+apollo-link-sentry@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/apollo-link-sentry/-/apollo-link-sentry-3.2.3.tgz#6fc40409812d0277f68bfb4902ab468d35d6d557"
+  integrity sha512-5btf/XOaxdR1+iK+UWD5oxLyi7MIffZmIJYrhaC6PxofTUg8eW8WDMkFcKS1NLw89DEMNHr1cxDli0dnaxb4ig==
+  dependencies:
+    deepmerge "^4.2.2"
+    dot-prop "^6.0.0"
+    tslib "^2.0.3"
+    zen-observable-ts "^1.2.5"
 
 append-buffer@^1.0.2:
   version "1.0.2"
@@ -6744,6 +6764,13 @@ dot-prop@^5.2.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-5.3.0.tgz#90ccce708cd9cd82cc4dc8c3ddd9abdd55b20e88"
   integrity sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==
+  dependencies:
+    is-obj "^2.0.0"
+
+dot-prop@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-6.0.1.tgz#fc26b3cf142b9e59b74dbd39ed66ce620c681083"
+  integrity sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==
   dependencies:
     is-obj "^2.0.0"
 


### PR DESCRIPTION
I've refactored our Sentry integration to follow the guides for
* [Event propagation](https://docs.sentry.io/platforms/javascript/guides/react/performance/instrumentation/automatic-instrumentation/#enable-instrumentation)
* [Router integration](https://docs.sentry.io/platforms/javascript/guides/react/configuration/integrations/react-router/#usage-with-routes--component)
* [GraphQL link](https://github.com/DiederikvandenB/apollo-link-sentry)

The routing integration means that the events in Sentry have the URL params substituted:

![image](https://user-images.githubusercontent.com/317667/225148292-57ac386b-6ba9-40a9-ae1a-82c2b39d4ee3.png)

The propagation config change gives us distributed tracing to other apps, e.g. editor-api

![image](https://user-images.githubusercontent.com/317667/225149275-6375b7bb-e435-442d-a1ec-c9e829b36706.png)



