### PR TITLE
Fix local docker setup to add support for yarn v3

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@ dist/
 .git/
 node_modules/
 .yarn/
+.yarnrc.yml

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 node_modules
 /.pnp
 .pnp.js
+.yarn
 
 # testing
 /coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Fixed
+
+- Local docker setup with yarn v3 (#905)
+
 ## [0.21.2] - 2024-01-23
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,14 @@ WORKDIR /app
 
 COPY package.json yarn.lock ./
 COPY . /app
+
+RUN corepack enable \
+  && corepack prepare yarn@stable --activate \
+  && yarn set version 3.4.1 \
+  && echo -e "nodeLinker: node-modules\n\n$(cat /app/.yarnrc.yml)" > /app/.yarnrc.yml \
+  && cat /app/.yarnrc.yml \
+  && printf "Switched to Yarn version: "; yarn --version
+
 RUN yarn
 
 EXPOSE 3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,13 @@ services:
       context: .
     volumes:
       - .:/app
-      - /app/node_modules
       - /var/run/docker.sock:/var/run/docker.sock
+      - /app/.yarn
+      - $PWD/.yarn/plugins:/app/.yarn/plugins
+      - $PWD/.yarn/releases:/app/.yarn/releases
+      - $PWD/.yarn/patches:/app/.yarn/patches
+      - $PWD/.yarn/sdks:/app/.yarn/sdks
+      - $PWD/.yarn/versions:/app/.yarn/versions
     stdin_open: true
   react-ui:
     <<: *x-app


### PR DESCRIPTION
Yarn v3 needs:
- activating inside Dockerfile
- volumes need mounting in docker-compose

### Notes

- `yarnrc.yml` could be different between environments (i.e. local machine and container) so ignoring the file in the repo and generating one on build in docker