### PR TITLE
Fix deprecation warnings in GitHub Actions

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -9,7 +9,7 @@ jobs:
   changelog-updated:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Check if changelog updated
@@ -26,4 +26,3 @@ jobs:
       if: steps.changed-files-specific.outputs.any_changed == 'false'
       run: |
         exit 1
-

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cache dependencies
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
           cache: "yarn"
@@ -41,7 +41,7 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Cache dependencies
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
           cache: "yarn"
@@ -71,7 +71,7 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Cache dependencies
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
           cache: "yarn"
@@ -85,7 +85,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cypress run
-        uses: cypress-io/github-action@v5
+        uses: cypress-io/github-action@v6
         with:
           install: false
           start: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -107,10 +107,10 @@ jobs:
           [ -n "${{ needs.setup-environment.outputs.deploy_dir }}" ]
 
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - name: Cache dependencies
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
           cache: "yarn"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Remove unused `REACT_APP_LOGIN_ENABLED` env var (#1006)
 - Fix infinite remix loop when `BYPASS_AUTH` set in `editor-api` (#1007)
 - Fixes for docker-compose.yml (#1008)
+- Fix deprecation warnings in GitHub Actions (#1011)
 
 ## [0.23.0] - 2024-05-09
 


### PR DESCRIPTION
Previously (e.g. in [this job run](https://github.com/RaspberryPiFoundation/editor-ui/actions/runs/9126135030) at the bottom) we were seeing a bunch of deprecation warnings like this one:

    lint:
    Node.js 16 actions are deprecated.
    Please update the following actions to use Node.js 20:
      actions/checkout@v3,
      actions/setup-node@v3.
    For more information see:
      https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.