### PR TITLE
Dispatch event when project identifier changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Support to enable embedding iframes in HTML projects from in-house domains (#985)
 - Unit tests for `pyodide` runner (#976)
+- Dispatch event when project identifier changes, e.g. after project is remixed (#2830)
 
 ## [0.22.2] - 2024-03-18
 

--- a/src/components/WebComponentProject/WebComponentProject.integration.test.js
+++ b/src/components/WebComponentProject/WebComponentProject.integration.test.js
@@ -1,0 +1,93 @@
+import React from "react";
+import { act, render } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { combineReducers, configureStore } from "@reduxjs/toolkit";
+import WebComponentProject from "./WebComponentProject";
+import EditorReducer from "../../redux/EditorSlice";
+import WebComponentAuthSlice from "../../redux/WebComponentAuthSlice";
+import InstructionsSlice from "../../redux/InstructionsSlice";
+import { setProject } from "../../redux/EditorSlice";
+import { projectIdentifierChangedEvent } from "../../events/WebComponentCustomEvents";
+
+const projectIdentifierChangedHandler = jest.fn();
+
+beforeAll(() => {
+  document.addEventListener(
+    "editor-projectIdentifierChanged",
+    projectIdentifierChangedHandler,
+  );
+});
+
+let store;
+
+describe("WebComponentProject", () => {
+  beforeEach(() => {
+    const rootReducer = combineReducers({
+      editor: EditorReducer,
+      auth: WebComponentAuthSlice,
+      instructions: InstructionsSlice,
+    });
+    const preloadedState = {
+      editor: {
+        project: {
+          identifier: undefined,
+          components: [
+            {
+              name: "main",
+              extension: "py",
+              content: "print('hello world')",
+            },
+          ],
+        },
+        openFiles: [["main.py"]],
+        focussedFileIndices: [1],
+      },
+      auth: {
+        user: null,
+      },
+    };
+    store = configureStore({ reducer: rootReducer, preloadedState });
+
+    render(
+      <Provider store={store}>
+        <WebComponentProject />
+      </Provider>,
+    );
+  });
+
+  test("does not trigger projectIdentifierChanged event when identifier is not set", () => {
+    expect(projectIdentifierChangedHandler).not.toHaveBeenCalled();
+  });
+
+  describe("when project identifier is changed", () => {
+    beforeEach(() => {
+      act(() => {
+        store.dispatch(
+          setProject({
+            identifier: "new-identifier",
+            components: [
+              {
+                name: "main",
+                extension: "py",
+                content: "print('hello world')",
+              },
+            ],
+          }),
+        );
+      });
+    });
+
+    test("triggers projectIdentifierChanged event with new identifier", () => {
+      expect(projectIdentifierChangedHandler).toHaveBeenCalledWith(
+        projectIdentifierChangedEvent("new-identifier"),
+      );
+    });
+  });
+});
+
+afterAll(() => {
+  document.removeEventListener(
+    "editor-projectIdentifierChanged",
+    projectIdentifierChangedHandler,
+  );
+});

--- a/src/components/WebComponentProject/WebComponentProject.jsx
+++ b/src/components/WebComponentProject/WebComponentProject.jsx
@@ -10,6 +10,7 @@ import { setIsSplitView, setWebComponent } from "../../redux/EditorSlice";
 import { MOBILE_MEDIA_QUERY } from "../../utils/mediaQueryBreakpoints";
 import {
   codeChangedEvent,
+  projectIdentifierChangedEvent,
   runCompletedEvent,
   runStartedEvent,
   stepChangedEvent,
@@ -21,6 +22,9 @@ const WebComponentProject = ({
   sidebarOptions = [],
 }) => {
   const project = useSelector((state) => state.editor.project);
+  const projectIdentifier = useSelector(
+    (state) => state.editor.project.identifier,
+  );
   const codeRunTriggered = useSelector(
     (state) => state.editor.codeRunTriggered,
   );
@@ -45,6 +49,12 @@ const WebComponentProject = ({
     }, 2000);
     return () => clearTimeout(timeout);
   }, [project]);
+
+  useEffect(() => {
+    if (projectIdentifier) {
+      document.dispatchEvent(projectIdentifierChangedEvent(projectIdentifier));
+    }
+  }, [projectIdentifier]);
 
   useEffect(() => {
     if (codeRunTriggered) {

--- a/src/events/WebComponentCustomEvents.js
+++ b/src/events/WebComponentCustomEvents.js
@@ -8,6 +8,9 @@ const webComponentCustomEvent = (type, detail) =>
 
 export const codeChangedEvent = webComponentCustomEvent("editor-codeChanged");
 
+export const projectIdentifierChangedEvent = (detail) =>
+  webComponentCustomEvent("editor-projectIdentifierChanged", detail);
+
 export const runCompletedEvent = (detail) =>
   webComponentCustomEvent("editor-runCompleted", detail);
 


### PR DESCRIPTION
See [this issue][1].

The integrated version of the editor in `editor-ui` redirects to the new project identifier URL after a project is remixed. However, the `editor-standalone` version which uses the editor web component was unable to detect changes in the project identifier and so the redirect was not working.

I've addressed this by making a new custom event ("editor-projectIdentifierChanged") available from the web component with the idea that we'll add an event listener in `ProjectComponentLoader` which redirects to the remixed project identifier URL (see https://github.com/RaspberryPiFoundation/editor-standalone/pull/63). The custom event is not dispatched when the project identifier is not set, because that's not currently useful in `editor-standalone`, but it would be easy enough to change.

This change should not change the behaviour of the `projects-ui` app which also uses the web component, because it is not listening for the new custom event. However, it would be easy enough to change that if it was desirable.

Note that I've added a separate integration test for `WebComponentProject`, because I wanted to use a real Redux store rather than the mock store that's being used in the unit test. This is the approach recommended [in the Redux docs][2]:

> Our recommendation for testing Redux-connected React components is via
> integration tests that include everything working together, with
> assertions aimed at verifying that the app behaves the way you expect
> when the user interacts with it in a given manner.

I hope the directory/file-naming convention I've used makes sense: `src/components/WebComponentProject/WebComponentProject.integration.test.js`.

[1]: https://github.com/RaspberryPiFoundation/editor-standalone/issues/55
[2]: https://redux.js.org/usage/writing-tests#integration-testing-connected-components-and-redux-logic