### PR TITLE
Add e2e spec for project remix behaviour in web component

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -94,7 +94,7 @@ jobs:
           wait-on: "http://localhost:3000, http://localhost:3001"
           quiet: true
         env:
-          REACT_APP_API_ENDPOINT: "https://staging-editor-api.raspberrypi.org"
+          REACT_APP_API_ENDPOINT: "https://test-editor-api.raspberrypi.org"
           PUBLIC_URL: "http://localhost:3000"
           ASSETS_URL: "http://localhost:3000"
           REACT_APP_PLAUSIBLE_SOURCE: ""

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Removed unused `isEmbedded` param from `useProject` call in `EmbeddedViewer` (#1016)
 - Improvements to Cypress specs in CI (#1017)
 - Fix warnings and verbose output when starting Webpack Dev Server (#1018)
+- Add e2e spec for project remix behaviour in web component (#1020)
 
 ## [0.23.0] - 2024-05-09
 

--- a/cypress/e2e/spec-wc.cy.js
+++ b/cypress/e2e/spec-wc.cy.js
@@ -1,5 +1,12 @@
 const origin = "http://localhost:3001";
 
+beforeEach(() => {
+  cy.intercept("*", (req) => {
+    req.headers["Origin"] = origin;
+    req.continue();
+  });
+});
+
 describe("default behaviour", () => {
   beforeEach(() => {
     cy.visit(origin);

--- a/cypress/e2e/spec-wc.cy.js
+++ b/cypress/e2e/spec-wc.cy.js
@@ -1,8 +1,8 @@
-const baseUrl = "http://localhost:3001";
+const origin = "http://localhost:3001";
 
 describe("default behaviour", () => {
   beforeEach(() => {
-    cy.visit(baseUrl);
+    cy.visit(origin);
   });
 
   it("renders the web component", () => {

--- a/cypress/e2e/spec-wc.cy.js
+++ b/cypress/e2e/spec-wc.cy.js
@@ -1,83 +1,85 @@
 const baseUrl = "http://localhost:3001";
 
-beforeEach(() => {
-  cy.visit(baseUrl);
-});
+describe("default behaviour", () => {
+  beforeEach(() => {
+    cy.visit(baseUrl);
+  });
 
-it("renders the web component", () => {
-  cy.get("editor-wc").shadow().find("button").should("contain", "Run");
-});
+  it("renders the web component", () => {
+    cy.get("editor-wc").shadow().find("button").should("contain", "Run");
+  });
 
-it("defaults to the text output tab", () => {
-  const runnerContainer = cy
-    .get("editor-wc")
-    .shadow()
-    .find(".proj-runner-container");
-  runnerContainer
-    .find(".react-tabs__tab--selected")
-    .should("contain", "Text output");
-});
+  it("defaults to the text output tab", () => {
+    const runnerContainer = cy
+      .get("editor-wc")
+      .shadow()
+      .find(".proj-runner-container");
+    runnerContainer
+      .find(".react-tabs__tab--selected")
+      .should("contain", "Text output");
+  });
 
-it("runs the python code", () => {
-  cy.get("editor-wc")
-    .shadow()
-    .find("div[class=cm-content]")
-    .invoke("text", 'print("Hello world")');
-  cy.get("editor-wc").shadow().find(".btn--run").click();
-  cy.get("editor-wc")
-    .shadow()
-    .find(".pythonrunner-console-output-line")
-    .should("contain", "Hello world");
-});
+  it("runs the python code", () => {
+    cy.get("editor-wc")
+      .shadow()
+      .find("div[class=cm-content]")
+      .invoke("text", 'print("Hello world")');
+    cy.get("editor-wc").shadow().find(".btn--run").click();
+    cy.get("editor-wc")
+      .shadow()
+      .find(".pythonrunner-console-output-line")
+      .should("contain", "Hello world");
+  });
 
-it("runs p5 code", () => {
-  const code = `from p5 import *\n\ndef setup():\n    size(400, 400)  # width and height of screen\n\ndef draw():\n    fill('cyan')  # Set the fill color for the sky to cyan\n    rect(0, 0, 400, 250)  # Draw a rectangle for the sky with these values for x, y, width, height    \n  \nrun(frame_rate=2)\n`;
-  cy.get("editor-wc")
-    .shadow()
-    .find("div[class=cm-content]")
-    .invoke("text", code);
-  cy.get("editor-wc").shadow().find(".btn--run").click();
-  cy.get("editor-wc").shadow().find(".p5Canvas").should("exist");
-});
+  it("runs p5 code", () => {
+    const code = `from p5 import *\n\ndef setup():\n    size(400, 400)  # width and height of screen\n\ndef draw():\n    fill('cyan')  # Set the fill color for the sky to cyan\n    rect(0, 0, 400, 250)  # Draw a rectangle for the sky with these values for x, y, width, height    \n  \nrun(frame_rate=2)\n`;
+    cy.get("editor-wc")
+      .shadow()
+      .find("div[class=cm-content]")
+      .invoke("text", code);
+    cy.get("editor-wc").shadow().find(".btn--run").click();
+    cy.get("editor-wc").shadow().find(".p5Canvas").should("exist");
+  });
 
-it("does not render visual output tab on page load", () => {
-  cy.get("editor-wc")
-    .shadow()
-    .find("#root")
-    .should("not.contain", "Visual output");
-});
+  it("does not render visual output tab on page load", () => {
+    cy.get("editor-wc")
+      .shadow()
+      .find("#root")
+      .should("not.contain", "Visual output");
+  });
 
-it("renders visual output tab if sense hat imported", () => {
-  cy.get("editor-wc")
-    .shadow()
-    .find("div[class=cm-content]")
-    .invoke("text", "import sense_hat");
-  cy.get("editor-wc").shadow().find(".btn--run").click();
-  cy.get("editor-wc").shadow().find("#root").should("contain", "Visual output");
-});
+  it("renders visual output tab if sense hat imported", () => {
+    cy.get("editor-wc")
+      .shadow()
+      .find("div[class=cm-content]")
+      .invoke("text", "import sense_hat");
+    cy.get("editor-wc").shadow().find(".btn--run").click();
+    cy.get("editor-wc").shadow().find("#root").should("contain", "Visual output");
+  });
 
-it("does not render astro pi component on page load", () => {
-  cy.get("editor-wc").shadow().find("#root").should("not.contain", "yaw");
-});
+  it("does not render astro pi component on page load", () => {
+    cy.get("editor-wc").shadow().find("#root").should("not.contain", "yaw");
+  });
 
-it("renders astro pi component if sense hat imported", () => {
-  cy.get("editor-wc")
-    .shadow()
-    .find("div[class=cm-content]")
-    .invoke("text", "import sense_hat");
-  cy.get("editor-wc").shadow().find(".btn--run").click();
-  cy.get("editor-wc").shadow().contains("Visual output").click();
-  cy.get("editor-wc").shadow().find("#root").should("contain", "yaw");
-});
+  it("renders astro pi component if sense hat imported", () => {
+    cy.get("editor-wc")
+      .shadow()
+      .find("div[class=cm-content]")
+      .invoke("text", "import sense_hat");
+    cy.get("editor-wc").shadow().find(".btn--run").click();
+    cy.get("editor-wc").shadow().contains("Visual output").click();
+    cy.get("editor-wc").shadow().find("#root").should("contain", "yaw");
+  });
 
-it("does not render astro pi component if sense hat unimported", () => {
-  cy.get("editor-wc")
-    .shadow()
-    .find("div[class=cm-content]")
-    .invoke("text", "import sense_hat");
-  cy.get("editor-wc").shadow().find(".btn--run").click();
-  cy.get("editor-wc").shadow().find("div[class=cm-content]").invoke("text", "");
-  cy.get("editor-wc").shadow().find(".btn--run").click();
-  cy.get("editor-wc").shadow().contains("Visual output").click();
-  cy.get("editor-wc").shadow().find("#root").should("not.contain", "yaw");
+  it("does not render astro pi component if sense hat unimported", () => {
+    cy.get("editor-wc")
+      .shadow()
+      .find("div[class=cm-content]")
+      .invoke("text", "import sense_hat");
+    cy.get("editor-wc").shadow().find(".btn--run").click();
+    cy.get("editor-wc").shadow().find("div[class=cm-content]").invoke("text", "");
+    cy.get("editor-wc").shadow().find(".btn--run").click();
+    cy.get("editor-wc").shadow().contains("Visual output").click();
+    cy.get("editor-wc").shadow().find("#root").should("not.contain", "yaw");
+  });
 });

--- a/src/web-component.html
+++ b/src/web-component.html
@@ -32,6 +32,7 @@
   </head>
   <body>
     <p id="results"></p>
+    <p id="project-identifier"></p>
   </body>
 
   <script>
@@ -74,6 +75,10 @@
         // const error = webComp.isErrorFree
         console.log(e.detail);
         document.getElementById("results").innerText = JSON.stringify(e.detail);
+      });
+
+      document.addEventListener("editor-projectIdentifierChanged", (e) => {
+        document.getElementById("project-identifier").innerText = e.detail;
       });
 
       document.getElementsByTagName("body")[0].prepend(webComp);


### PR DESCRIPTION
The `editor-standalone` app will:

* Listen for "editor-projectIdentifierChanged" custom events from the web component and will redirect to the remixed project's URL. The relevant web component behaviour was changed in #990. The relevant `editor-standalone` behaviour was changed in RaspberryPiFoundation/editor-standalone#63.
* Set the web component `load_remix_disabled` attribute to `true` so that the original project will be loaded in preference to the remixed version (unlike the way projects-ui works). The relevant web component behaviour was changed in #992 & #1003. The relevant `editor-standalone` behaviour will be changed in RaspberryPiFoundation/editor-standalone#85.

This spec checks that the web component provides the relevant behaviour for editor-standalone to use.

I did attempt to add an example for the default behaviour (i.e. when `load_remix_disabled` is not set). However, without any way to easily reset the state of the projects in the editor-api database, it's hard to come up with a robust way to write such a test.

Note that this PR changes both the editor app itself and the fake "app" wrapping the web component to use https://test-editor-api.raspberrypi.org instead of https://staging-editor-api.raspberrypi.org in CI. The former has `BYPASS_AUTH` set to `true` so the apps can make requests as if the user was logged in. The new e2e spec also relies on the `projects:create_all` rake task having been run - which we've only done manually for now, but needs automating.
