### PR TITLE
v0.21.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+## [0.21.2] - 2024-01-23
+
 ### Changed
 
 - Minor copy changes to HTML add file modal
@@ -690,6 +692,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Events in Web Component indicating whether Mission Zero criteria have been met (#113)
 
 [unreleased]: https://github.com/RaspberryPiFoundation/editor-ui/compare/v0.21.1...HEAD
+[0.21.2]: https://github.com/RaspberryPiFoundation/editor-ui/releases/tag/v0.21.2
 [0.21.1]: https://github.com/RaspberryPiFoundation/editor-ui/releases/tag/v0.21.1
 [0.21.0]: https://github.com/RaspberryPiFoundation/editor-ui/releases/tag/v0.21.0
 [0.20.0]: https://github.com/RaspberryPiFoundation/editor-ui/releases/tag/v0.20.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -691,7 +691,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Events in Web Component indicating whether Mission Zero criteria have been met (#113)
 
-[unreleased]: https://github.com/RaspberryPiFoundation/editor-ui/compare/v0.21.1...HEAD
+[unreleased]: https://github.com/RaspberryPiFoundation/editor-ui/compare/v0.21.2...HEAD
 [0.21.2]: https://github.com/RaspberryPiFoundation/editor-ui/releases/tag/v0.21.2
 [0.21.1]: https://github.com/RaspberryPiFoundation/editor-ui/releases/tag/v0.21.1
 [0.21.0]: https://github.com/RaspberryPiFoundation/editor-ui/releases/tag/v0.21.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raspberrypifoundation/editor-ui",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "private": true,
   "dependencies": {
     "@apollo/client": "^3.7.8",


### PR DESCRIPTION
## [0.21.2] - 2024-01-23

### Changed

- Minor copy changes to HTML add file modal
- Toggle errors sent via apiCallHandler off (#890)
- Upgrade webpack-dev-server to 4.0.0 to support conditional headers
- Upgrade yarn to 3.4.1 to workaround a string-width issue

### Fixed

- Editor input not focussing on iPad (#898)