### PR TITLE
Make `authKey` in e2e web component spec more realistic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix warnings and verbose output when starting Webpack Dev Server (#1018)
 - Add e2e spec for project remix behaviour in web component (#1020)
 - Fix initial value of `user` in `WebComponentLoader` (#1021)
+- Make `authKey` in e2e web component spec more realistic (#1022)
 
 ## [0.23.0] - 2024-05-09
 

--- a/cypress/e2e/spec-wc.cy.js
+++ b/cypress/e2e/spec-wc.cy.js
@@ -92,8 +92,7 @@ describe("default behaviour", () => {
 });
 
 describe("when load_remix_disabled is true, e.g. in editor-standalone", () => {
-  // Must match HydraPublicApiClient::BYPASS_AUTH_USER_ID in editor-api
-  const authKey = "00000000-0000-0000-0000-000000000000";
+  const authKey = `oidc.user:https://auth-v1.raspberrypi.org:editor-api`;
 
   const user = { access_token: "dummy-access-token" };
   const originalIdentifier = "blank-python-starter";


### PR DESCRIPTION
The comment about the `authKey` needing to match `HydraPublicApiClient::BYPASS_AUTH_USER_ID` in editor-api was incorrect. While the actual value is unimportant in this spec, it seems better to make it as realistic as possible.