### PR TITLE
Fixes for docker-compose.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Remove unused `REACT_APP_LOGIN_ENABLED` env var (#1006)
 - Fix infinite remix loop when `BYPASS_AUTH` set in `editor-api` (#1007)
+- Fixes for docker-compose.yml (#1008)
 
 ## [0.23.0] - 2024-05-09
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,18 @@
 version: "3.8"
+x-app: &x-app
+  build:
+    context: .
+  volumes:
+    - .:/app
+    - /var/run/docker.sock:/var/run/docker.sock
+    - /app/.yarn
+    - $PWD/.yarn/plugins:/app/.yarn/plugins
+    - $PWD/.yarn/releases:/app/.yarn/releases
+    - $PWD/.yarn/patches:/app/.yarn/patches
+    - $PWD/.yarn/sdks:/app/.yarn/sdks
+    - $PWD/.yarn/versions:/app/.yarn/versions
+  stdin_open: true
 services:
-  x-app: &x-app
-    build:
-      context: .
-    volumes:
-      - .:/app
-      - /var/run/docker.sock:/var/run/docker.sock
-      - /app/.yarn
-      - $PWD/.yarn/plugins:/app/.yarn/plugins
-      - $PWD/.yarn/releases:/app/.yarn/releases
-      - $PWD/.yarn/patches:/app/.yarn/patches
-      - $PWD/.yarn/sdks:/app/.yarn/sdks
-      - $PWD/.yarn/versions:/app/.yarn/versions
-    stdin_open: true
   react-ui:
     <<: *x-app
     command: yarn start

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 x-app: &x-app
   build:
     context: .


### PR DESCRIPTION
* Avoid creating an extra unnecessary container
* Avoid a warning about the `version` property
