### PR TITLE
Web component on port 3011

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,8 +27,8 @@
 
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   "forwardPorts": [
-    3000,
-    3001
+    3010,
+    3011
   ],
 
   // Uncomment the next line if you want start specific services in your Docker Compose config.

--- a/.env.webcomponent.example
+++ b/.env.webcomponent.example
@@ -3,5 +3,7 @@ REACT_APP_SENTRY_DSN=''
 REACT_APP_SENTRY_ENV='local'
 # NB This is the URL of react-ui, rather than the web component
 PUBLIC_URL=http://localhost:3010
+# Use the below if skulpt shims are needed locally (e.g. p5)
+# PUBLIC_URL='https://staging-editor.raspberrypi.org/branches/main'
 REACT_APP_IDENTITY_URL='http://localhost:3002'
 REACT_APP_API_ENDPOINT='http://localhost:3009'

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -91,7 +91,7 @@ jobs:
         start: |
           yarn start
           yarn start:wc
-        wait-on: 'http://localhost:3000, http://localhost:3001'
+        wait-on: 'http://localhost:3000, http://localhost:3011'
       env:
         REACT_APP_API_ENDPOINT: "https://staging-editor-api.raspberrypi.org"
         PUBLIC_URL: 'http://localhost:3000'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Changed
+
+- Web component local port to 3011 (#885)
+
 ### Added
 
 - Quiz rendering in InstructionsPanel (#777)

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Runs the web component in development mode. Open [http://localhost:3011](http://
 
 It is possible to add query strings to control how the web component is configured. Any HTML attribute can be set on the query string, including `class`, `style` etc.
 
-For example, to load the page with the Sense Hat always showing, add [`?sense_hat_always_enabled` to the URL](http://localhost:3001?sense_hat_always_enabled)
+For example, to load the page with the Sense Hat always showing, add [`?sense_hat_always_enabled` to the URL](http://localhost:3011?sense_hat_always_enabled)
 
 ### Styling
 

--- a/cypress/e2e/missionZero-wc.cy.js
+++ b/cypress/e2e/missionZero-wc.cy.js
@@ -1,4 +1,4 @@
-const baseUrl = "http://localhost:3001";
+const baseUrl = "http://localhost:3011";
 
 beforeEach(() => {
   cy.visit(`${baseUrl}?sense_hat_always_enabled=true`);

--- a/cypress/e2e/spec-wc.cy.js
+++ b/cypress/e2e/spec-wc.cy.js
@@ -1,4 +1,4 @@
-const baseUrl = "http://localhost:3001";
+const baseUrl = "http://localhost:3011";
 
 beforeEach(() => {
   cy.visit(baseUrl);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     <<: *x-app
     command: yarn start:wc
     ports:
-      - "3011:3001"
+      - "3011:3011"
     container_name: react-ui-wc
 networks:
   default:

--- a/webpack.component.config.js
+++ b/webpack.component.config.js
@@ -74,7 +74,7 @@ module.exports = {
     index: "web-component.html",
     host: "0.0.0.0",
     disableHostCheck: true,
-    port: 3001,
+    port: 3011,
     writeToDisk: true,
   },
   plugins: [


### PR DESCRIPTION
Move fully to port 3011 due to web component builds being reliant on it locally and docker port mapping not cutting the mustard