### PR TITLE
Minor instructions styling fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Styling for the instructions callouts (#788)
 - Output styles for Instructions (#790, #807)
 - Styling for the instructions code snippets (#795)
-- Styling for the instructions code blocks (#794)
+- Styling for the instructions code blocks (#794, #808)
 
 ### Changed
 
 - Application of styles in the web component to remove `sass-to-string` (#788)
 - Info panel links open in a new tab (#803)
 - Copy updates (#803)
+- Restyling the instructions progress bar (#808)
 
 ## Fixed
 

--- a/src/assets/stylesheets/Instructions.scss
+++ b/src/assets/stylesheets/Instructions.scss
@@ -20,7 +20,7 @@
     }
   }
 
-  .c-project-code__heading {
+  .c-code-filename {
     font-family: monospace;
     margin: 0;
     padding: $space-0-5 $space-1;

--- a/src/assets/stylesheets/ProgressBar.scss
+++ b/src/assets/stylesheets/ProgressBar.scss
@@ -4,6 +4,10 @@
   align-items: center;
   justify-content: center;
 
+  progress {
+    flex: 1;
+  }
+
   .btn-outer {
     padding: 0;
   }

--- a/src/assets/stylesheets/ProgressBar.scss
+++ b/src/assets/stylesheets/ProgressBar.scss
@@ -3,6 +3,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  max-width: 300px;
+  margin: auto;
 
   progress {
     flex: 1;

--- a/src/assets/stylesheets/Sidebar.scss
+++ b/src/assets/stylesheets/Sidebar.scss
@@ -120,10 +120,10 @@
     background-color: var(--sidebar-option-selected-background-hover);
   }
 
-  .sidebar__panel-footer {
-    background-color: $rpf-grey-700;
-    border-block-start: 1px solid $rpf-grey-600;
-  }
+  // .sidebar__panel-footer {
+  //   background-color: $rpf-grey-700;
+  //   border-block-start: 1px solid $rpf-grey-600;
+  // }
 }
 
 .sidebar__bar-close {
@@ -138,6 +138,10 @@
   border-radius: 0 8px 8px 0;
   width: inherit;
   background: var(--sidebar-panel-background);
+}
+
+.sidebar__panel--with-footer {
+  padding-block-end: 0;
 }
 
 .sidebar__panel-heading {
@@ -158,5 +162,8 @@
   padding: $space-1 0;
   overflow-y: scroll;
   scrollbar-width: none;
-  margin-block-end: $space-2;
+}
+
+.sidebar__panel-footer {
+  border-block-start: 1px solid $rpf-grey-150;
 }

--- a/src/assets/stylesheets/Sidebar.scss
+++ b/src/assets/stylesheets/Sidebar.scss
@@ -141,7 +141,7 @@
 }
 
 .sidebar__panel--with-footer {
-  padding-block-end: 0;
+  padding-block-end: $space-2;
 }
 
 .sidebar__panel-heading {
@@ -166,4 +166,10 @@
 
 .sidebar__panel-footer {
   border-block-start: 1px solid $rpf-grey-150;
+  position: absolute;
+  bottom: 0px;
+  width: 100%;
+  left: 0;
+  background-color: white;
+  border-bottom-right-radius: 8px;
 }

--- a/src/assets/stylesheets/Sidebar.scss
+++ b/src/assets/stylesheets/Sidebar.scss
@@ -119,11 +119,6 @@
   &--selected:hover {
     background-color: var(--sidebar-option-selected-background-hover);
   }
-
-  // .sidebar__panel-footer {
-  //   background-color: $rpf-grey-700;
-  //   border-block-start: 1px solid $rpf-grey-600;
-  // }
 }
 
 .sidebar__bar-close {


### PR DESCRIPTION
- Utilisting existing filename from `kramdown` for the code block
- Making the instructions progress bar more in line with the designs