### PR TITLE
Switch out image url for blob strings

### DIFF
--- a/src/components/Editor/Runners/HtmlRunner/HtmlRunner.jsx
+++ b/src/components/Editor/Runners/HtmlRunner/HtmlRunner.jsx
@@ -108,9 +108,10 @@ function HtmlRunner() {
     var updatedProjectFile = { ...projectFile };
     if (projectFile.extension === "css") {
       projectImages.forEach((image) => {
+        const blobString = `data:${image.content_type};base64,${image.blob_data}`;
         updatedProjectFile.content = updatedProjectFile.content.replaceAll(
           image.filename,
-          image.url,
+          blobString,
         );
       });
     }


### PR DESCRIPTION
Related to https://github.com/RaspberryPiFoundation/editor-api/pull/247

Allows images used in the HTML runner to utilise blob strings rather than urls to bypass CORS/CORP issues