### PR TITLE
Remove unused `/embedded/projects/:identifier` route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+- Remove unused `/embedded/projects/:identifier` route (#1013)
+
 ### Fixed
 
 - Remove unused `REACT_APP_LOGIN_ENABLED` env var (#1006)

--- a/src/components/AppRoutes.jsx
+++ b/src/components/AppRoutes.jsx
@@ -57,11 +57,6 @@ const AppRoutes = () => (
       />
     </Route>
 
-    <Route
-      path="/embedded/projects/:identifier"
-      element={suspense(<ProjectComponentLoader embedded={true} />)}
-    />
-
     {/* Redirects will be moved into a cloudflare worker. This is just interim */}
 
     {projectLinkRedirects.map((link) => {

--- a/src/containers/ProjectComponentLoader.jsx
+++ b/src/containers/ProjectComponentLoader.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect } from "react";
 import { useSelector } from "react-redux";
 import { useProject } from "../hooks/useProject";
-import { useEmbeddedMode } from "../hooks/useEmbeddedMode";
 import { useMediaQuery } from "react-responsive";
 import { useNavigate, useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
@@ -21,7 +20,6 @@ import { useProjectPersistence } from "../hooks/useProjectPersistence";
 const ProjectComponentLoader = (props) => {
   const loading = useSelector((state) => state.editor.loading);
   const { identifier } = useParams();
-  const embedded = props.embedded || false;
   const user = useSelector((state) => state.auth.user);
   const accessToken = user ? user.access_token : null;
   const project = useSelector((state) => state.editor.project);
@@ -56,7 +54,6 @@ const ProjectComponentLoader = (props) => {
   const isMobile = useMediaQuery({ query: MOBILE_MEDIA_QUERY });
   const sidebarOptions = ["projects", "file", "images", "settings", "info"];
 
-  useEmbeddedMode(embedded);
   useProject({ projectIdentifier: identifier, accessToken: accessToken });
   useProjectPersistence({
     user,


### PR DESCRIPTION
As far as we can tell, this route is [no longer used anywhere][1].

This was originally added in Mar 2022 in #72 for the "ESA demo". I suspect we now achieve a similar effect by using the web component with [its `embedded` attribute](https://github.com/RaspberryPiFoundation/editor-ui/blob/340ab1192fb3358ad4614034208603948f8b95d6/src/web-component.js#L50) set to `true`, rather than using an `iframe` with its `src` set to this route.

I found it confusing to see both the `/:locale/embed/viewer/:identifier` and this route in the `AppRoutes` component. Removing this one makes the code less confusing.

I've also removed the now redundant `embedded` property on the `ProjectComponentLoader` component and the similarly redundant call to `useEmbeddedMode` which is a no-op when `embedded` is `false`.

[1]: https://github.com/search?q=org%3Araspberrypilearning+embedded%2Fprojects&type=code