### PR TITLE
Fix width of new file button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Save/download panel spacing (#859)
 - Instructions output wrapping in Firefox (#862)
 - Instructions code blocks with no line numbers (#863)
+- New file button width (#865)
 
 ## [0.20.0] - 2023-11-24
 

--- a/src/assets/stylesheets/DesignSystemButton.scss
+++ b/src/assets/stylesheets/DesignSystemButton.scss
@@ -20,7 +20,7 @@
   width: fit-content;
 }
 
-.rpf-button--fill {
+.rpf-button.rpf-button--fill {
   justify-content: center;
   width: 100%;
   box-sizing: border-box;


### PR DESCRIPTION
Before:
![Screenshot 2024-01-04 at 15 41 01](https://github.com/RaspberryPiFoundation/editor-ui/assets/88904316/03107cc5-4729-4ee5-a747-b4a115fd1d4c)

After:
<img width="321" alt="Screenshot 2024-01-04 at 15 41 23" src="https://github.com/RaspberryPiFoundation/editor-ui/assets/88904316/3502d136-36bc-42d5-9f27-63c721df7f7b">

