### PR TITLE
Update docker-compose volumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Updated privacy policy link to use the child friendly privacy policy (#397)
 - Update URL structure to include locale (#407)
 - Update Sentry configuration to allow distributed tracing (#411)
-- Docker comopse volume configuration uses anonymous volumes (#nnn)
+- Docker comopse volume configuration uses anonymous volumes (#420)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Updated privacy policy link to use the child friendly privacy policy (#397)
 - Update URL structure to include locale (#407)
 - Update Sentry configuration to allow distributed tracing (#411)
+- Docker comopse volume configuration uses anonymous volumes (#nnn)
 
 ### Fixed
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     stdin_open: true
     volumes:
       - .:/app
-      - node_modules:/app/node_modules # ensures we retain node_modules from docker build
+      - /app/node_modules
   react-ui-wc:
     build: .
     command: yarn start:wc
@@ -19,7 +19,4 @@ services:
     stdin_open: true
     volumes:
       - .:/app
-      - node_modules:/app/node_modules # ensures we retain node_modules from docker build
-
-volumes:
-  node_modules:
+      - /app/node_modules


### PR DESCRIPTION
Avoid using a named volume for the `node_modules` directory, instead using an anonymous one that gets rebuilt during docker build.