### PR TITLE
Fix project height for standalone editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Fixed
 
-- Standalone editor height
+- Standalone editor height (#864)
 - Web component height on Firefox (#838)
 - Web component resizable handle errors & sidebar width (#806)
 - HTML projects loading in web component (#789)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Fixed
 
+- Standalone editor height
 - Web component height on Firefox (#838)
 - Web component resizable handle errors & sidebar width (#806)
 - HTML projects loading in web component (#789)

--- a/src/assets/stylesheets/Project.scss
+++ b/src/assets/stylesheets/Project.scss
@@ -5,7 +5,6 @@
   display: flex;
   flex-flow: column;
   overflow: hidden;
-  min-block-size: 100%;
   block-size: 100%;
   block-size: -moz-available;
   block-size: -webkit-fill-available;

--- a/src/assets/stylesheets/WebComponent.scss
+++ b/src/assets/stylesheets/WebComponent.scss
@@ -20,6 +20,10 @@
   display: flex;
   flex-flow: column;
   block-size: 100%;
+
+  .proj {
+    min-block-size: 100%;
+  }
 }
 
 code {


### PR DESCRIPTION
Currently due to the styling changes required to maximise the height of the web component in Firefox the standalone editor took up too much space (didn't account for the top nav). This fix applies the required `min-block-size` only to the web component