### PR TITLE
Release v0.23.0 (fixed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -769,7 +769,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Events in Web Component indicating whether Mission Zero criteria have been met (#113)
 
-[unreleased]: https://github.com/RaspberryPiFoundation/editor-ui/compare/v0.22.2...HEAD
+[unreleased]: https://github.com/RaspberryPiFoundation/editor-ui/compare/v0.23.0...HEAD
+[0.23.0]: https://github.com/RaspberryPiFoundation/editor-ui/releases/tag/v0.23.0
 [0.22.2]: https://github.com/RaspberryPiFoundation/editor-ui/releases/tag/v0.22.2
 [0.22.1]: https://github.com/RaspberryPiFoundation/editor-ui/releases/tag/v0.22.1
 [0.22.0]: https://github.com/RaspberryPiFoundation/editor-ui/releases/tag/v0.22.0


### PR DESCRIPTION
### Added

- Support to enable embedding iframes in HTML projects from in-house domains (#985)
- Dispatch event when project identifier changes, e.g. after project is remixed (#2830)
- Add `load_remix_disabled` attribute to web component (#992)

### Changed

- Invalidate cached project when project is remixed (#1003)

### Fixed

- Unit tests for `pyodide` runner (#976)
- Remove broken `format` script (#991)
