### PR TITLE
Fix infinite remix loop when BYPASS_AUTH set in editor-api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 - Remove unused `REACT_APP_LOGIN_ENABLED` env var (#1006)
+- Fix infinite remix loop when `BYPASS_AUTH` set in `editor-api` (#1007)
 
 ## [0.23.0] - 2024-05-09
 

--- a/src/redux/EditorSlice.js
+++ b/src/redux/EditorSlice.js
@@ -396,6 +396,7 @@ export const EditorSlice = createSlice({
     });
     builder.addCase("editor/remixProject/pending", (state, action) => {
       state.saving = "pending";
+      state.saveTriggered = false;
     });
     builder.addCase("editor/remixProject/fulfilled", (state, action) => {
       localStorage.removeItem(state.project.identifier);

--- a/src/redux/EditorSlice.test.js
+++ b/src/redux/EditorSlice.test.js
@@ -228,6 +228,14 @@ describe("When project has an identifier", () => {
     localStorage.clear();
   });
 
+  test("The saveProject/pending action sets saveTriggered to false", async () => {
+    const newState = reducer(
+      initialState.editor,
+      saveThunk.pending({ project }),
+    );
+    expect(newState.saveTriggered).toBe(false);
+  });
+
   test("Saving updates existing project", async () => {
     await saveAction(dispatch, () => initialState);
     expect(createOrUpdateProject).toHaveBeenCalledWith(project, access_token);
@@ -250,6 +258,14 @@ describe("When project has an identifier", () => {
     expect(
       reducer(initialState.editor, saveThunk.fulfilled({ project })),
     ).toEqual(expectedState);
+  });
+
+  test("The remixProject/pending action sets saveTriggered to false", async () => {
+    const newState = reducer(
+      initialState.editor,
+      remixThunk.pending({ project }),
+    );
+    expect(newState.saveTriggered).toBe(false);
   });
 
   test("Remixing triggers createRemix API call", async () => {


### PR DESCRIPTION
Previously when `BYPASS_AUTH` was set to `true` in `editor-api` and a remix was triggered in `editor-ui`, the editor went into an ♾️ infinite loop creating remix after remix after remix of the same project... 

This was happening, because `saveTriggered` was never being set to `false` in the "editor/remixProject/pending" case in `EditorSlice` like it is being in "editor/saveProject/pending". Thus [this condition][1] in the `useProjectPersistence` hook was always `true` and `syncProject("remix")` was repeatedly dispatched.

https://github.com/RaspberryPiFoundation/editor-ui/blob/2df8a9761bff2de4824a7815252eb62560e85356/src/redux/EditorSlice.js#L372-L375

https://github.com/RaspberryPiFoundation/editor-ui/blob/2df8a9761bff2de4824a7815252eb62560e85356/src/redux/EditorSlice.js#L397-L399

We were somehow (mostly?) getting away with this when `BYPASS_AUTH` was not set in `editor-ui`, because of the extra time taken to make real authentication requests from within the API request to create the remixed project. This meant that by the time the `useProjectPersistence` hook was executed for the 2nd time, [`isOwner(user, project)`][2] returned `true` and so `syncProject("save")` was dispatched instead of `syncProject("remix")`. This in turn meant that the "editor/saveProject/pending" case was executed and thus `saveTriggered` was set to `false` preventing the infinite loop at the cost of an unintended/unnecessary save of the remixed project just created.

By setting `saveTriggered` to `false` in the "editor/remixProject/pending" case like we do in the "editor/saveProject/pending" case, we can prevent the infinite loop and the extra saving of the project.

[1]: https://github.com/RaspberryPiFoundation/editor-ui/blob/2df8a9761bff2de4824a7815252eb62560e85356/src/hooks/useProjectPersistence.js#L23
[2]: https://github.com/RaspberryPiFoundation/editor-ui/blob/2df8a9761bff2de4824a7815252eb62560e85356/src/hooks/useProjectPersistence.js#L24