### PR TITLE
Fix warnings and verbose output when starting Webpack Dev Server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix deprecation warnings in GitHub Actions (#1011)
 - Removed unused `isEmbedded` param from `useProject` call in `EmbeddedViewer` (#1016)
 - Improvements to Cypress specs in CI (#1017)
+- Fix warnings and verbose output when starting Webpack Dev Server (#1018)
 
 ## [0.23.0] - 2024-05-09
 

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -773,5 +773,6 @@ module.exports = function (webpackEnv) {
     // Turn off performance processing because we utilize
     // our own hints via the FileSizeReporter
     performance: false,
+    stats: "minimal",
   };
 };

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -121,7 +121,7 @@ checkBrowsers(paths.appPath, isInteractive)
       proxyConfig,
       urls.lanUrlForConfig
     );
-    const devServer = new WebpackDevServer(compiler, serverConfig);
+    const devServer = new WebpackDevServer(serverConfig, compiler);
     // Launch WebpackDevServer.
     devServer.listen(port, HOST, err => {
       if (err) {

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -121,12 +121,12 @@ checkBrowsers(paths.appPath, isInteractive)
       proxyConfig,
       urls.lanUrlForConfig
     );
+    Object.assign(serverConfig, {port});
     const devServer = new WebpackDevServer(serverConfig, compiler);
     // Launch WebpackDevServer.
-    devServer.listen(port, HOST, err => {
-      if (err) {
-        return console.log(err);
-      }
+    (async () => {
+      await devServer.start();
+
       if (isInteractive) {
         clearConsole();
       }
@@ -141,7 +141,7 @@ checkBrowsers(paths.appPath, isInteractive)
 
       console.log(chalk.cyan('Starting the development server...\n'));
       openBrowser(urls.localUrlForBrowser);
-    });
+    })();
 
     ['SIGINT', 'SIGTERM'].forEach(function (sig) {
       process.on(sig, function () {

--- a/src/assets/stylesheets/App.scss
+++ b/src/assets/stylesheets/App.scss
@@ -70,8 +70,8 @@ body,
   overflow: auto;
   block-size: 100%;
   block-size: -moz-available;
-  block-size: -webkit-fill-available;
-  block-size: fill-available;
+  block-size: -webkit-stretch;
+  block-size: stretch;
   block-size: 100dvh;
   -ms-overflow-style: none; /* Remove scrollbar for IE and Edge */
   scrollbar-width: none; /* Remove scroll bar for Firefox */

--- a/src/assets/stylesheets/Project.scss
+++ b/src/assets/stylesheets/Project.scss
@@ -7,8 +7,8 @@
   overflow: hidden;
   block-size: 100%;
   block-size: -moz-available;
-  block-size: -webkit-fill-available;
-  block-size: fill-available;
+  block-size: -webkit-stretch;
+  block-size: stretch;
 }
 
 .proj-header {

--- a/src/assets/stylesheets/Sidebar.scss
+++ b/src/assets/stylesheets/Sidebar.scss
@@ -166,8 +166,8 @@
   inset-block-end: 0px;
   inline-size: 100%;
   inline-size: -moz-available;
-  inline-size: -webkit-fill-available;
-  inline-size: fill-available;
+  inline-size: -webkit-stretch;
+  inline-size: stretch;
   background-color: white;
   border-end-end-radius: 8px;
 }

--- a/webpack.component.config.js
+++ b/webpack.component.config.js
@@ -92,4 +92,5 @@ module.exports = {
       filename: "web-component.html",
     }),
   ],
+    stats: "minimal",
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5746,17 +5746,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30000981, caniuse-lite@npm:^1.0.30001109, caniuse-lite@npm:^1.0.30001449":
-  version: 1.0.30001486
-  resolution: "caniuse-lite@npm:1.0.30001486"
-  checksum: 5e8c2ba2679e4ad17dea6d2761a6449b814441bfeac81af6cc9d58af187df6af4b79b27befcbfc4a557e720b21c0399a7d1911c8705922e38938dcc0f40b5d4b
-  languageName: node
-  linkType: hard
-
-"caniuse-lite@npm:^1.0.30001125":
-  version: 1.0.30001561
-  resolution: "caniuse-lite@npm:1.0.30001561"
-  checksum: 949829fe037e23346595614e01d362130245920503a12677f2506ce68e1240360113d6383febed41e8aa38cd0f5fd9c69c21b0af65a71c0246d560db489f1373
+"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30000981, caniuse-lite@npm:^1.0.30001109, caniuse-lite@npm:^1.0.30001125, caniuse-lite@npm:^1.0.30001449":
+  version: 1.0.30001621
+  resolution: "caniuse-lite@npm:1.0.30001621"
+  checksum: 0afb65bbf558faea769c16e831fbbd5600c684c0f6bb4ffbc0d38528671fb5cb5d88714804241a88c61872ce289f7c6333aef6cfdfb09277bda0dbdf0aab3459
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
See individual commit notes for more detail:
* [Fix warning re fill-available vs stretch](https://github.com/RaspberryPiFoundation/editor-ui/commit/2e36964cc110678a0d52e18608d6e526e5846c4d)
* [Fix dev server constructor deprecation warning in start.js](https://github.com/RaspberryPiFoundation/editor-ui/commit/61ef83afa3bffba13a66d2297d5d4f1f086e5482)
* [Fix dev server listen deprecation warning in start.js](https://github.com/RaspberryPiFoundation/editor-ui/commit/1727fe4e61ed3389de73c4b03d7ff203f2772a42)
* [Don't display webpack stats on starting dev server](https://github.com/RaspberryPiFoundation/editor-ui/commit/959003aa268285746f0e88d4394c1a9a95f7b948)
* [Fix "caniuse-lite is outdated" warning](https://github.com/RaspberryPiFoundation/editor-ui/commit/36fd74dbd05213ad5c267429afd87a4bbfe92c1c)