### PR TITLE
Remove issue WebComponent media queries

### DIFF
--- a/src/assets/stylesheets/Project.scss
+++ b/src/assets/stylesheets/Project.scss
@@ -46,6 +46,8 @@
   height: fill-available;
 
   .project-wrapper {
+    container-name: editor-project;
+    container-type: normal;
     display: flex;
     flex-direction: column;
     grid-gap: $space-0-5;
@@ -55,37 +57,18 @@
 
   .proj-editor-wrapper {
     display: flex;
-    flex: 0 1 auto;
-    flex-flow: column;
+    flex: 1 1 auto;
     grid-gap: $space-1;
     overflow: hidden;
     height: 100%;
     width: 100%;
   }
 
-  // TODO: use container queries (fix with cquery breaking positioning of drag/drop & autocomplete)
-  @media (min-width: 912px) {
-    // width is 880px for the container + the rest of the page
-    .proj-editor-wrapper {
-      flex-flow: row;
-    }
-
-    .proj-editor-container {
-      max-height: 100% !important;
-    }
-
-    &--wc {
-      .proj-runner-container,
-      .proj-editor-container {
-        width: 50%;
-      }
-    }
-  }
-
   .sidebar,
   .proj-editor-container,
   .proj-runner-container {
     border-radius: 8px;
+    height: 100%;
   }
 
   .proj-editor-container {

--- a/src/components/Editor/Output/Output.jsx
+++ b/src/components/Editor/Output/Output.jsx
@@ -4,20 +4,34 @@ import ExternalFiles from "../../ExternalFiles/ExternalFiles";
 import RunnerFactory from "../Runners/RunnerFactory";
 import RunBar from "../../RunButton/RunBar";
 
-const Output = () => {
+const Output = ({
+  minHeight = "100%",
+  defaultWidth,
+  minWidth,
+  maxWidth,
+  panelDirection = "column",
+}) => {
   const project = useSelector((state) => state.editor.project);
   const isEmbedded = useSelector((state) => state.editor.isEmbedded);
   const searchParams = new URLSearchParams(window.location.search);
   const isBrowserPreview = searchParams.get("browserPreview") === "true";
 
   return (
-    <>
+    <div
+      style={{
+        minHeight: minHeight,
+        width: defaultWidth,
+        minWidth,
+        maxWidth,
+        flex: panelDirection === "column" ? "0 1 auto" : "1 0 auto",
+      }}
+    >
       <ExternalFiles />
       <div className="proj-runner-container">
         <RunnerFactory projectType={project.project_type} />
         {isEmbedded && !isBrowserPreview ? <RunBar embedded /> : null}
       </div>
-    </>
+    </div>
   );
 };
 

--- a/src/components/Editor/Project/Project.jsx
+++ b/src/components/Editor/Project/Project.jsx
@@ -31,6 +31,7 @@ const Project = (props) => {
   const [defaultHeight, setDefaultHeight] = useState("auto");
   const [maxWidth, setMaxWidth] = useState("100%");
   const [handleDirection, setHandleDirection] = useState("right");
+  const [flexDirection, setFlexDirection] = useState("column");
 
   useMemo(() => {
     const isDesktop = params["width-larger-than-880"];
@@ -39,6 +40,7 @@ const Project = (props) => {
     setDefaultHeight(isDesktop ? "100%" : "50%");
     setMaxWidth(isDesktop ? "75%" : "100%");
     setHandleDirection(isDesktop ? "right" : "bottom");
+    setFlexDirection(isDesktop ? "row" : "column");
   }, [params["width-larger-than-880"]]);
 
   return (
@@ -52,19 +54,25 @@ const Project = (props) => {
         {!forWebComponent && <Sidebar />}
         <div className="project-wrapper">
           {!forWebComponent ? <ProjectBar /> : null}
-          <div className="proj-editor-wrapper">
+          <div className="proj-editor-wrapper" style={{ flexDirection }}>
             <ResizableWithHandle
               data-testid="proj-editor-container"
               className="proj-editor-container"
               defaultWidth={defaultWidth}
-              defaultHeight={defaultHeight}
+              minHeight={defaultHeight}
               handleDirection={handleDirection}
               minWidth="25%"
               maxWidth={maxWidth}
             >
               <EditorInput />
             </ResizableWithHandle>
-            <Output />
+            <Output
+              panelDirection={flexDirection}
+              defaultWidth={defaultWidth}
+              minHeight={defaultHeight}
+              minWidth="25%"
+              maxWidth={maxWidth}
+            />
           </div>
         </div>
       </div>


### PR DESCRIPTION
Related to https://github.com/RaspberryPiFoundation/editor-ui/issues/708 and tweaked alongside https://github.com/RaspberryPiFoundation/projects-ui/pull/2392/files (see part selector and parent div styles).

It still doesn't fully solve the issue as the handle causes the web component to go to 100% of the screen size some times and the inline styles are horrific but it's a starter for 10 at least.