### PR TITLE
Minor fixes (mostly buttons) to resolve issues in safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+## [0.17.1] - 2023-07-25
+
+### Fixed
+
+- Safari minor style fixes
+
 ## [0.17.0] - 2023-07-24
 
 ### Added

--- a/src/App.scss
+++ b/src/App.scss
@@ -11,10 +11,6 @@ a {
   }
 }
 
-svg {
-  min-width: fit-content;
-}
-
 button {
   all: initial;
   border: 3px solid transparent;

--- a/src/components/Editor/Runners/PythonRunner/OutputViewToggle.scss
+++ b/src/components/Editor/Runners/PythonRunner/OutputViewToggle.scss
@@ -3,9 +3,10 @@
 
 .output-view-toggle {
   display: inline-flex;
-  margin-right: $space-0-5;
+  vertical-align: middle;
+  margin-inline-end: $space-0-5;
   align-items: center;
-  height: fit-content;
+  height: 100%;
 
   &__button {
     border: 0px;

--- a/src/components/Editor/Runners/PythonRunner/OutputViewToggle.scss
+++ b/src/components/Editor/Runners/PythonRunner/OutputViewToggle.scss
@@ -3,8 +3,9 @@
 
 .output-view-toggle {
   display: inline-flex;
-  margin: auto $space-0-5 auto auto;
+  margin-right: $space-0-5;
   align-items: center;
+  height: fit-content;
 
   &__button {
     border: 0px;
@@ -55,15 +56,19 @@
   .output-view-toggle {
     &__button {
       background-color: $rpf-grey-50;
+
+      &--active {
+        &::before {
+          background-color: $rpf-grey-150;
+        }
+        svg {
+          z-index: 1;
+        }
+      }
     }
 
     svg {
       fill: $rpf-black;
-    }
-  }
-  .output-view-toggle__button--active {
-    &::before {
-      background-color: $rpf-grey-150;
     }
   }
 }
@@ -83,6 +88,7 @@
         }
         svg {
           fill: $rpf-white;
+          z-index: 1;
         }
       }
 


### PR DESCRIPTION
Minor updates to styles to fix:

- Button width
- Order on svg when selected

Both of which cause the editor to look like this in Safari

![image](https://github.com/RaspberryPiFoundation/editor-ui/assets/74183390/12bd9c03-803c-4e57-b163-f996278ab328)
