### PR TITLE
Oidc-redux Signout Flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 - Clipped icon in "Save your work" toast (#707)
+- Hydra logout flow to delete session (#714)
 
 ## [0.19.2] - 2023-10-12
 

--- a/src/components/Login/LoginMenu.jsx
+++ b/src/components/Login/LoginMenu.jsx
@@ -27,7 +27,10 @@ const LoginMenu = () => {
           >
             {t("globalNav.accountMenu.projects")}
           </Link>
-          <LogoutButton className="btn--tertiary dropdown-container--list__item" />
+          <LogoutButton
+            user={user}
+            className="btn--tertiary dropdown-container--list__item"
+          />
         </>
       ) : (
         <LoginButton

--- a/src/components/Login/LogoutButton.jsx
+++ b/src/components/Login/LogoutButton.jsx
@@ -3,14 +3,15 @@ import userManager from "../../utils/userManager";
 import { useTranslation } from "react-i18next";
 import Button from "../Button/Button";
 import { useNavigate } from "react-router-dom";
+import PropTypes from "prop-types";
 
-const LogoutButton = (props) => {
-  const { className } = props;
+const LogoutButton = ({ className, user }) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
 
   const onLogoutButtonClick = async (event) => {
     event.preventDefault();
+    userManager.signoutRedirect({ id_token_hint: user?.id_token });
     await userManager.removeUser();
     localStorage.clear();
     navigate("/");
@@ -23,6 +24,13 @@ const LogoutButton = (props) => {
       onClickHandler={onLogoutButtonClick}
     />
   );
+};
+
+LogoutButton.propTypes = {
+  className: PropTypes.string,
+  user: PropTypes.shape({
+    id_token: PropTypes.string.isRequired,
+  }).isRequired,
 };
 
 export default LogoutButton;

--- a/src/components/Login/LogoutButton.jsx
+++ b/src/components/Login/LogoutButton.jsx
@@ -2,19 +2,16 @@ import React from "react";
 import userManager from "../../utils/userManager";
 import { useTranslation } from "react-i18next";
 import Button from "../Button/Button";
-import { useNavigate } from "react-router-dom";
 import PropTypes from "prop-types";
 
 const LogoutButton = ({ className, user }) => {
   const { t } = useTranslation();
-  const navigate = useNavigate();
 
   const onLogoutButtonClick = async (event) => {
     event.preventDefault();
     userManager.signoutRedirect({ id_token_hint: user?.id_token });
     await userManager.removeUser();
     localStorage.clear();
-    navigate("/");
   };
 
   return (

--- a/src/components/Login/LogoutButton.test.js
+++ b/src/components/Login/LogoutButton.test.js
@@ -7,27 +7,25 @@ import userManager from "../../utils/userManager";
 import LogoutButton from "./LogoutButton";
 
 jest.mock("../../utils/userManager", () => ({
+  signoutRedirect: jest.fn(),
   removeUser: jest.fn(),
 }));
 
 let logoutButton;
 
+const user = {
+  id_token: "1234",
+};
+
 beforeEach(() => {
   const middlewares = [];
   const mockStore = configureStore(middlewares);
-  const initialState = {
-    editor: {
-      project: {},
-    },
-    auth: {
-      user: {},
-    },
-  };
+  const initialState = {};
   const store = mockStore(initialState);
   render(
     <MemoryRouter initialEntries={["/"]}>
       <Provider store={store}>
-        <LogoutButton />
+        <LogoutButton user={user} />
       </Provider>
     </MemoryRouter>,
   );
@@ -40,5 +38,8 @@ test("Log out button shown", () => {
 
 test("Clicking log out button signs the user out", () => {
   fireEvent.click(logoutButton);
+  expect(userManager.signoutRedirect).toBeCalledWith({
+    id_token_hint: user.id_token,
+  });
   expect(userManager.removeUser).toHaveBeenCalled();
 });

--- a/src/utils/userManager.js
+++ b/src/utils/userManager.js
@@ -8,6 +8,7 @@ const host = `${window.location.protocol}//${window.location.hostname}${
 const userManagerConfig = {
   client_id: process.env.REACT_APP_AUTHENTICATION_CLIENT_ID,
   redirect_uri: `${host}/auth/callback`,
+  post_logout_redirect_uri: host,
   response_type: "code",
   scope: "openid email profile force-consent allow-u13-login",
   authority: process.env.REACT_APP_AUTHENTICATION_URL,


### PR DESCRIPTION
Related to #714 

Hits signoutRedirect with a `id_token` during logout to invalidate hydra session

### Note

This requires `post_logout_redirect_uris` to be registered with hydra client before merge (currently manual but I have an influx branch to bring this into terraform)