### PR TITLE
Add support for Block-to-Text app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add `output_only` attribute to web component (#1019 & originally #782)
 - Add `assets_identifier` attribute to web component (#1019 & originally #901)
 - Enhance `code` attribute on web component to override project main component content (#1019 & originally #901)
+- Add `runCode`, `stopCode` & `rerunCode` methods to web component (#1019 & originally #899)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fires custom event when the theme changes (#1015)
 - Add `output_only` attribute to web component (#1019 & originally #782)
 - Add `assets_identifier` attribute to web component (#1019 & originally #901)
+- Enhance `code` attribute on web component to override project main component content (#1019 & originally #901)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Enhance `code` attribute on web component to override project main component content (#1019 & originally #901)
 - Add `runCode`, `stopCode` & `rerunCode` methods to web component (#1019 & originally #899)
 - Send error details in "editor-runCompleted" event (#1019 & originally #915)
+- Return error details to web component (#1019 & originally #915)
+- Add `output_panels` attribute to web component (#1019 & originally #909)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add `project_name_editable` attribute to web component (#1009)
 - Fires custom event when the theme changes (#1015)
 - Add `output_only` attribute to web component (#1019 & originally #782)
+- Add `assets_identifier` attribute to web component (#1019 & originally #901)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Add `project_name_editable` attribute to web component (#1009)
 - Fires custom event when the theme changes (#1015)
+- Add `output_only` attribute to web component (#1019 & originally #782)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add `assets_identifier` attribute to web component (#1019 & originally #901)
 - Enhance `code` attribute on web component to override project main component content (#1019 & originally #901)
 - Add `runCode`, `stopCode` & `rerunCode` methods to web component (#1019 & originally #899)
+- Send error details in "editor-runCompleted" event (#1019 & originally #915)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ The web component can be included in a page by using the `<editor-wc>` HTML elem
 - `project_name_editable`: Allow the user to edit the project name in the project bar (defaults to `false`)
 - `output_only`: Only display the output panel (defaults to `false`)
 - `assets_identifier`: Load assets (not code) from this project identifier
+- `output_panels`: Array of panel names to display (defaults to `["text", "visual"]`)
 
 ### `yarn start:wc`
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ The web component can be included in a page by using the `<editor-wc>` HTML elem
 - `sense_hat_always_enabled`: Show the Astro Pi Sense HAT emulator on page load
 - `load_remix_disabled`: Do not load a logged-in user's remixed version of the project specified by `identifier` even if one exists (defaults to `false`)
 - `project_name_editable`: Allow the user to edit the project name in the project bar (defaults to `false`)
+- `output_only`: Only display the output panel (defaults to `false`)
 
 ### `yarn start:wc`
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The repo includes the Editor Web Component which shares components with the edit
 
 The web component can be included in a page by using the `<editor-wc>` HTML element. It takes the following attributes
 
-- `code`: A preset blob of code to show in the editor pane.
+- `code`: A preset blob of code to show in the editor pane (overrides content of `main.py`/`index.html`)
 - `sense_hat_always_enabled`: Show the Astro Pi Sense HAT emulator on page load
 - `load_remix_disabled`: Do not load a logged-in user's remixed version of the project specified by `identifier` even if one exists (defaults to `false`)
 - `project_name_editable`: Allow the user to edit the project name in the project bar (defaults to `false`)

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ The web component can be included in a page by using the `<editor-wc>` HTML elem
 - `load_remix_disabled`: Do not load a logged-in user's remixed version of the project specified by `identifier` even if one exists (defaults to `false`)
 - `project_name_editable`: Allow the user to edit the project name in the project bar (defaults to `false`)
 - `output_only`: Only display the output panel (defaults to `false`)
+- `assets_identifier`: Load assets (not code) from this project identifier
 
 ### `yarn start:wc`
 

--- a/cypress/e2e/spec-wc-block-to-text.cy.js
+++ b/cypress/e2e/spec-wc-block-to-text.cy.js
@@ -1,0 +1,41 @@
+const code = `
+from p5 import *
+
+img = None
+
+def preload():
+    global img
+    img = load_image("moon.png")
+
+def setup():
+    size(400, 200)
+
+def draw():
+    fill("green")
+    text_size(100)
+    text("PASS", 125, 110)
+    image(img, 10, 25, 100 , 100)
+    no_loop()
+
+run()
+`;
+
+const params = new URLSearchParams();
+params.set("assets_identifier", "encoded-art-starter");
+params.set("host_styles", JSON.stringify("#wc { min-height: 200px }"));
+params.set("code", code);
+params.set("output_only", true);
+params.set("output_panels", JSON.stringify(["visual"]));
+
+const baseUrl = `http://localhost:3001?${params.toString()}`;
+
+it("runs p5 sketch including image loaded from project ", () => {
+  cy.visit(baseUrl);
+
+  cy.get("editor-wc").shadow().find(".embedded-viewer").should("exist");
+  cy.get("editor-wc").shadow().find(".proj").should("not.exist");
+
+  cy.get("button").contains("Run code").click();
+
+  cy.get("#results").should("contain", '{"errorDetails":{}}');
+});

--- a/src/assets/stylesheets/EmbeddedViewer.scss
+++ b/src/assets/stylesheets/EmbeddedViewer.scss
@@ -28,7 +28,7 @@
   }
 }
 
-.--light {
+#app.--light {
   .embedded-viewer {
     background-color: $rpf-white;
   }

--- a/src/assets/stylesheets/InternalStyles.scss
+++ b/src/assets/stylesheets/InternalStyles.scss
@@ -40,6 +40,7 @@
 @use "./SaveStatus" as *;
 @use "./ContextMenu" as *;
 @use "./FilePanel" as *; // needs to be below Button
+@use "./EmbeddedViewer" as *;
 
 :host {
   font-size: 1.6rem;
@@ -118,4 +119,3 @@ button:focus-visible {
   .rpf-button--secondary {
     border-color: $rpf-navy-800;}
 }
-

--- a/src/assets/stylesheets/PythonRunner.scss
+++ b/src/assets/stylesheets/PythonRunner.scss
@@ -96,3 +96,7 @@
     }
   }
 }
+
+  .--light .output-panel--single, .--dark .output-panel--single {
+    border-block-end: none;
+}

--- a/src/assets/stylesheets/Tabs.scss
+++ b/src/assets/stylesheets/Tabs.scss
@@ -119,6 +119,10 @@
       padding: 0 $space-0-25 0 0;
     }
 
+    &__tab-container--hidden {
+      display: none;
+    }
+
     &__tab-panel--selected {
       flex: 1;
       display: flex;

--- a/src/components/Editor/Output/Output.jsx
+++ b/src/components/Editor/Output/Output.jsx
@@ -4,17 +4,19 @@ import ExternalFiles from "../../ExternalFiles/ExternalFiles";
 import RunnerFactory from "../Runners/RunnerFactory";
 import RunBar from "../../RunButton/RunBar";
 
-const Output = () => {
+const Output = ({ embedded = false, browserPreview = false }) => {
   const project = useSelector((state) => state.editor.project);
-  const isEmbedded = useSelector((state) => state.editor.isEmbedded);
+  const isEmbedded =
+    useSelector((state) => state.editor.isEmbedded) || embedded;
   const searchParams = new URLSearchParams(window.location.search);
-  const isBrowserPreview = searchParams.get("browserPreview") === "true";
+  const isBrowserPreview =
+    searchParams.get("browserPreview") === "true" || browserPreview;
   const usePyodide = searchParams.get("pyodide") === "true";
 
   return (
     <>
       <ExternalFiles />
-      <div className="proj-runner-container">
+      <div className="proj-runner-container" data-testid="output">
         <RunnerFactory
           projectType={project.project_type}
           usePyodide={usePyodide}

--- a/src/components/Editor/Output/Output.jsx
+++ b/src/components/Editor/Output/Output.jsx
@@ -4,7 +4,11 @@ import ExternalFiles from "../../ExternalFiles/ExternalFiles";
 import RunnerFactory from "../Runners/RunnerFactory";
 import RunBar from "../../RunButton/RunBar";
 
-const Output = ({ embedded = false, browserPreview = false }) => {
+const Output = ({
+  embedded = false,
+  browserPreview = false,
+  outputPanels = ["text", "visual"],
+}) => {
   const project = useSelector((state) => state.editor.project);
   const isEmbedded =
     useSelector((state) => state.editor.isEmbedded) || embedded;
@@ -21,6 +25,7 @@ const Output = ({ embedded = false, browserPreview = false }) => {
         <RunnerFactory
           projectType={project.project_type}
           usePyodide={usePyodide}
+          outputPanels={outputPanels}
         />
         {!webComponent && isEmbedded && !isBrowserPreview && (
           <RunBar embedded />

--- a/src/components/Editor/Output/Output.jsx
+++ b/src/components/Editor/Output/Output.jsx
@@ -12,6 +12,7 @@ const Output = ({ embedded = false, browserPreview = false }) => {
   const isBrowserPreview =
     searchParams.get("browserPreview") === "true" || browserPreview;
   const usePyodide = searchParams.get("pyodide") === "true";
+  const webComponent = useSelector((state) => state.editor.webComponent);
 
   return (
     <>
@@ -21,7 +22,9 @@ const Output = ({ embedded = false, browserPreview = false }) => {
           projectType={project.project_type}
           usePyodide={usePyodide}
         />
-        {isEmbedded && !isBrowserPreview && <RunBar embedded />}
+        {!webComponent && isEmbedded && !isBrowserPreview && (
+          <RunBar embedded />
+        )}
       </div>
     </>
   );

--- a/src/components/Editor/Output/Output.jsx
+++ b/src/components/Editor/Output/Output.jsx
@@ -21,7 +21,7 @@ const Output = ({ embedded = false, browserPreview = false }) => {
           projectType={project.project_type}
           usePyodide={usePyodide}
         />
-        {isEmbedded && !isBrowserPreview ? <RunBar embedded /> : null}
+        {isEmbedded && !isBrowserPreview && <RunBar embedded />}
       </div>
     </>
   );

--- a/src/components/Editor/Output/Output.test.js
+++ b/src/components/Editor/Output/Output.test.js
@@ -13,72 +13,122 @@ const user = {
   },
 };
 
-test("Component renders", () => {
-  const middlewares = [];
-  const mockStore = configureStore(middlewares);
-  const initialState = {
-    editor: {
-      project: {
-        components: [],
-      },
-    },
-    auth: {
-      user,
-    },
-  };
-  const store = mockStore(initialState);
-  const { container } = render(
-    <Provider store={store}>
-      <MemoryRouter>
-        <Output />
-      </MemoryRouter>
-    </Provider>,
-  );
-  expect(container.lastChild).toHaveClass("proj-runner-container");
-});
+let store;
+let mockStore;
+let initialState;
 
-describe("When embedded", () => {
-  let store;
-
+describe("Output component", () => {
   beforeEach(() => {
     const middlewares = [];
-    const mockStore = configureStore(middlewares);
-    const initialState = {
+    mockStore = configureStore(middlewares);
+    initialState = {
       editor: {
         project: {
           components: [],
         },
-        isEmbedded: true,
       },
       auth: {
         user,
       },
     };
-    store = mockStore(initialState);
   });
 
-  test("Shows run bar when not browser preview", () => {
-    render(
+  test("renders", () => {
+    const store = mockStore(initialState);
+    const { container } = render(
       <Provider store={store}>
         <MemoryRouter>
           <Output />
         </MemoryRouter>
       </Provider>,
     );
-    expect(screen.queryByText("runButton.run")).toBeInTheDocument();
+    expect(container.lastChild).toHaveClass("proj-runner-container");
   });
 
-  test("Does not show run bar when browser preview", () => {
-    delete window.location;
-    window.location = { search: '?browserPreview=true' };
+  describe("when isEmbedded state is true", () => {
+    beforeEach(() => {
+      initialState.editor.isEmbedded = true;
+      store = mockStore(initialState);
+    });
 
-    render(
-      <Provider store={store}>
-        <MemoryRouter>
-          <Output />
-        </MemoryRouter>
-      </Provider>,
-    );
-    expect(screen.queryByText("runButton.run")).not.toBeInTheDocument();
+    test("shows run bar", () => {
+      render(
+        <Provider store={store}>
+          <MemoryRouter>
+            <Output />
+          </MemoryRouter>
+        </Provider>,
+      );
+      expect(screen.queryByText("runButton.run")).toBeInTheDocument();
+    });
+
+    describe("when browserPreview property is true", () => {
+      test("does not show run bar", () => {
+        render(
+          <Provider store={store}>
+            <MemoryRouter>
+              <Output browserPreview={true} />
+            </MemoryRouter>
+          </Provider>,
+        );
+        expect(screen.queryByText("runButton.run")).not.toBeInTheDocument();
+      });
+    });
+
+    describe("when browserPreview is true in query string", () => {
+      let originalLocation;
+
+      beforeEach(() => {
+        originalLocation = window.location;
+        delete window.location;
+        window.location = { search: "?browserPreview=true" };
+      });
+
+      afterEach(() => {
+        window.location = originalLocation;
+      });
+
+      test("does not show run bar", () => {
+        render(
+          <Provider store={store}>
+            <MemoryRouter>
+              <Output />
+            </MemoryRouter>
+          </Provider>,
+        );
+        expect(screen.queryByText("runButton.run")).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("when isEmbedded state is false", () => {
+    beforeEach(() => {
+      initialState.editor.isEmbedded = false;
+      store = mockStore(initialState);
+    });
+
+    test("does not show run bar", () => {
+      render(
+        <Provider store={store}>
+          <MemoryRouter>
+            <Output />
+          </MemoryRouter>
+        </Provider>,
+      );
+      expect(screen.queryByText("runButton.run")).not.toBeInTheDocument();
+    });
+
+    describe("when embedded property is true", () => {
+      test("shows run bar", () => {
+        render(
+          <Provider store={store}>
+            <MemoryRouter>
+              <Output embedded={true} />
+            </MemoryRouter>
+          </Provider>,
+        );
+        expect(screen.queryByText("runButton.run")).toBeInTheDocument();
+      });
+    });
   });
 });

--- a/src/components/Editor/Output/Output.test.js
+++ b/src/components/Editor/Output/Output.test.js
@@ -62,6 +62,24 @@ describe("Output component", () => {
       expect(screen.queryByText("runButton.run")).toBeInTheDocument();
     });
 
+    describe("when webComponent state is true", () => {
+      beforeEach(() => {
+        initialState.editor.webComponent = true;
+        store = mockStore(initialState);
+      });
+
+      test("does not show run bar", () => {
+        render(
+          <Provider store={store}>
+            <MemoryRouter>
+              <Output />
+            </MemoryRouter>
+          </Provider>,
+        );
+        expect(screen.queryByText("runButton.run")).not.toBeInTheDocument();
+      });
+    });
+
     describe("when browserPreview property is true", () => {
       test("does not show run bar", () => {
         render(

--- a/src/components/Editor/Output/Output.test.js
+++ b/src/components/Editor/Output/Output.test.js
@@ -6,14 +6,6 @@ import configureStore from "redux-mock-store";
 import Output from "./Output";
 import { MemoryRouter } from "react-router-dom";
 
-let mockBrowserPreview = "false";
-
-jest
-  .spyOn(URLSearchParams.prototype, "get")
-  .mockImplementation((key) =>
-    key === "browserPreview" ? mockBrowserPreview : null,
-  );
-
 const user = {
   access_token: "39a09671-be55-4847-baf5-8919a0c24a25",
   profile: {
@@ -76,16 +68,17 @@ describe("When embedded", () => {
     expect(screen.queryByText("runButton.run")).toBeInTheDocument();
   });
 
-  // TODO: Get this test working
-  // test("Does not show run bar when browser preview", () => {
-  //   mockBrowserPreview = "true";
-  //   render(
-  //     <Provider store={store}>
-  //       <MemoryRouter>
-  //         <Output />
-  //       </MemoryRouter>
-  //     </Provider>,
-  //   );
-  //   expect(screen.queryByText("runButton.run")).not.toBeInTheDocument();
-  // });
+  test("Does not show run bar when browser preview", () => {
+    delete window.location;
+    window.location = { search: '?browserPreview=true' };
+
+    render(
+      <Provider store={store}>
+        <MemoryRouter>
+          <Output />
+        </MemoryRouter>
+      </Provider>,
+    );
+    expect(screen.queryByText("runButton.run")).not.toBeInTheDocument();
+  });
 });

--- a/src/components/Editor/Project/Project.jsx
+++ b/src/components/Editor/Project/Project.jsx
@@ -53,7 +53,7 @@ const Project = (props) => {
   }, []);
 
   return (
-    <div className="proj">
+    <div className="proj" data-testid="project">
       <div
         className={classnames("proj-container", {
           "proj-container--wc": webComponent,

--- a/src/components/Editor/Runners/PythonRunner/PythonRunner.jsx
+++ b/src/components/Editor/Runners/PythonRunner/PythonRunner.jsx
@@ -8,6 +8,7 @@ import Sk from "skulpt";
 import { useMediaQuery } from "react-responsive";
 import {
   setError,
+  setErrorDetails,
   codeRunHandled,
   stopDraw,
   setSenseHatEnabled,
@@ -60,6 +61,7 @@ const PythonRunner = () => {
   const user = useSelector((state) => state.auth.user);
   const isSplitView = useSelector((state) => state.editor.isSplitView);
   const isEmbedded = useSelector((state) => state.editor.isEmbedded);
+  const isOutputOnly = useSelector((state) => state.editor.isOutputOnly);
   const codeRunTriggered = useSelector(
     (state) => state.editor.codeRunTriggered,
   );
@@ -274,11 +276,16 @@ const PythonRunner = () => {
   };
 
   const handleError = (err) => {
+    let errorDetails = {};
     let errorMessage;
     if (err.message === t("output.errors.interrupted")) {
       errorMessage = err.message;
+      errorDetails = {
+        type: "Interrupted",
+        message: errorMessage,
+      };
     } else {
-      const errorDetails = (err.tp$str && err.tp$str().v)
+      const errorDescription = (err.tp$str && err.tp$str().v)
         .replace(/\[(.*?)\]/, "")
         .replace(/\.$/, "");
       const errorType = err.tp$name || err.constructor.name;
@@ -290,14 +297,23 @@ const PythonRunner = () => {
         userId = user.profile?.user;
       }
 
-      errorMessage = `${errorType}: ${errorDetails} on line ${lineNumber} of ${fileName}`;
+      errorMessage = `${errorType}: ${errorDescription} on line ${lineNumber} of ${fileName}`;
       createError(projectIdentifier, userId, {
         errorType,
         errorMessage,
       });
+
+      errorDetails = {
+        type: errorType,
+        line: lineNumber,
+        file: fileName,
+        description: errorDescription,
+        message: errorMessage,
+      };
     }
 
     dispatch(setError(errorMessage));
+    dispatch(setErrorDetails(errorDetails));
     dispatch(stopDraw());
     if (getInput()) {
       const input = getInput();
@@ -309,6 +325,7 @@ const PythonRunner = () => {
   const runCode = () => {
     // clear previous output
     dispatch(setError(""));
+    dispatch(setErrorDetails({}));
     output.current.innerHTML = "";
     dispatch(setSenseHatEnabled(false));
 
@@ -441,7 +458,7 @@ const PythonRunner = () => {
             {!isEmbedded && hasVisualOutput ? <OutputViewToggle /> : null}
             {!isEmbedded && isMobile ? <RunnerControls skinny /> : null}
           </div>
-          <ErrorMessage />
+          {!isOutputOnly && <ErrorMessage />}
           {hasVisualOutput ? (
             <TabPanel key={0}>
               <VisualOutputPane />

--- a/src/components/Editor/Runners/PythonRunner/PythonRunner.test.js
+++ b/src/components/Editor/Runners/PythonRunner/PythonRunner.test.js
@@ -919,6 +919,50 @@ test("Split view has text and visual tabs with different parent elements", () =>
   );
 });
 
+test("only displays text tab when outputPanels is set to just text", () => {
+  const middlewares = [];
+  const mockStore = configureStore(middlewares);
+  const initialState = {
+    editor: {
+      project: {},
+      senseHatAlwaysEnabled: true,
+    },
+    auth: {
+      user,
+    },
+  };
+  const store = mockStore(initialState);
+  render(
+    <Provider store={store}>
+      <PythonRunner outputPanels={["text"]} />
+    </Provider>,
+  );
+  expect(screen.queryByText("output.textOutput")).toBeInTheDocument();
+  expect(screen.queryByText("output.visualOutput")).not.toBeInTheDocument();
+});
+
+test("only displays visual tab when outputPanels is set to just visual", () => {
+  const middlewares = [];
+  const mockStore = configureStore(middlewares);
+  const initialState = {
+    editor: {
+      project: {},
+      senseHatAlwaysEnabled: true,
+    },
+    auth: {
+      user,
+    },
+  };
+  const store = mockStore(initialState);
+  render(
+    <Provider store={store}>
+      <PythonRunner outputPanels={["visual"]} />
+    </Provider>,
+  );
+  expect(screen.queryByText("output.textOutput")).not.toBeInTheDocument();
+  expect(screen.queryByText("output.visualOutput")).toBeInTheDocument();
+});
+
 describe("When font size is set", () => {
   let runnerContainer;
 

--- a/src/components/Editor/Runners/PythonRunner/PythonRunner.test.js
+++ b/src/components/Editor/Runners/PythonRunner/PythonRunner.test.js
@@ -7,6 +7,7 @@ import PythonRunner from "./PythonRunner";
 import {
   codeRunHandled,
   setError,
+  setErrorDetails,
   triggerDraw,
 } from "../../../../redux/EditorSlice";
 import { SettingsContext } from "../../../../utils/settings";
@@ -159,6 +160,111 @@ describe("Testing stopping the code run with input", () => {
     expect(store.getActions()).toEqual(
       expect.arrayContaining([codeRunHandled()]),
     );
+  });
+});
+
+describe("When an error occurs", () => {
+  let store;
+  beforeEach(() => {
+    const middlewares = [];
+    const mockStore = configureStore(middlewares);
+    const initialState = {
+      editor: {
+        project: {
+          components: [
+            {
+              content: "boom!",
+            },
+          ],
+          image_list: [],
+        },
+        codeRunTriggered: true,
+      },
+      auth: {
+        user,
+      },
+    };
+    store = mockStore(initialState);
+    render(
+      <Provider store={store}>
+        <PythonRunner />
+      </Provider>,
+    );
+  });
+
+  test("Sets error in state", () => {
+    expect(store.getActions()).toEqual(
+      expect.arrayContaining([
+        setError("SyntaxError: bad token T_OP on line 1 of main.py"),
+      ]),
+    );
+  });
+
+  test("Sets errorDetails in state", () => {
+    expect(store.getActions()).toEqual(
+      expect.arrayContaining([
+        setErrorDetails({
+          type: "SyntaxError",
+          line: 1,
+          file: "main.py",
+          description: "bad token T_OP",
+          message: "SyntaxError: bad token T_OP on line 1 of main.py",
+        }),
+      ]),
+    );
+  });
+});
+
+describe("When an error has occurred", () => {
+  let mockStore;
+  let store;
+  let initialState;
+
+  beforeEach(() => {
+    const middlewares = [];
+    mockStore = configureStore(middlewares);
+    initialState = {
+      editor: {
+        project: {
+          components: [
+            {
+              content: "boom!",
+            },
+          ],
+          image_list: [],
+        },
+        error: "SyntaxError: bad token T_OP on line 1 of main.py",
+      },
+      auth: {
+        user,
+      },
+    };
+  });
+
+  test("Displays error message", () => {
+    store = mockStore(initialState);
+    render(
+      <Provider store={store}>
+        <PythonRunner />
+      </Provider>,
+    );
+
+    expect(
+      screen.getByText("SyntaxError: bad token T_OP on line 1 of main.py"),
+    ).toBeVisible();
+  });
+
+  test("Does not display error message when isOutputOnly state is true", () => {
+    initialState.editor.isOutputOnly = true;
+    store = mockStore(initialState);
+    render(
+      <Provider store={store}>
+        <PythonRunner />
+      </Provider>,
+    );
+    expect(
+      screen.queryByText("SyntaxError: bad token T_OP on line 1 of main.py"),
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/src/components/Editor/Runners/RunnerFactory.jsx
+++ b/src/components/Editor/Runners/RunnerFactory.jsx
@@ -3,7 +3,11 @@ import PyodideRunner from "./PyodideRunner/PyodideRunner";
 import PythonRunner from "./PythonRunner/PythonRunner";
 import HtmlRunner from "./HtmlRunner/HtmlRunner";
 
-const RunnerFactory = ({ projectType, usePyodide }) => {
+const RunnerFactory = ({
+  projectType,
+  usePyodide,
+  outputPanels = ["text", "visual"],
+}) => {
   const Runner = () => {
     if (projectType === "html") {
       return HtmlRunner;
@@ -16,7 +20,9 @@ const RunnerFactory = ({ projectType, usePyodide }) => {
 
   const Selected = Runner();
 
-  return <Selected />;
+  const props = projectType === "html" ? {} : { outputPanels };
+
+  return <Selected {...props} />;
 };
 
 export default RunnerFactory;

--- a/src/components/EmbeddedViewer/__snapshots__/EmbeddedViewer.test.js.snap
+++ b/src/components/EmbeddedViewer/__snapshots__/EmbeddedViewer.test.js.snap
@@ -11,6 +11,7 @@ exports[`Renders without crashing 1`] = `
     />
     <div
       class="proj-runner-container"
+      data-testid="output"
     >
       <div
         class="pythonrunner-container"

--- a/src/components/ExternalFiles/ExternalFiles.jsx
+++ b/src/components/ExternalFiles/ExternalFiles.jsx
@@ -6,7 +6,7 @@ const ExternalFiles = () => {
 
   return (
     <div id="file-content" hidden>
-      {project.components.map((file, i) => {
+      {project.components?.map((file, i) => {
         if (["csv", "txt"].includes(file.extension)) {
           return (
             <div id={`${file.name}.${file.extension}`} key={i}>

--- a/src/components/Mobile/MobileProject/MobileProject.jsx
+++ b/src/components/Mobile/MobileProject/MobileProject.jsx
@@ -37,7 +37,10 @@ const MobileProject = ({ withSidebar, sidebarOptions = [] }) => {
   }, [codeRunTriggered, sidebarShowing, withSidebar]);
 
   return (
-    <div className="proj-container proj-editor-container proj-container--mobile">
+    <div
+      className="proj-container proj-editor-container proj-container--mobile"
+      data-testid="mobile-project"
+    >
       <Tabs
         forceRenderTabPanel={true}
         selectedIndex={selectedTab}

--- a/src/components/WebComponentProject/WebComponentProject.jsx
+++ b/src/components/WebComponentProject/WebComponentProject.jsx
@@ -44,10 +44,8 @@ const WebComponentProject = ({
   const [codeHasRun, setCodeHasRun] = useState(codeHasBeenRun);
   const dispatch = useDispatch();
 
-  useEffect(() => {
-    dispatch(setIsSplitView(false));
-    dispatch(setWebComponent(true));
-  }, [dispatch]);
+  dispatch(setIsSplitView(false));
+  dispatch(setWebComponent(true));
 
   useEffect(() => {
     setCodeHasRun(false);

--- a/src/components/WebComponentProject/WebComponentProject.jsx
+++ b/src/components/WebComponentProject/WebComponentProject.jsx
@@ -30,6 +30,7 @@ const WebComponentProject = ({
   withSidebar = false,
   sidebarOptions = [],
   outputOnly = false,
+  outputPanels = ["text", "visual"],
 }) => {
   const loading = useSelector((state) => state.editor.loading);
   const project = useSelector((state) => state.editor.project);
@@ -108,7 +109,11 @@ const WebComponentProject = ({
       {outputOnly && (
         <div className="embedded-viewer" data-testid="output-only">
           {loading === "success" && (
-            <Output embedded={true} browserPreview={false} />
+            <Output
+              embedded={true}
+              browserPreview={false}
+              outputPanels={outputPanels}
+            />
           )}
         </div>
       )}

--- a/src/components/WebComponentProject/WebComponentProject.jsx
+++ b/src/components/WebComponentProject/WebComponentProject.jsx
@@ -2,8 +2,12 @@ import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useMediaQuery } from "react-responsive";
 
+import "../../assets/stylesheets/EmbeddedViewer.scss";
+import "../../assets/stylesheets/Project.scss";
+
 import Project from "../Editor/Project/Project";
 import MobileProject from "../Mobile/MobileProject/MobileProject";
+import Output from "../Editor/Output/Output";
 import { defaultMZCriteria } from "../../utils/DefaultMZCriteria";
 import Sk from "skulpt";
 import { setIsSplitView, setWebComponent } from "../../redux/EditorSlice";
@@ -21,7 +25,9 @@ const WebComponentProject = ({
   nameEditable = false,
   withSidebar = false,
   sidebarOptions = [],
+  outputOnly = false,
 }) => {
+  const loading = useSelector((state) => state.editor.loading);
   const project = useSelector((state) => state.editor.project);
   const projectIdentifier = useSelector(
     (state) => state.editor.project.identifier,
@@ -80,18 +86,26 @@ const WebComponentProject = ({
 
   return (
     <>
-      {isMobile ? (
-        <MobileProject
-          withSidebar={withSidebar}
-          sidebarOptions={sidebarOptions}
-        />
-      ) : (
-        <Project
-          nameEditable={nameEditable}
-          withProjectbar={withProjectbar}
-          withSidebar={withSidebar}
-          sidebarOptions={sidebarOptions}
-        />
+      {!outputOnly &&
+        (isMobile ? (
+          <MobileProject
+            withSidebar={withSidebar}
+            sidebarOptions={sidebarOptions}
+          />
+        ) : (
+          <Project
+            nameEditable={nameEditable}
+            withProjectbar={withProjectbar}
+            withSidebar={withSidebar}
+            sidebarOptions={sidebarOptions}
+          />
+        ))}
+      {outputOnly && (
+        <div className="embedded-viewer" data-testid="output-only">
+          {loading === "success" && (
+            <Output embedded={true} browserPreview={false} />
+          )}
+        </div>
       )}
     </>
   );

--- a/src/components/WebComponentProject/WebComponentProject.jsx
+++ b/src/components/WebComponentProject/WebComponentProject.jsx
@@ -10,7 +10,11 @@ import MobileProject from "../Mobile/MobileProject/MobileProject";
 import Output from "../Editor/Output/Output";
 import { defaultMZCriteria } from "../../utils/DefaultMZCriteria";
 import Sk from "skulpt";
-import { setIsSplitView, setWebComponent } from "../../redux/EditorSlice";
+import {
+  setIsSplitView,
+  setWebComponent,
+  setIsOutputOnly,
+} from "../../redux/EditorSlice";
 import { MOBILE_MEDIA_QUERY } from "../../utils/mediaQueryBreakpoints";
 import {
   codeChangedEvent,
@@ -35,7 +39,9 @@ const WebComponentProject = ({
   const codeRunTriggered = useSelector(
     (state) => state.editor.codeRunTriggered,
   );
+
   const error = useSelector((state) => state.editor.error);
+  const errorDetails = useSelector((state) => state.editor.errorDetails);
   const codeHasBeenRun = useSelector((state) => state.editor.codeHasBeenRun);
   const currentStepPosition = useSelector(
     (state) => state.instructions.currentStepPosition,
@@ -46,6 +52,7 @@ const WebComponentProject = ({
 
   dispatch(setIsSplitView(false));
   dispatch(setWebComponent(true));
+  dispatch(setIsOutputOnly(outputOnly));
 
   useEffect(() => {
     setCodeHasRun(false);
@@ -69,14 +76,14 @@ const WebComponentProject = ({
       const mz_criteria = Sk.sense_hat
         ? Sk.sense_hat.mz_criteria
         : { ...defaultMZCriteria };
-      document.dispatchEvent(
-        runCompletedEvent({
-          isErrorFree: error === "",
-          ...mz_criteria,
-        }),
-      );
+
+      const payload = outputOnly
+        ? { errorDetails }
+        : { isErrorFree: error === "", ...mz_criteria };
+
+      document.dispatchEvent(runCompletedEvent(payload));
     }
-  }, [codeRunTriggered, codeHasRun, error]);
+  }, [codeRunTriggered, codeHasRun, outputOnly, error, errorDetails]);
 
   useEffect(() => {
     document.dispatchEvent(stepChangedEvent(currentStepPosition));

--- a/src/components/WebComponentProject/WebComponentProject.test.js
+++ b/src/components/WebComponentProject/WebComponentProject.test.js
@@ -171,6 +171,67 @@ describe("When withProjectbar is true", () => {
   });
 });
 
+describe("When output_only is true", () => {
+  let mockStore;
+  let initialState;
+
+  beforeEach(() => {
+    const middlewares = [];
+    mockStore = configureStore(middlewares);
+    initialState = {
+      editor: {
+        project: {
+          components: [],
+        },
+        openFiles: [],
+        focussedFileIndices: [],
+      },
+      instructions: {},
+      auth: {},
+    };
+  });
+
+  describe("when loading is pending", () => {
+    beforeEach(() => {
+      initialState.editor.loading = "pending";
+      store = mockStore(initialState);
+
+      render(
+        <Provider store={store}>
+          <WebComponentProject outputOnly={true} />
+        </Provider>,
+      );
+    });
+
+    test("does not render anything", () => {
+      expect(screen.queryByTestId("output")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("when loading is success", () => {
+    beforeEach(() => {
+      initialState.editor.loading = "success";
+      store = mockStore(initialState);
+
+      render(
+        <Provider store={store}>
+          <WebComponentProject outputOnly={true} />
+        </Provider>,
+      );
+    });
+
+    test("only renders the output", () => {
+      expect(screen.queryByTestId("output")).toBeInTheDocument();
+      expect(screen.queryByTestId("project")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("mobile-project")).not.toBeInTheDocument();
+    });
+
+    test("styles output like embedded viewer", () => {
+      expect(screen.getByTestId("output-only")).toHaveClass("embedded-viewer");
+    });
+  });
+});
+
 afterAll(() => {
   document.removeEventListener("editor-codeChanged", codeChangedHandler);
   document.removeEventListener("editor-runStarted", runStartedHandler);

--- a/src/components/WebComponentProject/WebComponentProject.test.js
+++ b/src/components/WebComponentProject/WebComponentProject.test.js
@@ -105,6 +105,21 @@ describe("When code run finishes", () => {
 
   test("Triggers runCompletedEvent", () => {
     expect(runCompletedHandler).toHaveBeenCalled();
+    expect(runCompletedHandler.mock.lastCall[0].detail).toHaveProperty(
+      "isErrorFree",
+    );
+  });
+
+  test("Triggers runCompletedEvent with error details when outputOnly is true", () => {
+    render(
+      <Provider store={store}>
+        <WebComponentProject outputOnly={true} />
+      </Provider>,
+    );
+    expect(runCompletedHandler).toHaveBeenCalled();
+    expect(runCompletedHandler.mock.lastCall[0].detail).toHaveProperty(
+      "errorDetails",
+    );
   });
 });
 
@@ -200,6 +215,14 @@ describe("When output_only is true", () => {
         <Provider store={store}>
           <WebComponentProject outputOnly={true} />
         </Provider>,
+      );
+    });
+
+    test("sets isOutputOnly state to true", () => {
+      expect(store.getActions()).toEqual(
+        expect.arrayContaining([
+          { type: "editor/setIsOutputOnly", payload: true },
+        ]),
       );
     });
 

--- a/src/containers/WebComponentLoader.jsx
+++ b/src/containers/WebComponentLoader.jsx
@@ -40,6 +40,7 @@ const WebComponentLoader = (props) => {
     hostStyles,
     showSavePrompt = false,
     loadRemixDisabled = false,
+    outputOnly = false,
   } = props;
 
   const dispatch = useDispatch();
@@ -158,6 +159,7 @@ const WebComponentLoader = (props) => {
               nameEditable={projectNameEditable}
               withSidebar={withSidebar}
               sidebarOptions={sidebarOptions}
+              outputOnly={outputOnly}
             />
             {errorModalShowing && <ErrorModal />}
             {newFileModalShowing && <NewFileModal />}

--- a/src/containers/WebComponentLoader.jsx
+++ b/src/containers/WebComponentLoader.jsx
@@ -37,6 +37,7 @@ const WebComponentLoader = (props) => {
     withSidebar = false,
     sidebarOptions = [],
     theme,
+    outputPanels = ["text", "visual"],
     embedded = false,
     hostStyles,
     showSavePrompt = false,
@@ -162,6 +163,7 @@ const WebComponentLoader = (props) => {
               withSidebar={withSidebar}
               sidebarOptions={sidebarOptions}
               outputOnly={outputOnly}
+              outputPanels={outputPanels}
             />
             {errorModalShowing && <ErrorModal />}
             {newFileModalShowing && <NewFileModal />}

--- a/src/containers/WebComponentLoader.jsx
+++ b/src/containers/WebComponentLoader.jsx
@@ -26,6 +26,7 @@ import Style from "style-it";
 
 const WebComponentLoader = (props) => {
   const {
+    assetsIdentifier,
     authKey,
     identifier,
     code,
@@ -105,6 +106,7 @@ const WebComponentLoader = (props) => {
 
   useProject({
     projectIdentifier: projectIdentifier,
+    assetsIdentifier: assetsIdentifier,
     code,
     accessToken: user?.access_token,
     loadRemix: loadRemix && !loadRemixDisabled,

--- a/src/containers/WebComponentLoader.test.js
+++ b/src/containers/WebComponentLoader.test.js
@@ -122,6 +122,38 @@ describe("When no user is in state", () => {
     });
   });
 
+  describe("with assetsIdentifier set", () => {
+    const assetsIdentifier = "my-assets-identifier";
+
+    beforeEach(() => {
+      render(
+        <Provider store={store}>
+          <CookiesProvider cookies={cookies}>
+            <WebComponentLoader
+              code={code}
+              assetsIdentifier={assetsIdentifier}
+              senseHatAlwaysEnabled={true}
+              instructions={instructions}
+              authKey={authKey}
+              theme="light"
+            />
+          </CookiesProvider>
+        </Provider>,
+      );
+    });
+
+    test("Calls useProject hook with correct attributes", () => {
+      expect(useProject).toHaveBeenCalledWith({
+        assetsIdentifier: assetsIdentifier,
+        code,
+        accessToken: undefined,
+        loadRemix: false,
+        loadCache: true,
+        remixLoadFailed: false,
+      });
+    });
+  });
+
   describe("with user set in local storage", () => {
     beforeEach(() => {
       localStorage.setItem(authKey, JSON.stringify(user));

--- a/src/hooks/useProject.js
+++ b/src/hooks/useProject.js
@@ -135,8 +135,10 @@ export const useProject = ({
       const otherComponents =
         project.components?.filter(
           (component) =>
-            component.name !== defaultName &&
-            component.extension !== defaultExtension,
+            !(
+              component.name === defaultName &&
+              component.extension === defaultExtension
+            ),
         ) || [];
 
       const updatedProject = {

--- a/src/hooks/useProject.js
+++ b/src/hooks/useProject.js
@@ -6,6 +6,7 @@ import { defaultPythonProject } from "../utils/defaultProjects";
 import { useTranslation } from "react-i18next";
 
 export const useProject = ({
+  assetsIdentifier = null,
   projectIdentifier = null,
   code = null,
   accessToken = null,
@@ -45,6 +46,18 @@ export const useProject = ({
 
       if (loadCache && (is_cached_saved_project || is_cached_unsaved_project)) {
         loadCachedProject();
+        return;
+      }
+
+      if (assetsIdentifier) {
+        dispatch(
+          syncProject("load")({
+            identifier: assetsIdentifier,
+            locale: i18n.language,
+            accessToken,
+            assetsOnly: true,
+          }),
+        );
         return;
       }
 

--- a/src/hooks/useProject.js
+++ b/src/hooks/useProject.js
@@ -14,6 +14,7 @@ export const useProject = ({
   loadCache = true,
   remixLoadFailed = false,
 }) => {
+  const loading = useSelector((state) => state.editor.loading);
   const isEmbedded = useSelector((state) => state.editor.isEmbedded);
   const isBrowserPreview = useSelector((state) => state.editor.browserPreview);
   const project = useSelector((state) => state.editor.project);
@@ -119,4 +120,37 @@ export const useProject = ({
       }
     }
   }, [projectIdentifier, accessToken, loadRemix, remixLoadFailed]);
+
+  useEffect(() => {
+    if (code && loading === "success") {
+      const defaultName = project.project_type === "html" ? "index" : "main";
+      const defaultExtension = project.project_type === "html" ? "html" : "py";
+
+      const mainComponent = project.components?.find(
+        (component) =>
+          component.name === defaultName &&
+          component.extension === defaultExtension,
+      ) || { name: defaultName, extension: defaultExtension, content: "" };
+
+      const otherComponents =
+        project.components?.filter(
+          (component) =>
+            component.name !== defaultName &&
+            component.extension !== defaultExtension,
+        ) || [];
+
+      const updatedProject = {
+        ...project,
+        project_type: project.project_type || "python",
+        components: [
+          ...otherComponents,
+          {
+            ...mainComponent,
+            content: code,
+          },
+        ],
+      };
+      dispatch(setProject(updatedProject));
+    }
+  }, [code, loading]);
 };

--- a/src/hooks/useProject.test.js
+++ b/src/hooks/useProject.test.js
@@ -418,6 +418,26 @@ describe("When not embedded", () => {
           ],
         };
       });
+
+      test("leaves existing components intact", () => {
+        renderHook(() => useProject({ code: "# my source code" }), { wrapper });
+        expect(setProject).toHaveBeenCalledWith({
+          ...projectWithOnlyAssets,
+          components: [
+            {
+              name: "not-main",
+              extension: "py",
+              content: "# some other code",
+            },
+            {
+              name: "main",
+              extension: "py",
+              content: "# my source code",
+            },
+          ],
+          project_type: "python",
+        });
+      });
     });
   });
 

--- a/src/hooks/useProject.test.js
+++ b/src/hooks/useProject.test.js
@@ -257,6 +257,170 @@ describe("When not embedded", () => {
     );
   });
 
+  describe("when code property is set and loading state is 'success'", () => {
+    const projectWithOnlyAssets = {
+      image_list: [
+        { filename: "image1.jpg", url: "http://example.com/image1.jpg" },
+      ],
+    };
+
+    beforeEach(() => {
+      initialState.editor.loading = "success";
+      const mockStore = configureStore([]);
+      store = mockStore(initialState);
+      wrapper = ({ children }) => <Provider store={store}>{children}</Provider>;
+    });
+
+    describe("when project_type is not set", () => {
+      beforeEach(() => {
+        initialState.editor.project = projectWithOnlyAssets;
+      });
+
+      test("updates project with supplied source code", () => {
+        renderHook(() => useProject({ code: "# my source code" }), { wrapper });
+        expect(setProject).toHaveBeenCalledWith({
+          project_type: "python",
+          components: [
+            {
+              name: "main",
+              extension: "py",
+              content: "# my source code",
+            },
+          ],
+          ...projectWithOnlyAssets,
+        });
+      });
+    });
+
+    describe("when project_type is python", () => {
+      beforeEach(() => {
+        initialState.editor.project = {
+          ...projectWithOnlyAssets,
+          project_type: "python",
+        };
+      });
+
+      test("updates project with supplied source code", () => {
+        renderHook(() => useProject({ code: "# my source code" }), { wrapper });
+        expect(setProject).toHaveBeenCalledWith({
+          project_type: "python",
+          components: [
+            {
+              name: "main",
+              extension: "py",
+              content: "# my source code",
+            },
+          ],
+          ...projectWithOnlyAssets,
+        });
+      });
+    });
+
+    describe("when project_type is html", () => {
+      beforeEach(() => {
+        initialState.editor.project = {
+          ...projectWithOnlyAssets,
+          project_type: "html",
+        };
+      });
+
+      test("updates project with supplied source code", () => {
+        renderHook(() => useProject({ code: "<!-- my source code -->" }), {
+          wrapper,
+        });
+        expect(setProject).toHaveBeenCalledWith({
+          project_type: "html",
+          components: [
+            {
+              name: "index",
+              extension: "html",
+              content: "<!-- my source code -->",
+            },
+          ],
+          ...projectWithOnlyAssets,
+        });
+      });
+    });
+
+    describe("when project already has a python main component", () => {
+      beforeEach(() => {
+        initialState.editor.project = {
+          ...projectWithOnlyAssets,
+          components: [
+            {
+              name: "main",
+              extension: "py",
+              content: "# code for existing main component",
+            },
+          ],
+        };
+      });
+
+      test("overwrites source code in existing main component", () => {
+        renderHook(() => useProject({ code: "# my source code" }), { wrapper });
+        expect(setProject).toHaveBeenCalledWith({
+          project_type: "python",
+          components: [
+            {
+              name: "main",
+              extension: "py",
+              content: "# my source code",
+            },
+          ],
+          ...projectWithOnlyAssets,
+        });
+      });
+    });
+
+    describe("when project already has an html main component", () => {
+      beforeEach(() => {
+        initialState.editor.project = {
+          ...projectWithOnlyAssets,
+          project_type: "html",
+          components: [
+            {
+              name: "index",
+              extension: "html",
+              content: "<!-- code for existing main component -->",
+            },
+          ],
+        };
+      });
+
+      test("overwrites source code in existing main component", () => {
+        renderHook(() => useProject({ code: "<!-- my source code -->" }), {
+          wrapper,
+        });
+        expect(setProject).toHaveBeenCalledWith({
+          project_type: "html",
+          components: [
+            {
+              name: "index",
+              extension: "html",
+              content: "<!-- my source code -->",
+            },
+          ],
+          ...projectWithOnlyAssets,
+        });
+      });
+    });
+
+    describe("when project already has other components", () => {
+      beforeEach(() => {
+        initialState.editor.project = {
+          ...projectWithOnlyAssets,
+          components: [
+            {
+              name: "not-main",
+              extension: "py",
+              content: "# some other code",
+            },
+          ],
+        };
+      });
+    });
+  });
+
   afterEach(() => {
     localStorage.clear();
   });

--- a/src/hooks/useProject.test.js
+++ b/src/hooks/useProject.test.js
@@ -239,6 +239,24 @@ describe("When not embedded", () => {
     );
   });
 
+  test("If assetsIdentifer is set then set assetsOnly to true when loading project", async () => {
+    syncProject.mockImplementationOnce(jest.fn((_) => loadProject));
+    renderHook(
+      () =>
+        useProject({ assetsIdentifier: "hello-world-project", accessToken }),
+      { wrapper },
+    );
+    expect(syncProject).toHaveBeenCalledWith("load");
+    await waitFor(() =>
+      expect(loadProject).toHaveBeenCalledWith({
+        identifier: "hello-world-project",
+        locale: "ja-JP",
+        accessToken,
+        assetsOnly: true,
+      }),
+    );
+  });
+
   afterEach(() => {
     localStorage.clear();
   });

--- a/src/redux/EditorSlice.js
+++ b/src/redux/EditorSlice.js
@@ -102,6 +102,7 @@ export const EditorSlice = createSlice({
     codeHasBeenRun: false,
     drawTriggered: false,
     isEmbedded: false,
+    isOutputOnly: false,
     browserPreview: false,
     isSplitView: true,
     isThemeable: true,
@@ -130,6 +131,7 @@ export const EditorSlice = createSlice({
     deleteProjectModalShowing: false,
     sidebarShowing: true,
     modals: {},
+    errorDetails: {},
   },
   reducers: {
     closeFile: (state, action) => {
@@ -192,6 +194,9 @@ export const EditorSlice = createSlice({
     },
     setEmbedded: (state, _action) => {
       state.isEmbedded = true;
+    },
+    setIsOutputOnly: (state, action) => {
+      state.isOutputOnly = action.payload;
     },
     setBrowserPreview: (state, _action) => {
       state.browserPreview = true;
@@ -372,6 +377,9 @@ export const EditorSlice = createSlice({
     disableTheming: (state) => {
       state.isThemeable = false;
     },
+    setErrorDetails: (state, action) => {
+      state.errorDetails = action.payload;
+    },
   },
   extraReducers: (builder) => {
     builder.addCase("editor/saveProject/pending", (state) => {
@@ -461,6 +469,7 @@ export const {
   setFocussedFileIndex,
   setPage,
   setEmbedded,
+  setIsOutputOnly,
   setBrowserPreview,
   setError,
   setIsSplitView,
@@ -503,6 +512,7 @@ export const {
   showSidebar,
   hideSidebar,
   disableTheming,
+  setErrorDetails,
 } = EditorSlice.actions;
 
 export default EditorSlice.reducer;

--- a/src/redux/EditorSlice.js
+++ b/src/redux/EditorSlice.js
@@ -12,19 +12,24 @@ import {
   createRemix,
   deleteProject,
   readProjectList,
+  loadAssets,
 } from "../utils/apiCallHandler";
 
 export const syncProject = (actionName) =>
   createAsyncThunk(
     `editor/${actionName}Project`,
     async (
-      { project, identifier, locale, accessToken, autosave },
+      { project, identifier, locale, accessToken, autosave, assetsOnly },
       { rejectWithValue },
     ) => {
       let response;
       switch (actionName) {
         case "load":
-          response = await readProject(identifier, locale, accessToken);
+          if (assetsOnly) {
+            response = await loadAssets(identifier, locale, accessToken);
+          } else {
+            response = await readProject(identifier, locale, accessToken);
+          }
           break;
         case "loadRemix":
           response = await loadRemix(identifier, accessToken);

--- a/src/redux/EditorSlice.test.js
+++ b/src/redux/EditorSlice.test.js
@@ -2,6 +2,8 @@ import {
   createOrUpdateProject,
   createRemix,
   deleteProject,
+  loadAssets,
+  readProject,
   readProjectList,
 } from "../utils/apiCallHandler";
 
@@ -612,5 +614,56 @@ describe("Updating file name", () => {
         updateComponentName({ key: 1, name: "my_file", extension: "py" }),
       ),
     ).toEqual(expectedState);
+  });
+});
+
+describe("Loading a project", () => {
+  const dispatch = jest.fn();
+  const identifier = "my-project-identifier";
+  const accessToken = "myToken";
+  const locale = "es-LA";
+
+  let initialState;
+  let loadThunk;
+
+  beforeEach(() => {
+    initialState = { editor: {}, auth: {} };
+    loadThunk = syncProject("load");
+  });
+
+  describe("when assetsOnly is false", () => {
+    let loadAction;
+
+    beforeEach(() => {
+      loadAction = loadThunk({
+        identifier,
+        locale,
+        accessToken,
+        assetsOnly: false,
+      });
+    });
+
+    test("readProject is called", async () => {
+      await loadAction(dispatch, () => initialState);
+      expect(readProject).toHaveBeenCalledWith(identifier, locale, accessToken);
+    });
+  });
+
+  describe("when assetsOnly is true", () => {
+    let loadAction;
+
+    beforeEach(() => {
+      loadAction = loadThunk({
+        identifier,
+        locale,
+        accessToken,
+        assetsOnly: true,
+      });
+    });
+
+    test("loadAssets is called", async () => {
+      await loadAction(dispatch, () => initialState);
+      expect(loadAssets).toHaveBeenCalledWith(identifier, locale, accessToken);
+    });
   });
 });

--- a/src/redux/EditorSlice.test.js
+++ b/src/redux/EditorSlice.test.js
@@ -18,6 +18,8 @@ import reducer, {
   updateComponentName,
   loadProjectList,
   setLoadRemixDisabled,
+  setIsOutputOnly,
+  setErrorDetails,
 } from "./EditorSlice";
 
 jest.mock("../utils/apiCallHandler");
@@ -56,6 +58,41 @@ test("Action setLoadRemixDisabled sets loadRemixDisabled to false", () => {
   expect(reducer(previousState, setLoadRemixDisabled(false))).toEqual(
     expectedState,
   );
+});
+
+test("Action setIsOutputOnly sets isOutputOnly to true", () => {
+  const previousState = {
+    isOutputOnly: false,
+  };
+  const expectedState = {
+    isOutputOnly: true,
+  };
+  expect(reducer(previousState, setIsOutputOnly(true))).toEqual(expectedState);
+});
+
+test("Action setOutputOnly sets isOutputOnly to false", () => {
+  const previousState = {
+    isOutputOnly: true,
+  };
+  const expectedState = {
+    isOutputOnly: false,
+  };
+  expect(reducer(previousState, setIsOutputOnly(false))).toEqual(expectedState);
+});
+
+test("Action setErrorDetails sets errorDetails to true", () => {
+  const previousState = {
+    errorDetails: {},
+  };
+  const expectedState = {
+    errorDetails: { type: "Interrupted", message: "Some error message" },
+  };
+  expect(
+    reducer(
+      previousState,
+      setErrorDetails({ type: "Interrupted", message: "Some error message" }),
+    ),
+  ).toEqual(expectedState);
 });
 
 test("Showing rename modal sets file state and showing status", () => {

--- a/src/utils/apiCallHandler.js
+++ b/src/utils/apiCallHandler.js
@@ -76,6 +76,14 @@ export const readProject = async (projectIdentifier, locale, accessToken) => {
   );
 };
 
+export const loadAssets = async (assetsIdentifier, locale, accessToken) => {
+  const queryString = locale ? `?locale=${locale}` : "";
+  return await get(
+    `${host}/api/projects/${assetsIdentifier}/images${queryString}`,
+    headers(accessToken),
+  );
+};
+
 export const readProjectList = async (page, accessToken) => {
   return await get(`${host}/api/projects`, {
     params: { page },

--- a/src/utils/apiCallHandler.test.js
+++ b/src/utils/apiCallHandler.test.js
@@ -4,6 +4,7 @@ import {
   getImage,
   createOrUpdateProject,
   readProject,
+  loadAssets,
   createRemix,
   uploadImages,
   readProjectList,
@@ -128,6 +129,40 @@ describe("Testing project API calls", () => {
     await readProject(projectIdentifier, null, accessToken);
     expect(axios.get).toHaveBeenCalledWith(
       `${host}/api/projects/${projectIdentifier}`,
+      authHeaders,
+    );
+  });
+
+  test("Load assets with identifier only", async () => {
+    const projectIdentifier = "hello-world-project";
+    axios.get.mockImplementationOnce(() => Promise.resolve());
+
+    await loadAssets(projectIdentifier);
+    expect(axios.get).toHaveBeenCalledWith(
+      `${host}/api/projects/${projectIdentifier}/images`,
+      defaultHeaders,
+    );
+  });
+
+  test("Load assets with locale", async () => {
+    const projectIdentifier = "hello-world-project";
+    const locale = "es-LA";
+    axios.get.mockImplementationOnce(() => Promise.resolve());
+
+    await loadAssets(projectIdentifier, locale);
+    expect(axios.get).toHaveBeenCalledWith(
+      `${host}/api/projects/${projectIdentifier}/images?locale=${locale}`,
+      defaultHeaders,
+    );
+  });
+
+  test("Load assets with access token", async () => {
+    const projectIdentifier = "hello-world-project";
+    axios.get.mockImplementationOnce(() => Promise.resolve());
+
+    await loadAssets(projectIdentifier, null, accessToken);
+    expect(axios.get).toHaveBeenCalledWith(
+      `${host}/api/projects/${projectIdentifier}/images`,
       authHeaders,
     );
   });

--- a/src/web-component.html
+++ b/src/web-component.html
@@ -81,7 +81,16 @@
         document.getElementById("project-identifier").innerText = e.detail;
       });
 
-      document.getElementsByTagName("body")[0].prepend(webComp);
+      const body = document.getElementsByTagName("body")[0];
+      body.prepend(webComp);
+
+      const runButton = document.createElement("button");
+      const runButtonText = document.createTextNode("Run code");
+      runButton.appendChild(runButtonText);
+      runButton.onclick = (event) => {
+        webComp.rerunCode();
+      }
+      body.append(runButton);
     });
   </script>
 </html>

--- a/src/web-component.js
+++ b/src/web-component.js
@@ -37,6 +37,7 @@ class WebComponent extends HTMLElement {
   static get observedAttributes() {
     return [
       "host_styles",
+      "assets_identifier",
       "auth_key",
       "identifier",
       "code",

--- a/src/web-component.js
+++ b/src/web-component.js
@@ -48,6 +48,7 @@ class WebComponent extends HTMLElement {
       "project_name_editable",
       "with_sidebar",
       "output_only",
+      "output_panels",
       "sidebar_options",
       "theme",
       "embedded",
@@ -72,7 +73,12 @@ class WebComponent extends HTMLElement {
     ) {
       value = newVal !== "false";
     } else if (
-      ["instructions", "sidebar_options", "host_styles"].includes(name)
+      [
+        "instructions",
+        "sidebar_options",
+        "host_styles",
+        "output_panels",
+      ].includes(name)
     ) {
       value = JSON.parse(newVal);
     } else {

--- a/src/web-component.js
+++ b/src/web-component.js
@@ -45,6 +45,7 @@ class WebComponent extends HTMLElement {
       "with_projectbar",
       "project_name_editable",
       "with_sidebar",
+      "output_only",
       "sidebar_options",
       "theme",
       "embedded",
@@ -64,6 +65,7 @@ class WebComponent extends HTMLElement {
         "project_name_editable",
         "show_save_prompt",
         "load_remix_disabled",
+        "output_only",
       ].includes(name)
     ) {
       value = newVal !== "false";

--- a/src/web-component.js
+++ b/src/web-component.js
@@ -8,6 +8,7 @@ import store from "./redux/stores/WebComponentStore";
 import { Provider } from "react-redux";
 import "./utils/i18n";
 import camelCase from "camelcase";
+import { stopCodeRun, stopDraw, triggerCodeRun } from "./redux/EditorSlice";
 
 Sentry.init({
   dsn: process.env.REACT_APP_SENTRY_DSN,
@@ -99,6 +100,34 @@ class WebComponent extends HTMLElement {
     this.componentProperties.menuItems = newValue;
 
     this.mountReactApp();
+  }
+
+  stopCode() {
+    const state = store.getState();
+    if (state.editor.codeRunTriggered || state.editor.drawTriggered) {
+      store.dispatch(stopCodeRun());
+      store.dispatch(stopDraw());
+    }
+  }
+
+  runCode() {
+    store.dispatch(triggerCodeRun());
+  }
+
+  rerunCode() {
+    this.stopCode();
+
+    new Promise((resolve) => {
+      let checkInterval = setInterval(() => {
+        let state = store.getState();
+        if (!state.codeRunTriggered && !state.drawTriggered) {
+          clearInterval(checkInterval);
+          resolve();
+        }
+      }, 50);
+    }).then(() => {
+      this.runCode();
+    });
   }
 
   reactProps() {


### PR DESCRIPTION
### Summary

This adds a bunch of new attributes (e.g. `output_only`, `output_panels` & `assets_identifier`), methods (e.g. `rerunCode`) and behaviour to the web component to support [the Block-to-Text app](https://block-to-text-alpha.pages.dev/).

This branch is heavily based on the work in #782 which is what is what is currently being used by the alpha version of the Block-to-Text app. I've cherry-picked commits from the original work onto the latest work in`main` and curated the commits a bit to try to make them atomic and easier to follow.

<img width="1890" alt="Screenshot 2024-05-31 at 10 25 39" src="https://github.com/RaspberryPiFoundation/editor-ui/assets/3169/078a2a04-72d9-41b2-9cc3-53e7a5ee7ab4">

### Detail

In each commit:

* I've reviewed the code
* I've added unit tests
* I've fixed any bugs that I've found
* I've tried to explain the change at a high level
* I've tried to explain the motivations behind the change

Obviously writing the explanations after the fact and not being the original author of the changes is sub-optimal, so please let me know if I've got anything wrong!

In the final commit, I've also added a new Cypress end-to-end spec which uses the existing `src/web-component.html` page to configure the web component in a similar way to how the Block-to-Text app uses it. The spec uses the web component to runs a simple P5 sketch, drawing some text and an image from an existing project. Hopefully this gives us some confidence that the web component will work OK with the Block-to-Text app.

<img width="1912" alt="332883390-ddd6800a-2ce1-4278-b7e3-8129604c1153" src="https://github.com/RaspberryPiFoundation/editor-ui/assets/3169/b23a8e83-db12-4333-ac19-b5b85bc44609">

### Notes/Questions

I haven't included [the change](https://github.com/RaspberryPiFoundation/editor-ui/pull/782/files#diff-d355fe835fa320ad389b053fa105e008bf035de5f236519bb92264fb061c04c9R65) which exposes the `embedded` property as a web component attribute, even though the Block-to-Text app is [setting it](https://github.com/RaspberryPiFoundation/block-to-text-alpha/blob/d16a8ecc1d3da202363fb16db31f4bf93f46aa04/src/components/Editor.js#L21), because I don't believe it's necessary. Please let me know if you think I'm mistaken!

I do have some concerns about the number of configuration options knocking around in the code, particularly all the boolean ones where I suspect there may well be some overlap. I understand why it's like this, but I don't think it helps us that some configuration is done via properties, some by query string params, and some by web component attributes. Also I'm not entirely convinced that configuration options belong in a Redux store. However, I am hopeful that it will be easier to rationalize all this a bit in [the 2nd step](https://github.com/RaspberryPiFoundation/editor-standalone/issues/16) of [this issue](https://github.com/RaspberryPiFoundation/editor-ui/issues/1010) and it seems a bit too risky to do any of that at this stage.

I also wonder whether we could simplify/reduce the number of web component attributes, e.g. perhaps we could have `identifier` & `assetsOnly` instead of `identifier` & `assetsIdentifier`; or perhaps we could even have a higher-level `mode` attribute which had a special "Block-to-Text" value which set the relevant lower-level properties...? However, I think we should probably just get the changes in this PR merged and tackle any of that later.

I've run the Block-to-Text app locally against this branch of `editor-ui` and worked my way through all the steps of the exercise successfully. However, I haven't done a great deal of manual testing of the `editor-ui` app or of the web component in other modes - I'm hoping that the existing automated tests will have highlighted any regressions. Let me know if you think I should do some manual testing of particular functionality before merging.

Closes https://github.com/RaspberryPiFoundation/projects-ui/issues/2498.