### PR TITLE
Remove broken `format` script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Support to enable embedding iframes in HTML projects from in-house domains (#985)
 - Unit tests for `pyodide` runner (#976)
 - Dispatch event when project identifier changes, e.g. after project is remixed (#2830)
+- Remove broken `format` script (#991)
 
 ## [0.22.2] - 2024-03-18
 

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "build-storybook": "cd ./storybook && yarn install && yarn run build-storybook -- -o ../public/storybook --loglevel warn",
     "lint": "eslint \"src/**/*.{js,jsx,json}\"",
     "lint:fix": "eslint --fix \"src/**/*.{js,jsx,json}\"",
-    "format": "prettier --write src/**/*.{js,jsx,css,md,json,scss} --config ./.prettierrc",
     "stylelint": "stylelint src/**/*.scss",
     "test": "node scripts/test.js --transformIgnorePatterns 'node_modules/(?!three)/'",
     "test:integration": "cd e2e; docker compose up --exit-code-from cypress",


### PR DESCRIPTION
This script is broken, because no `.prettierrc` file is included in the repo.

We're relying on the `prettier` plugin for `eslint` to do code formatting & checking, e.g. in `.github/workflows/ci-cd.yml` where we [invoke `yarn lint`][1] to check the formatting.

Similarly, the `lint:fix` script can be used to apply formatting. So the `format` script is redundant and potentially confusing to new developers.

[1]: https://github.com/RaspberryPiFoundation/editor-ui/blob/5197facfc6253be548205d24e89478af286eb384/.github/workflows/ci-cd.yml#L31-L32