### PR TITLE
Add crossorigin attribute to img tags in html iframe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+## [0.22.1] - 2024-02-23
+
+### Fix
+
+- HTMLRunner images - add crossorigin attribute to iframe imgs (#927)
+
 ## [0.22.0] - 2024-02-22
 
 ### Added
@@ -714,7 +720,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Events in Web Component indicating whether Mission Zero criteria have been met (#113)
 
-[unreleased]: https://github.com/RaspberryPiFoundation/editor-ui/compare/v0.22.0...HEAD
+[unreleased]: https://github.com/RaspberryPiFoundation/editor-ui/compare/v0.22.1...HEAD
+[0.22.1]: https://github.com/RaspberryPiFoundation/editor-ui/releases/tag/v0.22.1
 [0.22.0]: https://github.com/RaspberryPiFoundation/editor-ui/releases/tag/v0.22.0
 [0.21.2]: https://github.com/RaspberryPiFoundation/editor-ui/releases/tag/v0.21.2
 [0.21.1]: https://github.com/RaspberryPiFoundation/editor-ui/releases/tag/v0.21.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raspberrypifoundation/editor-ui",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "private": true,
   "dependencies": {
     "@apollo/client": "^3.7.8",

--- a/src/components/Button/Button.jsx
+++ b/src/components/Button/Button.jsx
@@ -65,7 +65,9 @@ const Button = (props) => {
       onClick={buttonOuter ? null : onButtonClick}
       onKeyDown={onKeyDown}
     >
-      {buttonImage && <img src={buttonImage} alt={buttonImageAltText} />}
+      {buttonImage && (
+        <img src={buttonImage} alt={buttonImageAltText} crossOrigin="true" />
+      )}
       {ButtonIcon && buttonIconPosition === "left" && <ButtonIcon />}
       {text && <span>{text}</span>}
       {ButtonIcon && buttonIconPosition === "right" && <ButtonIcon />}
@@ -81,7 +83,9 @@ const Button = (props) => {
       onClick={buttonOuter ? null : onButtonClick}
       onKeyDown={onKeyDown}
     >
-      {buttonImage && <img src={buttonImage} alt={buttonImageAltText} />}
+      {buttonImage && (
+        <img src={buttonImage} alt={buttonImageAltText} crossOrigin="true" />
+      )}
       {ButtonIcon && buttonIconPosition === "left" && <ButtonIcon />}
       {buttonText && <span>{buttonText}</span>}
       {ButtonIcon && buttonIconPosition === "right" && <ButtonIcon />}

--- a/src/components/Editor/Runners/HtmlRunner/HtmlRunner.jsx
+++ b/src/components/Editor/Runners/HtmlRunner/HtmlRunner.jsx
@@ -277,6 +277,7 @@ function HtmlRunner() {
         );
       }
       srcNode.setAttribute(attr, src);
+      srcNode.setAttribute("crossorigin", true);
     });
   };
 

--- a/src/components/Menus/Dropdown/Dropdown.jsx
+++ b/src/components/Menus/Dropdown/Dropdown.jsx
@@ -50,7 +50,7 @@ const Dropdown = (props) => {
         buttonImageAltText={buttonImageAltText}
       />
 
-      {isOpen ? (
+      {isOpen && (
         <>
           <div
             className="dropdown-backdrop"
@@ -58,7 +58,7 @@ const Dropdown = (props) => {
           ></div>
           <MenuContent />
         </>
-      ) : null}
+      )}
     </div>
   );
 };


### PR DESCRIPTION
Dynamically add `crossorigin` attribute to `img` tags when `src` attribute is swapped out for a backend provided image.

#### Fix

https://github.com/RaspberryPiFoundation/editor-ui/assets/74183390/4d362a70-6502-4c46-96ce-8f73a6f4583b
