### PR TITLE
Correct typo; login -> log in

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -180,7 +180,7 @@ i18n
             subtitle: "Start coding, no setup required!",
             python: "Start coding Python",
             html: "Start coding HTML/CSS",
-            login: "Login",
+            login: "Log in",
             start: "Not sure where to start?",
             projectPython: "Python path",
             projectHtml: "Web path",


### PR DESCRIPTION
"Log in" is the correct spelling when used as a verb, eg. here:

<img width="743" alt="Screenshot 2023-09-25 at 12 00 36" src="https://github.com/RaspberryPiFoundation/editor-ui/assets/91799/7342f7a6-bb5d-4be5-b604-7a7dad488e37">
