### PR TITLE
Add project_name_editable attribute to web component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
+- Add `project_name_editable` attribute to web component (#1009)
+
 ### Changed
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ The web component can be included in a page by using the `<editor-wc>` HTML elem
 - `code`: A preset blob of code to show in the editor pane.
 - `sense_hat_always_enabled`: Show the Astro Pi Sense HAT emulator on page load
 - `load_remix_disabled`: Do not load a logged-in user's remixed version of the project specified by `identifier` even if one exists (defaults to `false`)
+- `project_name_editable`: Allow the user to edit the project name in the project bar (defaults to `false`)
 
 ### `yarn start:wc`
 

--- a/src/components/Editor/Project/Project.jsx
+++ b/src/components/Editor/Project/Project.jsx
@@ -18,7 +18,7 @@ import { projContainer } from "../../../utils/containerQueries";
 const Project = (props) => {
   const webComponent = useSelector((state) => state.editor.webComponent);
   const {
-    projectNameReadonly = false,
+    projectNameEditable = true,
     withProjectbar = true,
     withSidebar = true,
     sidebarOptions = [],
@@ -62,7 +62,7 @@ const Project = (props) => {
         {withSidebar && <Sidebar options={sidebarOptions} />}
         <div className="project-wrapper" ref={containerRef}>
           {withProjectbar && (
-            <ProjectBar projectNameReadonly={projectNameReadonly} />
+            <ProjectBar projectNameEditable={projectNameEditable} />
           )}
           {!loading && (
             <div className="proj-editor-wrapper">

--- a/src/components/Editor/Project/Project.jsx
+++ b/src/components/Editor/Project/Project.jsx
@@ -18,7 +18,7 @@ import { projContainer } from "../../../utils/containerQueries";
 const Project = (props) => {
   const webComponent = useSelector((state) => state.editor.webComponent);
   const {
-    forWebComponent = false,
+    projectNameReadonly = false,
     withProjectbar = true,
     withSidebar = true,
     sidebarOptions = [],
@@ -61,7 +61,9 @@ const Project = (props) => {
       >
         {withSidebar && <Sidebar options={sidebarOptions} />}
         <div className="project-wrapper" ref={containerRef}>
-          {withProjectbar && <ProjectBar forWebComponent={forWebComponent} />}
+          {withProjectbar && (
+            <ProjectBar projectNameReadonly={projectNameReadonly} />
+          )}
           {!loading && (
             <div className="proj-editor-wrapper">
               <ResizableWithHandle

--- a/src/components/Editor/Project/Project.jsx
+++ b/src/components/Editor/Project/Project.jsx
@@ -18,7 +18,7 @@ import { projContainer } from "../../../utils/containerQueries";
 const Project = (props) => {
   const webComponent = useSelector((state) => state.editor.webComponent);
   const {
-    projectNameEditable = true,
+    nameEditable = true,
     withProjectbar = true,
     withSidebar = true,
     sidebarOptions = [],
@@ -61,9 +61,7 @@ const Project = (props) => {
       >
         {withSidebar && <Sidebar options={sidebarOptions} />}
         <div className="project-wrapper" ref={containerRef}>
-          {withProjectbar && (
-            <ProjectBar projectNameEditable={projectNameEditable} />
-          )}
+          {withProjectbar && <ProjectBar nameEditable={nameEditable} />}
           {!loading && (
             <div className="proj-editor-wrapper">
               <ResizableWithHandle

--- a/src/components/ProjectBar/ProjectBar.jsx
+++ b/src/components/ProjectBar/ProjectBar.jsx
@@ -10,7 +10,7 @@ import SaveButton from "../SaveButton/SaveButton";
 import "../../assets/stylesheets/ProjectBar.scss";
 import { isOwner } from "../../utils/projectHelpers";
 
-const ProjectBar = ({ projectNameReadonly = false }) => {
+const ProjectBar = ({ projectNameEditable = true }) => {
   const { t } = useTranslation();
 
   const project = useSelector((state) => state.editor.project);
@@ -24,7 +24,7 @@ const ProjectBar = ({ projectNameReadonly = false }) => {
     loading === "success" && (
       <div className="project-bar">
         {loading === "success" && (
-          <ProjectName projectNameReadonly={projectNameReadonly} />
+          <ProjectName projectNameEditable={projectNameEditable} />
         )}
         <div className="project-bar__right">
           {loading === "success" && (

--- a/src/components/ProjectBar/ProjectBar.jsx
+++ b/src/components/ProjectBar/ProjectBar.jsx
@@ -10,7 +10,7 @@ import SaveButton from "../SaveButton/SaveButton";
 import "../../assets/stylesheets/ProjectBar.scss";
 import { isOwner } from "../../utils/projectHelpers";
 
-const ProjectBar = ({ projectNameEditable = true }) => {
+const ProjectBar = ({ nameEditable = true }) => {
   const { t } = useTranslation();
 
   const project = useSelector((state) => state.editor.project);
@@ -23,9 +23,7 @@ const ProjectBar = ({ projectNameEditable = true }) => {
   return (
     loading === "success" && (
       <div className="project-bar">
-        {loading === "success" && (
-          <ProjectName projectNameEditable={projectNameEditable} />
-        )}
+        {loading === "success" && <ProjectName editable={nameEditable} />}
         <div className="project-bar__right">
           {loading === "success" && (
             <div className="project-bar__btn-wrapper">

--- a/src/components/ProjectBar/ProjectBar.jsx
+++ b/src/components/ProjectBar/ProjectBar.jsx
@@ -10,7 +10,7 @@ import SaveButton from "../SaveButton/SaveButton";
 import "../../assets/stylesheets/ProjectBar.scss";
 import { isOwner } from "../../utils/projectHelpers";
 
-const ProjectBar = ({ forWebComponent = false }) => {
+const ProjectBar = ({ projectNameReadonly = false }) => {
   const { t } = useTranslation();
 
   const project = useSelector((state) => state.editor.project);
@@ -24,7 +24,7 @@ const ProjectBar = ({ forWebComponent = false }) => {
     loading === "success" && (
       <div className="project-bar">
         {loading === "success" && (
-          <ProjectName forWebComponent={forWebComponent} />
+          <ProjectName projectNameReadonly={projectNameReadonly} />
         )}
         <div className="project-bar__right">
           {loading === "success" && (

--- a/src/components/ProjectName/ProjectName.jsx
+++ b/src/components/ProjectName/ProjectName.jsx
@@ -14,7 +14,7 @@ import PropTypes from "prop-types";
 const ProjectName = ({
   className = null,
   showLabel = false,
-  projectNameReadonly = false,
+  projectNameEditable = true,
 }) => {
   const project = useSelector((state) => state.editor.project, shallowEqual);
 
@@ -109,7 +109,7 @@ const ProjectName = ({
         <h1 style={{ height: 0, width: 0, overflow: "hidden" }}>
           {project.name || t("header.newProject")}
         </h1>
-        {projectNameReadonly ? (
+        {!projectNameEditable ? (
           <div className="project-name__title">{name}</div>
         ) : (
           <input
@@ -125,7 +125,7 @@ const ProjectName = ({
             onChange={handleOnChange}
           />
         )}
-        {!projectNameReadonly && (
+        {projectNameEditable && (
           <div ref={tickButton}>
             <DesignSystemButton
               className="project-name__button"

--- a/src/components/ProjectName/ProjectName.jsx
+++ b/src/components/ProjectName/ProjectName.jsx
@@ -14,7 +14,7 @@ import PropTypes from "prop-types";
 const ProjectName = ({
   className = null,
   showLabel = false,
-  forWebComponent = false,
+  projectNameReadonly = false,
 }) => {
   const project = useSelector((state) => state.editor.project, shallowEqual);
 
@@ -109,7 +109,7 @@ const ProjectName = ({
         <h1 style={{ height: 0, width: 0, overflow: "hidden" }}>
           {project.name || t("header.newProject")}
         </h1>
-        {forWebComponent ? (
+        {projectNameReadonly ? (
           <div className="project-name__title">{name}</div>
         ) : (
           <input
@@ -125,7 +125,7 @@ const ProjectName = ({
             onChange={handleOnChange}
           />
         )}
-        {!forWebComponent && (
+        {!projectNameReadonly && (
           <div ref={tickButton}>
             <DesignSystemButton
               className="project-name__button"

--- a/src/components/ProjectName/ProjectName.jsx
+++ b/src/components/ProjectName/ProjectName.jsx
@@ -24,11 +24,11 @@ const ProjectName = ({
   const nameInput = useRef();
   const tickButton = useRef();
 
-  const [isEditable, setEditable] = useState(false);
+  const [isEditing, setEditing] = useState(false);
   const [name, setName] = useState(project.name || t("projectName.newProject"));
 
   const onEditNameButtonClick = () => {
-    setEditable(true);
+    setEditing(true);
   };
 
   const selectText = () => {
@@ -36,7 +36,7 @@ const ProjectName = ({
   };
 
   const handleScroll = () => {
-    if (!isEditable) {
+    if (!isEditing) {
       nameInput.current.scrollLeft = 0;
     }
   };
@@ -52,14 +52,14 @@ const ProjectName = ({
   const updateName = (event) => {
     event.stopPropagation();
     event.preventDefault();
-    setEditable(false);
+    setEditing(false);
     dispatch(updateProjectName(nameInput.current.value));
   };
 
   const resetName = useCallback(
     (event) => {
       event.preventDefault();
-      setEditable(false);
+      setEditing(false);
       setName(project.name);
     },
     [project.name],
@@ -74,7 +74,7 @@ const ProjectName = ({
   };
 
   useEffect(() => {
-    if (isEditable) {
+    if (isEditing) {
       nameInput.current.focus();
     }
   });
@@ -82,7 +82,7 @@ const ProjectName = ({
   useEffect(() => {
     const handleClickOutside = (event) => {
       if (
-        isEditable &&
+        isEditing &&
         nameInput.current &&
         !nameInput.current.contains(event.target) &&
         tickButton.current &&
@@ -95,7 +95,7 @@ const ProjectName = ({
     return () => {
       document.removeEventListener("mousedown", handleClickOutside);
     };
-  }, [isEditable, nameInput, tickButton, project, resetName]);
+  }, [isEditing, nameInput, tickButton, project, resetName]);
 
   return (
     <>
@@ -119,7 +119,7 @@ const ProjectName = ({
             onScroll={handleScroll}
             onKeyDown={handleKeyDown}
             value={name}
-            disabled={!isEditable}
+            disabled={!isEditing}
             onChange={handleOnChange}
           />
         ) : (
@@ -130,14 +130,14 @@ const ProjectName = ({
             <DesignSystemButton
               className="project-name__button"
               aria-label={t(
-                isEditable ? "header.renameSave" : "header.renameProject",
+                isEditing ? "header.renameSave" : "header.renameProject",
               )}
               title={t(
-                isEditable ? "header.renameSave" : "header.renameProject",
+                isEditing ? "header.renameSave" : "header.renameProject",
               )}
-              icon={isEditable ? <TickIcon /> : <PencilIcon />}
-              onClick={isEditable ? updateName : onEditNameButtonClick}
-              type={isEditable ? "primary" : "tertiary"}
+              icon={isEditing ? <TickIcon /> : <PencilIcon />}
+              onClick={isEditing ? updateName : onEditNameButtonClick}
+              type={isEditing ? "primary" : "tertiary"}
             />
           </div>
         )}

--- a/src/components/ProjectName/ProjectName.jsx
+++ b/src/components/ProjectName/ProjectName.jsx
@@ -14,7 +14,7 @@ import PropTypes from "prop-types";
 const ProjectName = ({
   className = null,
   showLabel = false,
-  projectNameEditable = true,
+  editable = true,
 }) => {
   const project = useSelector((state) => state.editor.project, shallowEqual);
 
@@ -109,7 +109,7 @@ const ProjectName = ({
         <h1 style={{ height: 0, width: 0, overflow: "hidden" }}>
           {project.name || t("header.newProject")}
         </h1>
-        {projectNameEditable ? (
+        {editable ? (
           <input
             className="project-name__input"
             id={"project_name"}
@@ -125,7 +125,7 @@ const ProjectName = ({
         ) : (
           <div className="project-name__title">{name}</div>
         )}
-        {projectNameEditable && (
+        {editable && (
           <div ref={tickButton}>
             <DesignSystemButton
               className="project-name__button"

--- a/src/components/ProjectName/ProjectName.jsx
+++ b/src/components/ProjectName/ProjectName.jsx
@@ -109,9 +109,7 @@ const ProjectName = ({
         <h1 style={{ height: 0, width: 0, overflow: "hidden" }}>
           {project.name || t("header.newProject")}
         </h1>
-        {!projectNameEditable ? (
-          <div className="project-name__title">{name}</div>
-        ) : (
+        {projectNameEditable ? (
           <input
             className="project-name__input"
             id={"project_name"}
@@ -124,6 +122,8 @@ const ProjectName = ({
             disabled={!isEditable}
             onChange={handleOnChange}
           />
+        ) : (
+          <div className="project-name__title">{name}</div>
         )}
         {projectNameEditable && (
           <div ref={tickButton}>

--- a/src/components/ProjectName/ProjectName.test.js
+++ b/src/components/ProjectName/ProjectName.test.js
@@ -53,7 +53,7 @@ describe("With a webComponent=true", () => {
     store = mockStore(initialState);
     render(
       <Provider store={store}>
-        <ProjectName showLabel={true} projectNameEditable={false} />
+        <ProjectName showLabel={true} editable={false} />
       </Provider>,
     );
   });

--- a/src/components/ProjectName/ProjectName.test.js
+++ b/src/components/ProjectName/ProjectName.test.js
@@ -53,7 +53,7 @@ describe("With a webComponent=true", () => {
     store = mockStore(initialState);
     render(
       <Provider store={store}>
-        <ProjectName showLabel={true} forWebComponent={true} />
+        <ProjectName showLabel={true} projectNameReadonly={true} />
       </Provider>,
     );
   });

--- a/src/components/ProjectName/ProjectName.test.js
+++ b/src/components/ProjectName/ProjectName.test.js
@@ -53,7 +53,7 @@ describe("With a webComponent=true", () => {
     store = mockStore(initialState);
     render(
       <Provider store={store}>
-        <ProjectName showLabel={true} projectNameReadonly={true} />
+        <ProjectName showLabel={true} projectNameEditable={false} />
       </Provider>,
     );
   });

--- a/src/components/WebComponentProject/WebComponentProject.jsx
+++ b/src/components/WebComponentProject/WebComponentProject.jsx
@@ -86,7 +86,7 @@ const WebComponentProject = ({
         />
       ) : (
         <Project
-          forWebComponent={true}
+          projectNameReadonly={true}
           withProjectbar={withProjectbar}
           withSidebar={withSidebar}
           sidebarOptions={sidebarOptions}

--- a/src/components/WebComponentProject/WebComponentProject.jsx
+++ b/src/components/WebComponentProject/WebComponentProject.jsx
@@ -86,7 +86,7 @@ const WebComponentProject = ({
         />
       ) : (
         <Project
-          projectNameReadonly={true}
+          projectNameEditable={false}
           withProjectbar={withProjectbar}
           withSidebar={withSidebar}
           sidebarOptions={sidebarOptions}

--- a/src/components/WebComponentProject/WebComponentProject.jsx
+++ b/src/components/WebComponentProject/WebComponentProject.jsx
@@ -18,6 +18,7 @@ import {
 
 const WebComponentProject = ({
   withProjectbar = false,
+  nameEditable = false,
   withSidebar = false,
   sidebarOptions = [],
 }) => {
@@ -86,7 +87,7 @@ const WebComponentProject = ({
         />
       ) : (
         <Project
-          nameEditable={false}
+          nameEditable={nameEditable}
           withProjectbar={withProjectbar}
           withSidebar={withSidebar}
           sidebarOptions={sidebarOptions}

--- a/src/components/WebComponentProject/WebComponentProject.jsx
+++ b/src/components/WebComponentProject/WebComponentProject.jsx
@@ -86,7 +86,7 @@ const WebComponentProject = ({
         />
       ) : (
         <Project
-          projectNameEditable={false}
+          nameEditable={false}
           withProjectbar={withProjectbar}
           withSidebar={withSidebar}
           sidebarOptions={sidebarOptions}

--- a/src/containers/WebComponentLoader.jsx
+++ b/src/containers/WebComponentLoader.jsx
@@ -32,6 +32,7 @@ const WebComponentLoader = (props) => {
     senseHatAlwaysEnabled = false,
     instructions,
     withProjectbar = false,
+    projectNameEditable = false,
     withSidebar = false,
     sidebarOptions = [],
     theme,
@@ -151,6 +152,7 @@ const WebComponentLoader = (props) => {
             />
             <WebComponentProject
               withProjectbar={withProjectbar}
+              nameEditable={projectNameEditable}
               withSidebar={withSidebar}
               sidebarOptions={sidebarOptions}
             />

--- a/src/web-component.js
+++ b/src/web-component.js
@@ -43,6 +43,7 @@ class WebComponent extends HTMLElement {
       "sense_hat_always_enabled",
       "instructions",
       "with_projectbar",
+      "project_name_editable",
       "with_sidebar",
       "sidebar_options",
       "theme",
@@ -60,6 +61,7 @@ class WebComponent extends HTMLElement {
         "sense_hat_always_enabled",
         "with_sidebar",
         "with_projectbar",
+        "project_name_editable",
         "show_save_prompt",
         "load_remix_disabled",
       ].includes(name)


### PR DESCRIPTION
Addresses #986 which is part of RaspberryPiFoundation/editor-standalone#16.

This will allow us to make the project name editable in `editor-standalone` (see RaspberryPiFoundation/editor-standalone#125) while leaving other projects using the web component (e.g. `projects-ui`) and the integrated version in `editor-ui` unchanged.

Note that this new attribute only affects the `ProjectName` component in the `ProjectBar` and not the one in the sidebar, i.e. in `ProjectsPanel`.
