### PR TITLE
Fix initial value of `user` in `WebComponentLoader`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Improvements to Cypress specs in CI (#1017)
 - Fix warnings and verbose output when starting Webpack Dev Server (#1018)
 - Add e2e spec for project remix behaviour in web component (#1020)
+- Fix initial value of `user` in `WebComponentLoader` (#1021)
 
 ## [0.23.0] - 2024-05-09
 

--- a/cypress/e2e/spec-wc.cy.js
+++ b/cypress/e2e/spec-wc.cy.js
@@ -98,15 +98,15 @@ describe("when load_remix_disabled is true, e.g. in editor-standalone", () => {
   const user = { access_token: "dummy-access-token" };
   const originalIdentifier = "blank-python-starter";
 
-  let baseUrl;
-
-  beforeEach(() => {
+  const urlFor = (identifier) => {
     const params = new URLSearchParams();
     params.set("auth_key", authKey);
-    params.set("identifier", originalIdentifier);
+    params.set("identifier", identifier);
     params.set("load_remix_disabled", "true");
-    baseUrl = `${origin}?${params.toString()}`;
+    return `${origin}?${params.toString()}`;
+  };
 
+  beforeEach(() => {
     cy.on('window:before:load', (win) => {
       win.localStorage.setItem(authKey, JSON.stringify(user));
     });
@@ -114,7 +114,7 @@ describe("when load_remix_disabled is true, e.g. in editor-standalone", () => {
 
   it("loads the original project in preference to the remixed version", () => {
     // View the original project
-    cy.visit(baseUrl);
+    cy.visit(urlFor(originalIdentifier));
     cy.get("#project-identifier").should("have.text", originalIdentifier);
 
     // Edit code
@@ -130,7 +130,7 @@ describe("when load_remix_disabled is true, e.g. in editor-standalone", () => {
     cy.get("editor-wc").shadow().find("[contenteditable]").should("have.text", "# remixed!");
 
     // Visit the original project again
-    cy.visit(baseUrl);
+    cy.visit(urlFor(originalIdentifier));
 
     // Check we no longer see the changed code, i.e. `load_remix_disabled=true` is respected
     cy.get("editor-wc").shadow().find("[contenteditable]").should("not.have.text", "# remixed!");

--- a/cypress/e2e/spec-wc.cy.js
+++ b/cypress/e2e/spec-wc.cy.js
@@ -125,14 +125,21 @@ describe("when load_remix_disabled is true, e.g. in editor-standalone", () => {
 
     // Check receipt of an event to trigger a redirect to the remixed project URL
     cy.get("#project-identifier").should("not.have.text", originalIdentifier);
+    cy.get("#project-identifier").invoke("text").then((remixIdentifier) => {
+      // Check we're still seeing the changed code
+      cy.get("editor-wc").shadow().find("[contenteditable]").should("have.text", "# remixed!");
 
-    // Check we're still seeing the changed code
-    cy.get("editor-wc").shadow().find("[contenteditable]").should("have.text", "# remixed!");
+      // Visit the original project again
+      cy.visit(urlFor(originalIdentifier));
 
-    // Visit the original project again
-    cy.visit(urlFor(originalIdentifier));
+      // Check we no longer see the changed code, i.e. `load_remix_disabled=true` is respected
+      cy.get("editor-wc").shadow().find("[contenteditable]").should("not.have.text", "# remixed!");
 
-    // Check we no longer see the changed code, i.e. `load_remix_disabled=true` is respected
-    cy.get("editor-wc").shadow().find("[contenteditable]").should("not.have.text", "# remixed!");
+      // View the remixed project
+      cy.visit(urlFor(remixIdentifier));
+
+      // Check we're still seeing the changed code
+      cy.get("editor-wc").shadow().find("[contenteditable]").should("have.text", "# remixed!");
+    });
   });
 });

--- a/cypress/e2e/spec-wc.cy.js
+++ b/cypress/e2e/spec-wc.cy.js
@@ -113,7 +113,7 @@ describe("when load_remix_disabled is true, e.g. in editor-standalone", () => {
   });
 
   it("loads the original project in preference to the remixed version", () => {
-    // Visit the original project URL
+    // View the original project
     cy.visit(baseUrl);
     cy.get("#project-identifier").should("have.text", originalIdentifier);
 
@@ -129,7 +129,7 @@ describe("when load_remix_disabled is true, e.g. in editor-standalone", () => {
     // Check we're still seeing the changed code
     cy.get("editor-wc").shadow().find("[contenteditable]").should("have.text", "# remixed!");
 
-    // Visit the original project URL
+    // Visit the original project again
     cy.visit(baseUrl);
 
     // Check we no longer see the changed code, i.e. `load_remix_disabled=true` is respected

--- a/src/containers/WebComponentLoader.jsx
+++ b/src/containers/WebComponentLoader.jsx
@@ -46,7 +46,10 @@ const WebComponentLoader = (props) => {
   const { t } = useTranslation();
   const [projectIdentifier, setProjectIdentifier] = useState(identifier);
   localStorage.setItem("authKey", authKey);
-  const user = useSelector((state) => state.auth.user);
+  const localStorageUser = authKey
+    ? JSON.parse(localStorage.getItem(authKey))
+    : null;
+  const user = useSelector((state) => state.auth.user || localStorageUser);
   const [loadCache, setLoadCache] = useState(!!!user);
   const [loadRemix, setLoadRemix] = useState(!!user);
   const project = useSelector((state) => state.editor.project);

--- a/src/containers/WebComponentLoader.test.js
+++ b/src/containers/WebComponentLoader.test.js
@@ -88,7 +88,7 @@ describe("When no user is in state", () => {
         },
         hasShownSavePrompt: true,
         justLoaded: false,
-        user: undefined,
+        user: null,
         saveTriggered: false,
       });
     });
@@ -146,16 +146,16 @@ describe("When no user is in state", () => {
       expect(useProject).toHaveBeenCalledWith({
         projectIdentifier: identifier,
         code,
-        accessToken: undefined,
-        loadRemix: false,
-        loadCache: true,
+        accessToken: "my_token",
+        loadRemix: true,
+        loadCache: false,
         remixLoadFailed: false,
       });
     });
 
     test("Calls useProjectPersistence hook with correct attributes", () => {
       expect(useProjectPersistence).toHaveBeenCalledWith({
-        user: undefined,
+        user,
         project: { components: [] },
         hasShownSavePrompt: true,
         justLoaded: false,


### PR DESCRIPTION
Previously, even if the `authKey` property was provided and a logged-in user was stored in `localStorage`, on first render the value of `user` was `null`. This was because the `localStorageUserMiddleware` which dispatches `setUser` to store the user in Redux had not yet been triggered.

**This meant that previously if we tried to use the web component to view a project that the logged-in user owned, the request to editor-api to load the project would respond with a 403 Forbidden and the project would not load.**

I'm fairly (but not completely) sure that the assertions in the "with user set in local storage" group of examples in
`src/containers/WebComponentLoader.test.js` were incorrect, i.e. if the `authKey` is set and a `user` is present in `localStorage` we ought to load the project based on the fact the user is logged in. I have fixed these assertions.

The `null` value of the `user` property in the call to `useProjectPersistence` in the "When no user is in state with no user in local storage" group of examples in `src/containers/WebComponentLoader.test.js` is due to the return value for `localStorage.getItem(authKey)` and not the fallback in the new ternary expression in `WebComponentLoader`. I think this is fine.

I'm not sure whether my fix is definitely correct/idiomatic - maybe I should be using a `useState` hook for the `localStorageUser` in combination with a `useEffect` hook...?

Also stepping back a bit, it's not entirely clear to me that [dispatching `setUser`][1] in `localStorageUserMiddleware` is definitely the most sensible place to do that.

[1]: https://github.com/RaspberryPiFoundation/editor-ui/blob/92b45d59d8187b26538c03af825bb34313b7e344/src/redux/middlewares/localStorageUserMiddleware.js#L11