### PR TITLE
Invalidate cached project when project is remixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Unit tests for `pyodide` runner (#976)
 - Dispatch event when project identifier changes, e.g. after project is remixed (#2830)
 - Remove broken `format` script (#991)
+- Invalidate cached project when project is remixed (#1003)
 
 ## [0.22.2] - 2024-03-18
 

--- a/src/redux/EditorSlice.js
+++ b/src/redux/EditorSlice.js
@@ -394,6 +394,7 @@ export const EditorSlice = createSlice({
       state.saving = "pending";
     });
     builder.addCase("editor/remixProject/fulfilled", (state, action) => {
+      localStorage.removeItem(state.project.identifier);
       state.lastSaveAutosave = false;
       state.saving = "success";
       state.project = action.payload.project;

--- a/src/redux/EditorSlice.test.js
+++ b/src/redux/EditorSlice.test.js
@@ -187,6 +187,8 @@ describe("When project has an identifier", () => {
   let remixAction;
 
   beforeEach(() => {
+    localStorage.clear();
+
     saveThunk = syncProject("save");
     saveAction = saveThunk({
       project,
@@ -195,6 +197,10 @@ describe("When project has an identifier", () => {
     });
     remixThunk = syncProject("remix");
     remixAction = remixThunk({ project, accessToken: access_token });
+  });
+
+  afterEach(() => {
+    localStorage.clear();
   });
 
   test("Saving updates existing project", async () => {
@@ -245,6 +251,20 @@ describe("When project has an identifier", () => {
     expect(
       reducer(initialState.editor, remixThunk.fulfilled({ project })),
     ).toEqual(expectedState);
+  });
+
+  test("The remixProject/fulfilled action removes original project from local storage", async () => {
+    localStorage.setItem(project.identifier, JSON.stringify(project));
+
+    const remixedProject = Object.assign({}, project);
+    remixedProject.identifier = "my-remixed-project";
+
+    reducer(
+      initialState.editor,
+      remixThunk.fulfilled({ project: remixedProject }),
+    );
+
+    expect(localStorage.getItem(project.identifier)).toBeNull();
   });
 });
 


### PR DESCRIPTION
This fixes [an issue](https://github.com/RaspberryPiFoundation/editor-ui/issues/1001) which you can see if you follow these steps:

1. Login
2. Visit a project you do not own
3. Edit the code
4. Save the project (thus remixing it)
5. Visit the original project URL again
6. See your changes in the code when you should see the original version

This was happening because after step 3 the auto-save functionality stored the project (with your code changes) in local storage against the original project identifier. When the project was saved, the remixed version was created in the database, but the cached version was left in local storage. When you re-visit the original project URL, the project cached in local storage was loaded, because the URL path matches the local storage key, i.e. the original project identifier.

The fix is to invalidate the cached project after it is successfully remixed in a similar way to how [the cached project is invalidated after it is successfully *saved*][1]. In this case, since we're *remixing*, the original project should always have an identifier, so we don't need to fallback to "project" like we do for saving.

I did wonder whether we should only do this if the remixed project identifier (i.e. `action.payload.project.identifier`) is different from the original project identifier (i.e. `state.project.identifier`). However, I'm fairly confident this will always be true if we are remixing.

Note that this came up when I was testing the changes in #992.

[1]: https://github.com/RaspberryPiFoundation/editor-ui/blob/70ea01cefa38aa60d1d6d9fb4bc11188b6009049/src/redux/EditorSlice.js#L373

Fixes #1001.