### PR TITLE
Fixing text output width on firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 - Local docker setup with yarn v3 (#905)
-- Part of Stylelint issues: duplicates, logical properties #916
+- Part of Stylelint issues: duplicates, logical properties (#916)
+- Text output wrapping on Firefox (#922)
 
 ## [0.21.2] - 2024-01-23
 

--- a/src/assets/stylesheets/PythonRunner.scss
+++ b/src/assets/stylesheets/PythonRunner.scss
@@ -17,6 +17,7 @@
   white-space: -moz-pre-wrap;
   white-space: -pre-wrap;
   white-space: -o-pre-wrap;
+  width: 100%;
   word-wrap: break-word;
   overflow-y: auto;
 


### PR DESCRIPTION
## Before

<img width="1093" alt="Screenshot 2024-02-19 at 09 50 42" src="https://github.com/RaspberryPiFoundation/editor-ui/assets/88904316/58de163e-93b8-4544-8048-13f214c6ff65">

## After

<img width="1100" alt="Screenshot 2024-02-19 at 09 51 07" src="https://github.com/RaspberryPiFoundation/editor-ui/assets/88904316/a6116b14-2f96-4e96-ab5e-31febea0a98f">
