### PR TITLE
Web component events refactor and testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Replace physical properties with logical values
 - Moved web component custom events from the `editor-wc` element to the `document` (#710)
+- Renamed web component custom events to be prefixed with `editor-` (#710)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 - `step_number` attribute and `stepChanged` custom event for the web component (#709)
+- Web component tests (#709, #710)
 
 ### Changed
 
 - Replace physical properties with logical values
+- Moved web component custom events from the `editor-wc` element to the `document` (#710)
 
 ### Fixed
 

--- a/src/components/WebComponentProject/WebComponentProject.jsx
+++ b/src/components/WebComponentProject/WebComponentProject.jsx
@@ -10,7 +10,6 @@ import Project from "../Editor/Project/Project";
 import MobileProject from "../Mobile/MobileProject/MobileProject";
 import { defaultMZCriteria } from "../../utils/DefaultMZCriteria";
 import Sk from "skulpt";
-import store from "../../app/store";
 import { setIsSplitView } from "../../redux/EditorSlice";
 import { MOBILE_MEDIA_QUERY } from "../../utils/mediaQueryBreakpoints";
 import {
@@ -24,13 +23,14 @@ const WebComponentProject = () => {
   const codeRunTriggered = useSelector(
     (state) => state.editor.codeRunTriggered,
   );
+  const error = useSelector((state) => state.editor.error);
+  const codeHasBeenRun = useSelector((state) => state.editor.codeHasBeenRun);
   const [cookies] = useCookies(["theme", "fontSize"]);
   const defaultTheme = window.matchMedia("(prefers-color-scheme:dark)").matches
     ? "dark"
     : "light";
   const isMobile = useMediaQuery({ query: MOBILE_MEDIA_QUERY });
-  const webComponent = document.querySelector("editor-wc");
-  const [codeHasRun, setCodeHasRun] = React.useState(false);
+  const [codeHasRun, setCodeHasRun] = React.useState(codeHasBeenRun);
   const dispatch = useDispatch();
   useEffect(() => {
     dispatch(setIsSplitView(false));
@@ -39,28 +39,27 @@ const WebComponentProject = () => {
   useEffect(() => {
     setCodeHasRun(false);
     const timeout = setTimeout(() => {
-      webComponent.dispatchEvent(codeChangedEvent);
+      document.dispatchEvent(codeChangedEvent);
     }, 2000);
     return () => clearTimeout(timeout);
-  }, [project, webComponent]);
+  }, [project]);
 
   useEffect(() => {
     if (codeRunTriggered) {
-      webComponent.dispatchEvent(runStartedEvent);
+      document.dispatchEvent(runStartedEvent);
       setCodeHasRun(true);
     } else if (codeHasRun) {
-      const state = store.getState();
       const mz_criteria = Sk.sense_hat
         ? Sk.sense_hat.mz_criteria
         : { ...defaultMZCriteria };
-      webComponent.dispatchEvent(
+      document.dispatchEvent(
         runCompletedEvent({
-          isErrorFree: state.editor.error === "",
+          isErrorFree: error === "",
           ...mz_criteria,
         }),
       );
     }
-  }, [codeRunTriggered, codeHasRun, webComponent]);
+  }, [codeRunTriggered, codeHasRun, error]);
 
   return (
     <>

--- a/src/components/WebComponentProject/WebComponentProject.jsx
+++ b/src/components/WebComponentProject/WebComponentProject.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useCookies } from "react-cookie";
 import { useMediaQuery } from "react-responsive";
@@ -30,7 +30,7 @@ const WebComponentProject = () => {
     ? "dark"
     : "light";
   const isMobile = useMediaQuery({ query: MOBILE_MEDIA_QUERY });
-  const [codeHasRun, setCodeHasRun] = React.useState(codeHasBeenRun);
+  const [codeHasRun, setCodeHasRun] = useState(codeHasBeenRun);
   const dispatch = useDispatch();
   useEffect(() => {
     dispatch(setIsSplitView(false));

--- a/src/components/WebComponentProject/WebComponentProject.test.js
+++ b/src/components/WebComponentProject/WebComponentProject.test.js
@@ -1,0 +1,97 @@
+import React from "react";
+import { act, render } from "@testing-library/react";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+import WebComponentProject from "./WebComponentProject";
+
+const codeChangedHandler = jest.fn();
+const runStartedHandler = jest.fn();
+const runCompletedHandler = jest.fn();
+
+beforeAll(() => {
+  document.addEventListener("editor-codeChanged", codeChangedHandler);
+  document.addEventListener("editor-runStarted", runStartedHandler);
+  document.addEventListener("editor-runCompleted", runCompletedHandler);
+});
+
+jest.useFakeTimers();
+
+let store;
+
+describe("When code running", () => {
+  beforeEach(() => {
+    const middlewares = [];
+    const mockStore = configureStore(middlewares);
+    const initialState = {
+      editor: {
+        project: {
+          components: [
+            { name: "main", extension: "py", content: "print('hello')" },
+          ],
+        },
+        openFiles: [],
+        focussedFileIndices: [],
+        codeRunTriggered: true,
+      },
+      auth: {},
+    };
+    store = mockStore(initialState);
+
+    render(
+      <Provider store={store}>
+        <WebComponentProject />
+      </Provider>,
+    );
+  });
+
+  test("Triggers codeChanged event", () => {
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(codeChangedHandler).toHaveBeenCalled();
+  });
+
+  test("Triggers runStarted event", () => {
+    expect(runStartedHandler).toHaveBeenCalled();
+  });
+});
+
+describe("When code run finishes", () => {
+  let store;
+
+  beforeEach(() => {
+    const middlewares = [];
+    const mockStore = configureStore(middlewares);
+    const initialState = {
+      editor: {
+        project: {
+          components: [
+            { name: "main", extension: "py", content: "print('hello')" },
+          ],
+        },
+        openFiles: [],
+        focussedFileIndices: [],
+        codeRunTriggered: false,
+        codeHasBeenRun: true,
+      },
+      auth: {},
+    };
+    store = mockStore(initialState);
+
+    render(
+      <Provider store={store}>
+        <WebComponentProject />
+      </Provider>,
+    );
+  });
+
+  test("Triggers runCompletedEvent", () => {
+    expect(runCompletedHandler).toHaveBeenCalled();
+  });
+});
+
+afterAll(() => {
+  document.removeEventListener("editor-codeChanged", codeChangedHandler);
+  document.removeEventListener("editor-runStarted", runStartedHandler);
+  document.removeEventListener("editor-runCompleted", runCompletedHandler);
+});

--- a/src/events/WebComponentCustomEvents.js
+++ b/src/events/WebComponentCustomEvents.js
@@ -6,12 +6,12 @@ const webComponentCustomEvent = (type, detail) =>
     detail: detail,
   });
 
-export const codeChangedEvent = webComponentCustomEvent("codeChanged");
+export const codeChangedEvent = webComponentCustomEvent("editor-codeChanged");
 
 export const runCompletedEvent = (detail) =>
-  webComponentCustomEvent("runCompleted", detail);
+  webComponentCustomEvent("editor-runCompleted", detail);
 
-export const runStartedEvent = webComponentCustomEvent("runStarted");
+export const runStartedEvent = webComponentCustomEvent("editor-runStarted");
 
 export const stepChangedEvent = (detail) =>
-  webComponentCustomEvent("stepChanged", detail);
+  webComponentCustomEvent("editor-stepChanged", detail);

--- a/src/web-component.html
+++ b/src/web-component.html
@@ -43,13 +43,13 @@
       });
 
       // subscribe to the 'codeChanged' custom event which is pushed by the project react component
-      webComp.addEventListener("codeChanged", function (e) {
+      document.addEventListener("editor-codeChanged", function (e) {
         console.log("listener in index html");
         const code = webComp.editorCode;
         console.log(code);
       });
 
-      webComp.addEventListener("runCompleted", (e) => {
+      document.addEventListener("editor-runCompleted", (e) => {
         // const error = webComp.isErrorFree
         console.log(e.detail);
         document.getElementById("results").innerText = JSON.stringify(e.detail);


### PR DESCRIPTION
# What's Changed?

- Moved web component custom events from the `editor-wc` element to the `document`, mainly to make it easier to test
- Namespaced custom events to be prefixed with `editor-`, so host page knows the event has come from the editor web component
- Slight refactor of the `WebComponentProject`, mostly to make it more testable
- Added tests for the `WebComponentProject`