### PR TITLE
Reset openFiles when project is loaded/reloaded

### DIFF
--- a/src/components/Editor/EditorPanel/EditorPanel.jsx
+++ b/src/components/Editor/EditorPanel/EditorPanel.jsx
@@ -69,9 +69,15 @@ const EditorPanel = ({ extension = "html", fileName = "index" }) => {
   const editorTheme = isDarkMode ? editorDarkTheme : editorLightTheme;
 
   useEffect(() => {
-    const code = project.components.find(
+    const file = project.components.find(
       (item) => item.extension === extension && item.name === fileName,
-    ).content;
+    );
+
+    if (!file) {
+      return;
+    }
+
+    const code = file.content;
     const mode = getMode();
 
     let customIndentUnit = "  ";
@@ -112,7 +118,7 @@ const EditorPanel = ({ extension = "html", fileName = "index" }) => {
     return () => {
       view.destroy();
     };
-  }, [cookies]);
+  }, [project]);
 
   return (
     <div className={`editor editor--${settings.fontSize}`} ref={editor}></div>

--- a/src/redux/EditorSlice.js
+++ b/src/redux/EditorSlice.js
@@ -205,13 +205,12 @@ export const EditorSlice = createSlice({
         state.project.image_list = [];
       }
       state.loading = "success";
-      if (state.openFiles.flat().length === 0) {
-        const firstPanelIndex = 0;
-        if (state.project.project_type === "html") {
-          state.openFiles[firstPanelIndex].push("index.html");
-        } else {
-          state.openFiles[firstPanelIndex].push("main.py");
-        }
+      state.openFiles = [[]];
+      const firstPanelIndex = 0;
+      if (state.project.project_type === "html") {
+        state.openFiles[firstPanelIndex].push("index.html");
+      } else {
+        state.openFiles[firstPanelIndex].push("main.py");
       }
       state.justLoaded = true;
     },

--- a/src/redux/reducers/loadProjectReducers.js
+++ b/src/redux/reducers/loadProjectReducers.js
@@ -15,13 +15,12 @@ const loadProjectFulfilled = (state, action) => {
     state.justLoaded = true;
     state.saving = "idle";
     state.currentLoadingRequestId = undefined;
-    if (state.openFiles.flat().length === 0) {
-      const firstPanelIndex = 0;
-      if (state.project.project_type === "html") {
-        state.openFiles[firstPanelIndex].push("index.html");
-      } else {
-        state.openFiles[firstPanelIndex].push("main.py");
-      }
+    state.openFiles = [[]];
+    const firstPanelIndex = 0;
+    if (state.project.project_type === "html") {
+      state.openFiles[firstPanelIndex].push("index.html");
+    } else {
+      state.openFiles[firstPanelIndex].push("main.py");
     }
   }
 };


### PR DESCRIPTION
Currently there's an issue switching between projects. It's an edge case for logged in users toggling between multiple projects but currently the whole page breaks. Fix is to reset `openFiles` on project load and to be a little more defensive when loading project content.

https://github.com/RaspberryPiFoundation/editor-ui/assets/74183390/709c3e51-959d-48e8-884d-91717af2752a