### PR TITLE
Fix web-component boolean attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Fixed
+
+- Boolean web component attributes
+
 ## [0.21.0] - 2024-01-05
 
 ### Added

--- a/src/web-component.js
+++ b/src/web-component.js
@@ -58,7 +58,7 @@ class WebComponent extends HTMLElement {
         name,
       )
     ) {
-      value = newVal === "true";
+      value = newVal !== "false";
     } else if (
       ["instructions", "sidebar_options", "host_styles"].includes(name)
     ) {
@@ -105,6 +105,8 @@ class WebComponent extends HTMLElement {
       this.attachShadow({ mode: "open" }).appendChild(this.mountPoint);
       this.root = ReactDOMClient.createRoot(this.mountPoint);
     }
+
+    console.log(this.reactProps());
 
     this.root.render(
       <React.StrictMode>

--- a/src/web-component.js
+++ b/src/web-component.js
@@ -106,8 +106,6 @@ class WebComponent extends HTMLElement {
       this.root = ReactDOMClient.createRoot(this.mountPoint);
     }
 
-    console.log(this.reactProps());
-
     this.root.render(
       <React.StrictMode>
         <Provider store={store}>


### PR DESCRIPTION
Fix so anything other than explicitly setting the boolean attributes as false is taken as true