### PR TITLE
Issue 2428 host styles added for web component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
+- WebComponent can receive style strings from host app (#811)
 - Quiz rendering in InstructionsPanel (#777)
 - Styling for the task section of the instructions (#781)
 - Styling for the instructions callouts (#788)

--- a/src/components/WebComponentProject/WebComponentProject.jsx
+++ b/src/components/WebComponentProject/WebComponentProject.jsx
@@ -24,10 +24,6 @@ const WebComponentProject = ({
   sidebarOptions = [],
   hostStyles = [],
 }) => {
-  console.log("HostStyles");
-  console.log(hostStyles);
-  console.log(typeof hostStyles);
-
   const project = useSelector((state) => state.editor.project);
   const codeRunTriggered = useSelector(
     (state) => state.editor.codeRunTriggered,

--- a/src/components/WebComponentProject/WebComponentProject.jsx
+++ b/src/components/WebComponentProject/WebComponentProject.jsx
@@ -24,10 +24,6 @@ const WebComponentProject = ({
   sidebarOptions = [],
   hostStyles = [],
 }) => {
-  console.log("HOST STYLES");
-  console.log(hostStyles);
-  console.log("Internal styles");
-  console.log(internalStyles);
   const project = useSelector((state) => state.editor.project);
   const codeRunTriggered = useSelector(
     (state) => state.editor.codeRunTriggered,

--- a/src/components/WebComponentProject/WebComponentProject.jsx
+++ b/src/components/WebComponentProject/WebComponentProject.jsx
@@ -24,6 +24,10 @@ const WebComponentProject = ({
   sidebarOptions = [],
   hostStyles = [],
 }) => {
+  console.log("HostStyles");
+  console.log(hostStyles);
+  console.log(typeof hostStyles);
+
   const project = useSelector((state) => state.editor.project);
   const codeRunTriggered = useSelector(
     (state) => state.editor.codeRunTriggered,

--- a/src/components/WebComponentProject/WebComponentProject.jsx
+++ b/src/components/WebComponentProject/WebComponentProject.jsx
@@ -19,7 +19,15 @@ import {
   stepChangedEvent,
 } from "../../events/WebComponentCustomEvents";
 
-const WebComponentProject = ({ withSidebar = false, sidebarOptions = [] }) => {
+const WebComponentProject = ({
+  withSidebar = false,
+  sidebarOptions = [],
+  hostStyles = [],
+}) => {
+  console.log("HOST STYLES");
+  console.log(hostStyles);
+  console.log("Internal styles");
+  console.log(internalStyles);
   const project = useSelector((state) => state.editor.project);
   const codeRunTriggered = useSelector(
     (state) => state.editor.codeRunTriggered,
@@ -74,6 +82,7 @@ const WebComponentProject = ({ withSidebar = false, sidebarOptions = [] }) => {
   return (
     <>
       <style>{externalStyles.toString()}</style>
+      <style>{hostStyles}</style>
       <Style>
         {internalStyles.toString()}
         <div id="wc" className={`--${cookies.theme || defaultTheme}`}>

--- a/src/containers/WebComponentLoader.jsx
+++ b/src/containers/WebComponentLoader.jsx
@@ -23,7 +23,9 @@ const WebComponentLoader = (props) => {
     sidebarOptions = [],
     theme,
     embedded = false,
+    hostStyles,
   } = props;
+
   const dispatch = useDispatch();
   const { t } = useTranslation();
   const [projectIdentifier, setProjectIdentifier] = useState(identifier);
@@ -98,6 +100,7 @@ const WebComponentLoader = (props) => {
         <WebComponentProject
           withSidebar={withSidebar}
           sidebarOptions={sidebarOptions}
+          hostStyles={hostStyles}
         />
       </SettingsContext.Provider>
     </>

--- a/src/web-component.html
+++ b/src/web-component.html
@@ -56,7 +56,7 @@
       // Pre-set the code attribute with an empty string.
       webComp.setAttribute("code", "");
       webComp.setAttribute("class", "editor-wc");
-      webCom.setAttribute("host_styles", "");
+      webComp.setAttribute("host_styles", "");
       // Set any attribute you like in the query string, including class, style, hidden, script, etc.
       queryParams.forEach((value, key) => {
         webComp.setAttribute(key, value);

--- a/src/web-component.html
+++ b/src/web-component.html
@@ -50,12 +50,13 @@
           "download",
           "settings",
           "info",
-        ])
+        ]),
       );
 
       // Pre-set the code attribute with an empty string.
       webComp.setAttribute("code", "");
       webComp.setAttribute("class", "editor-wc");
+      webCom.setAttribute("host_styles", "");
       // Set any attribute you like in the query string, including class, style, hidden, script, etc.
       queryParams.forEach((value, key) => {
         webComp.setAttribute(key, value);

--- a/src/web-component.js
+++ b/src/web-component.js
@@ -54,9 +54,7 @@ class WebComponent extends HTMLElement {
 
     if (["sense_hat_always_enabled", "with_sidebar"].includes(name)) {
       value = newVal === "true";
-    } else if (
-      ["instructions", "sidebar_options", "host_styes"].includes(name)
-    ) {
+    } else if (["instructions", "sidebar_options"].includes(name)) {
       value = JSON.parse(newVal);
     } else {
       value = newVal;

--- a/src/web-component.js
+++ b/src/web-component.js
@@ -35,7 +35,9 @@ class WebComponent extends HTMLElement {
   }
 
   static get observedAttributes() {
+    console.log("ObservedAttributes caklked");
     return [
+      "host_styles",
       "auth_key",
       "identifier",
       "code",
@@ -53,7 +55,9 @@ class WebComponent extends HTMLElement {
 
     if (["sense_hat_always_enabled", "with_sidebar"].includes(name)) {
       value = newVal === "true";
-    } else if (["instructions", "sidebar_options"].includes(name)) {
+    } else if (
+      ["instructions", "sidebar_options", "host_styes"].includes(name)
+    ) {
       value = JSON.parse(newVal);
     } else {
       value = newVal;
@@ -97,6 +101,9 @@ class WebComponent extends HTMLElement {
       this.attachShadow({ mode: "open" }).appendChild(this.mountPoint);
       this.root = ReactDOMClient.createRoot(this.mountPoint);
     }
+    console.log("PROPPS!!");
+    const props = { ...this.reactProps() };
+    console.log(props);
 
     this.root.render(
       <React.StrictMode>

--- a/src/web-component.js
+++ b/src/web-component.js
@@ -35,7 +35,6 @@ class WebComponent extends HTMLElement {
   }
 
   static get observedAttributes() {
-    console.log("ObservedAttributes caklked");
     return [
       "host_styles",
       "auth_key",
@@ -101,7 +100,6 @@ class WebComponent extends HTMLElement {
       this.attachShadow({ mode: "open" }).appendChild(this.mountPoint);
       this.root = ReactDOMClient.createRoot(this.mountPoint);
     }
-    console.log("PROPPS!!");
     const props = { ...this.reactProps() };
     console.log(props);
 

--- a/src/web-component.js
+++ b/src/web-component.js
@@ -98,8 +98,6 @@ class WebComponent extends HTMLElement {
       this.attachShadow({ mode: "open" }).appendChild(this.mountPoint);
       this.root = ReactDOMClient.createRoot(this.mountPoint);
     }
-    const props = { ...this.reactProps() };
-    console.log(props);
 
     this.root.render(
       <React.StrictMode>


### PR DESCRIPTION
Part of [#2428](https://github.com/RaspberryPiFoundation/projects-ui/issues/2428)

- css strings can be passed to the WebComponent through a `hostStyle` prop, allowing the ShadowDOM to receive styles from the host app.

