### PR TITLE
Improvements to Cypress specs in CI

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -92,6 +92,7 @@ jobs:
             yarn start
             yarn start:wc
           wait-on: "http://localhost:3000, http://localhost:3001"
+          quiet: true
         env:
           REACT_APP_API_ENDPOINT: "https://staging-editor-api.raspberrypi.org"
           PUBLIC_URL: "http://localhost:3000"

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -96,6 +96,7 @@ jobs:
           REACT_APP_API_ENDPOINT: "https://staging-editor-api.raspberrypi.org"
           PUBLIC_URL: "http://localhost:3000"
           ASSETS_URL: "http://localhost:3000"
+          REACT_APP_PLAUSIBLE_SOURCE: ""
 
       - name: Archive cypress artifacts
         uses: actions/upload-artifact@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fixes for docker-compose.yml (#1008)
 - Fix deprecation warnings in GitHub Actions (#1011)
 - Removed unused `isEmbedded` param from `useProject` call in `EmbeddedViewer` (#1016)
+- Improvements to Cypress specs in CI (#1017)
 
 ## [0.23.0] - 2024-05-09
 

--- a/cypress.config.mjs
+++ b/cypress.config.mjs
@@ -5,7 +5,6 @@ export default defineConfig({
     chromeWebSecurity: false,
     supportFile: false,
     defaultCommandTimeout: 10000,
-    screenshotOnRunFailure: process.env.CI !== "true",
     video: false,
     setupNodeEvents(on, config) {
       on("task", {


### PR DESCRIPTION
See individual commit notes for details:
* [Avoid repeated `URIError` in Cypress spec CI output](https://github.com/RaspberryPiFoundation/editor-ui/commit/db0225e4ec2ea460a70c7703f48f84ed945ebde1)
* [Reinstate default Cypress screenshot behaviour](https://github.com/RaspberryPiFoundation/editor-ui/commit/9beab733c90c09e6ec6be407060b1a5c1a9b8906)
* [Use `quiet` option when running Cypress specs in CI](https://github.com/RaspberryPiFoundation/editor-ui/commit/d8bfcca5f45efacb7f1a4eaa1075c6d8e00e3318)