### PR TITLE
Add `load-remix-enabled` attribute to web component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Dispatch event when project identifier changes, e.g. after project is remixed (#2830)
 - Remove broken `format` script (#991)
 - Invalidate cached project when project is remixed (#1003)
+- Add `load_remix_disabled` attribute to web component (#992)
 
 ## [0.22.2] - 2024-03-18
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ The web component can be included in a page by using the `<editor-wc>` HTML elem
 
 - `code`: A preset blob of code to show in the editor pane.
 - `sense_hat_always_enabled`: Show the Astro Pi Sense HAT emulator on page load
+- `load_remix_disabled`: Do not load a logged-in user's remixed version of the project specified by `identifier` even if one exists (defaults to `false`)
 
 ### `yarn start:wc`
 

--- a/src/containers/WebComponentLoader.jsx
+++ b/src/containers/WebComponentLoader.jsx
@@ -1,6 +1,10 @@
 import React, { useEffect, useState } from "react";
 import { useSelector, useDispatch } from "react-redux";
-import { disableTheming, setSenseHatAlwaysEnabled } from "../redux/EditorSlice";
+import {
+  disableTheming,
+  setSenseHatAlwaysEnabled,
+  setLoadRemixDisabled,
+} from "../redux/EditorSlice";
 import WebComponentProject from "../components/WebComponentProject/WebComponentProject";
 import { useTranslation } from "react-i18next";
 import { setInstructions } from "../redux/InstructionsSlice";
@@ -34,6 +38,7 @@ const WebComponentLoader = (props) => {
     embedded = false,
     hostStyles,
     showSavePrompt = false,
+    loadRemixDisabled = false,
   } = props;
 
   const dispatch = useDispatch();
@@ -97,7 +102,7 @@ const WebComponentLoader = (props) => {
     projectIdentifier: projectIdentifier,
     code,
     accessToken: user?.access_token,
-    loadRemix,
+    loadRemix: loadRemix && !loadRemixDisabled,
     loadCache,
     remixLoadFailed,
   });
@@ -113,6 +118,10 @@ const WebComponentLoader = (props) => {
   useEffect(() => {
     dispatch(setSenseHatAlwaysEnabled(senseHatAlwaysEnabled));
   }, [senseHatAlwaysEnabled, dispatch]);
+
+  useEffect(() => {
+    dispatch(setLoadRemixDisabled(loadRemixDisabled));
+  }, [loadRemixDisabled, dispatch]);
 
   useEffect(() => {
     if (instructions) {

--- a/src/containers/WebComponentLoader.test.js
+++ b/src/containers/WebComponentLoader.test.js
@@ -259,6 +259,7 @@ describe("When user is in state", () => {
                 instructions={instructions}
                 authKey={authKey}
                 theme="light"
+                loadRemixDisabled={false}
               />
             </CookiesProvider>
           </Provider>,
@@ -273,6 +274,35 @@ describe("When user is in state", () => {
           loadRemix: true,
           loadCache: false,
           remixLoadFailed: false,
+        });
+      });
+
+      describe("when loadRemixDisabled is true", () => {
+        beforeEach(() => {
+          render(
+            <Provider store={store}>
+              <CookiesProvider cookies={cookies}>
+                <WebComponentLoader
+                  identifier={identifier}
+                  instructions={instructions}
+                  authKey={authKey}
+                  theme="light"
+                  loadRemixDisabled={true}
+                />
+              </CookiesProvider>
+            </Provider>,
+          );
+        });
+
+        test("Calls useProject hook with loadRemix set to false, i.e. it is overidden", () => {
+          expect(useProject).toHaveBeenCalledWith({
+            projectIdentifier: identifier,
+            code: undefined,
+            accessToken: "my_token",
+            loadRemix: false,
+            loadCache: false,
+            remixLoadFailed: false,
+          });
         });
       });
 

--- a/src/redux/EditorSlice.js
+++ b/src/redux/EditorSlice.js
@@ -111,6 +111,7 @@ export const EditorSlice = createSlice({
     lastSavedTime: null,
     senseHatAlwaysEnabled: false,
     senseHatEnabled: false,
+    loadRemixDisabled: false,
     accessDeniedNoAuthModalShowing: false,
     accessDeniedWithAuthModalShowing: false,
     betaModalShowing: false,
@@ -222,6 +223,9 @@ export const EditorSlice = createSlice({
     },
     setSenseHatEnabled: (state, action) => {
       state.senseHatEnabled = action.payload;
+    },
+    setLoadRemixDisabled: (state, action) => {
+      state.loadRemixDisabled = action.payload;
     },
     triggerDraw: (state) => {
       state.drawTriggered = true;
@@ -460,6 +464,7 @@ export const {
   setProject,
   setSenseHatAlwaysEnabled,
   setSenseHatEnabled,
+  setLoadRemixDisabled,
   stopCodeRun,
   stopDraw,
   triggerCodeRun,

--- a/src/redux/EditorSlice.test.js
+++ b/src/redux/EditorSlice.test.js
@@ -15,6 +15,7 @@ import reducer, {
   setFocussedFileIndex,
   updateComponentName,
   loadProjectList,
+  setLoadRemixDisabled,
 } from "./EditorSlice";
 
 jest.mock("../utils/apiCallHandler");
@@ -29,6 +30,30 @@ test("Action stopCodeRun sets codeRunStopped to true", () => {
     codeRunStopped: true,
   };
   expect(reducer(previousState, stopCodeRun())).toEqual(expectedState);
+});
+
+test("Action setLoadRemixDisabled sets loadRemixDisabled to true", () => {
+  const previousState = {
+    loadRemixDisabled: false,
+  };
+  const expectedState = {
+    loadRemixDisabled: true,
+  };
+  expect(reducer(previousState, setLoadRemixDisabled(true))).toEqual(
+    expectedState,
+  );
+});
+
+test("Action setLoadRemixDisabled sets loadRemixDisabled to false", () => {
+  const previousState = {
+    loadRemixDisabled: true,
+  };
+  const expectedState = {
+    loadRemixDisabled: false,
+  };
+  expect(reducer(previousState, setLoadRemixDisabled(false))).toEqual(
+    expectedState,
+  );
 });
 
 test("Showing rename modal sets file state and showing status", () => {

--- a/src/web-component.js
+++ b/src/web-component.js
@@ -48,6 +48,7 @@ class WebComponent extends HTMLElement {
       "theme",
       "embedded",
       "show_save_prompt",
+      "load_remix_disabled",
     ];
   }
 
@@ -60,6 +61,7 @@ class WebComponent extends HTMLElement {
         "with_sidebar",
         "with_projectbar",
         "show_save_prompt",
+        "load_remix_disabled",
       ].includes(name)
     ) {
       value = newVal !== "false";


### PR DESCRIPTION
This work came out of [this issue][1].

These changes mean that it is now possible to configure the web component not to load a logged-in user's remixed version of the project by setting `load_remix_disabled` to `true`.

We want to use this in `editor-standalone` with the web component editor so that we reproduce the behaviour currently in `editor-ui` with the integrated editor.

When the new attribute is set to `true`, the `loadRemix` property passed to `useProject` in `WebComponentLoader` is forced to be `false` so that the remixed version of the project will not be loaded.

The name of the new attribute isn't ideal - I would rather have used `load_remix_enabled` - however, boolean attributes of the web component default to `false` and I want the default behaviour to remain unchanged to avoid breaking the `projects-ui` app.

I've opened [this draft PR](https://github.com/RaspberryPiFoundation/editor-standalone/pull/85) on `editor-standalone` to illustrate the changes I plan to make. I'm hoping to add some end-to-end/integration tests in that repo to verify the new behaviour.

Screencast showing the fix in action in my local version of `editor-standalone` with the new `load_remix_disabled` attribute of the editor web component set to `true` in the `Project` & `MobileProject` components.

https://github.com/RaspberryPiFoundation/editor-ui/assets/3169/3f94dc06-f828-49f0-95f4-40848ec234bc



[1]: https://github.com/RaspberryPiFoundation/editor-standalone/issues/55.