### PR TITLE
Allow editor-api to request roles assigned to users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - Made `p5` canvas responsive to the available space (#887)
+- Specify the 'roles' scope in OAuth requests
 
 ### Fixed
 

--- a/src/utils/userManager.js
+++ b/src/utils/userManager.js
@@ -10,7 +10,7 @@ const userManagerConfig = {
   redirect_uri: `${host}/auth/callback`,
   post_logout_redirect_uri: host,
   response_type: "code",
-  scope: "openid email profile force-consent allow-u13-login",
+  scope: "openid email profile force-consent allow-u13-login roles",
   authority: process.env.REACT_APP_AUTHENTICATION_URL,
   silent_redirect_uri: `${host}/auth/silent_renew`,
   automaticSilentRenew: true,


### PR DESCRIPTION
This is to support the Learning Management MVP. We need to determine whether the user is a `school-owner`, `school-teacher` or `school-student`.

More context:
https://raspberrypifoundation.slack.com/archives/C02JBAA2NFP/p1707153536934779?thread_ts=1707152297.160759&cid=C02JBAA2NFP