### PR TITLE
Support use of the web component in editor-standalone's embedded view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
+- Add `embedded` attribute to web component (#1030)
+- Add `output_split_view` attribute to web component (#1030)
+
 ### Changed
+
+- Changes to web component behaviour to support use in embedded view in editor-standalone (#1030)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ The web component can be included in a page by using the `<editor-wc>` HTML elem
 - `output_only`: Only display the output panel (defaults to `false`)
 - `assets_identifier`: Load assets (not code) from this project identifier
 - `output_panels`: Array of panel names to display (defaults to `["text", "visual"]`)
+- `embedded`: Enable embedded mode which hides some functionality (defaults to `false`)
 
 ### `yarn start:wc`
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ The web component can be included in a page by using the `<editor-wc>` HTML elem
 - `assets_identifier`: Load assets (not code) from this project identifier
 - `output_panels`: Array of panel names to display (defaults to `["text", "visual"]`)
 - `embedded`: Enable embedded mode which hides some functionality (defaults to `false`)
+- `output_split_view`: Start with split view in output panel (defaults to `false`, i.e. tabbed view)
 
 ### `yarn start:wc`
 

--- a/cypress/e2e/spec-wc.cy.js
+++ b/cypress/e2e/spec-wc.cy.js
@@ -142,3 +142,62 @@ describe("when load_remix_disabled is true, e.g. in editor-standalone", () => {
     });
   });
 });
+
+describe("when embedded, output_only & output_split_view are true", () => {
+  const urlFor = (identifier) => {
+    const params = new URLSearchParams();
+    params.set("identifier", identifier);
+    params.set("load_remix_disabled", "true");
+    params.set("embedded", "true");
+    params.set("output_only", "true");
+    params.set("output_split_view", "true");
+    return `${origin}?${params.toString()}`;
+  };
+
+  it("displays the embedded view for a Python project", () => {
+    cy.visit(urlFor("clean-car-example"));
+
+    // Check text output panel is visible and has a run button
+    // Important to wait for this before making the negative assertions that follow
+    cy.get("editor-wc").shadow().contains("Text output").should("be.visible");
+    cy.get("editor-wc").shadow().find("button").contains("Run").should("be.visible");
+
+    // Check that the side bar is not displayed
+    cy.get("editor-wc").shadow().contains("Project files").should("not.exist");
+    // Check that the project bar is not displayed
+    cy.get("editor-wc").shadow().contains("Don't Collide: Clean Car").should("not.exist");
+    // Check that the editor input containing the code is not displayed
+    cy.get("editor-wc").shadow().contains("# The draw_obstacle function goes here").should("not.exist");
+
+    // Run the code and check it executed without error
+    cy.get("editor-wc").shadow().find("button").contains("Run").click();
+    cy.get("#results").should("contain", '{"errorDetails":{}}');
+
+    // Check that the visual output panel is displayed in split view mode (vs tabbed view)
+    cy.get("editor-wc").shadow().contains("Visual output").should("be.visible");
+    cy.get("editor-wc").shadow().contains("Visual output").parents("ul").children().should("have.length", 1);
+  });
+
+  it("displays the embedded view for an HTML project", () => {
+    cy.visit(urlFor("anime-expressions-solution"));
+
+    // Check HTML preview output panel is visible and has a run button
+    // Important to wait for this before making the negative assertions that follow
+    cy.get("editor-wc").shadow().contains("index.html preview").should("be.visible");
+    cy.get("editor-wc").shadow().find("button").contains("Run").should("be.visible");
+
+    // Check that the code has automatically run i.e. the HTML has been rendered
+    cy.get("editor-wc").shadow().find("iframe#output-frame").its("0.contentDocument.body").should("contain", "Draw anime with me");
+
+    // Check that the side bar is not displayed
+    cy.get("editor-wc").shadow().contains("Project files").should("not.exist");
+    // Check that the project bar is not displayed
+    cy.get("editor-wc").shadow().contains("Anime expressions solution").should("not.exist");
+    // Check that the editor input containing the code is not displayed
+    cy.get("editor-wc").shadow().contains("<h1>Draw anime with me</h1>").should("not.exist");
+
+    // Run the code and check it executed without error
+    cy.get("editor-wc").shadow().find("button").contains("Run").click();
+    cy.get("#results").should("contain", '{"errorDetails":{}}');
+  });
+});

--- a/src/components/Editor/Output/Output.jsx
+++ b/src/components/Editor/Output/Output.jsx
@@ -10,7 +10,6 @@ const Output = ({ outputPanels = ["text", "visual"] }) => {
   const searchParams = new URLSearchParams(window.location.search);
   const isBrowserPreview = searchParams.get("browserPreview") === "true";
   const usePyodide = searchParams.get("pyodide") === "true";
-  const webComponent = useSelector((state) => state.editor.webComponent);
 
   return (
     <>
@@ -21,9 +20,7 @@ const Output = ({ outputPanels = ["text", "visual"] }) => {
           usePyodide={usePyodide}
           outputPanels={outputPanels}
         />
-        {!webComponent && isEmbedded && !isBrowserPreview && (
-          <RunBar embedded />
-        )}
+        {isEmbedded && !isBrowserPreview && <RunBar embedded />}
       </div>
     </>
   );

--- a/src/components/Editor/Output/Output.jsx
+++ b/src/components/Editor/Output/Output.jsx
@@ -4,17 +4,11 @@ import ExternalFiles from "../../ExternalFiles/ExternalFiles";
 import RunnerFactory from "../Runners/RunnerFactory";
 import RunBar from "../../RunButton/RunBar";
 
-const Output = ({
-  embedded = false,
-  browserPreview = false,
-  outputPanels = ["text", "visual"],
-}) => {
+const Output = ({ outputPanels = ["text", "visual"] }) => {
   const project = useSelector((state) => state.editor.project);
-  const isEmbedded =
-    useSelector((state) => state.editor.isEmbedded) || embedded;
+  const isEmbedded = useSelector((state) => state.editor.isEmbedded);
   const searchParams = new URLSearchParams(window.location.search);
-  const isBrowserPreview =
-    searchParams.get("browserPreview") === "true" || browserPreview;
+  const isBrowserPreview = searchParams.get("browserPreview") === "true";
   const usePyodide = searchParams.get("pyodide") === "true";
   const webComponent = useSelector((state) => state.editor.webComponent);
 

--- a/src/components/Editor/Output/Output.test.js
+++ b/src/components/Editor/Output/Output.test.js
@@ -62,24 +62,6 @@ describe("Output component", () => {
       expect(screen.queryByText("runButton.run")).toBeInTheDocument();
     });
 
-    describe("when webComponent state is true", () => {
-      beforeEach(() => {
-        initialState.editor.webComponent = true;
-        store = mockStore(initialState);
-      });
-
-      test("does not show run bar", () => {
-        render(
-          <Provider store={store}>
-            <MemoryRouter>
-              <Output />
-            </MemoryRouter>
-          </Provider>,
-        );
-        expect(screen.queryByText("runButton.run")).not.toBeInTheDocument();
-      });
-    });
-
     describe("when browserPreview is true in query string", () => {
       let originalLocation;
 

--- a/src/components/Editor/Output/Output.test.js
+++ b/src/components/Editor/Output/Output.test.js
@@ -80,19 +80,6 @@ describe("Output component", () => {
       });
     });
 
-    describe("when browserPreview property is true", () => {
-      test("does not show run bar", () => {
-        render(
-          <Provider store={store}>
-            <MemoryRouter>
-              <Output browserPreview={true} />
-            </MemoryRouter>
-          </Provider>,
-        );
-        expect(screen.queryByText("runButton.run")).not.toBeInTheDocument();
-      });
-    });
-
     describe("when browserPreview is true in query string", () => {
       let originalLocation;
 
@@ -134,19 +121,6 @@ describe("Output component", () => {
         </Provider>,
       );
       expect(screen.queryByText("runButton.run")).not.toBeInTheDocument();
-    });
-
-    describe("when embedded property is true", () => {
-      test("shows run bar", () => {
-        render(
-          <Provider store={store}>
-            <MemoryRouter>
-              <Output embedded={true} />
-            </MemoryRouter>
-          </Provider>,
-        );
-        expect(screen.queryByText("runButton.run")).toBeInTheDocument();
-      });
     });
   });
 });

--- a/src/components/Editor/Runners/HtmlRunner/HtmlRunner.jsx
+++ b/src/components/Editor/Runners/HtmlRunner/HtmlRunner.jsx
@@ -27,7 +27,6 @@ import RunnerControls from "../../../RunButton/RunnerControls";
 import { MOBILE_MEDIA_QUERY } from "../../../../utils/mediaQueryBreakpoints";
 
 function HtmlRunner() {
-  const webComponent = useSelector((state) => state.editor.webComponent);
   const project = useSelector((state) => state.editor.project);
   const projectCode = project.components;
   const projectImages = project.image_list;
@@ -327,7 +326,7 @@ function HtmlRunner() {
                   "output.preview",
                 )}`}</span>
               </Tab>
-              {!!!isEmbedded && !!!webComponent && (
+              {!!!isEmbedded && (
                 <a
                   className="btn btn--tertiary htmlrunner-link"
                   target="_blank"

--- a/src/components/Editor/Runners/HtmlRunner/HtmlRunner.test.js
+++ b/src/components/Editor/Runners/HtmlRunner/HtmlRunner.test.js
@@ -150,6 +150,10 @@ describe("When page first loaded in embedded viewer", () => {
       expect.arrayContaining([triggerCodeRun()]),
     );
   });
+
+  test("does not display link to open preview in another browser tab", () => {
+    expect(screen.queryByText("output.newTab")).not.toBeInTheDocument();
+  });
 });
 
 describe("When page first loaded from search params", () => {
@@ -494,6 +498,40 @@ describe("When on desktop", () => {
 
   test("There is no run button", () => {
     expect(screen.queryByText("runButton.run")).not.toBeInTheDocument();
+  });
+});
+
+describe("When not embedded", () => {
+  let store;
+
+  beforeEach(() => {
+    const middlewares = [];
+    const mockStore = configureStore(middlewares);
+    const initialState = {
+      editor: {
+        project: {
+          components: [indexPage],
+        },
+        focussedFileIndices: [0],
+        openFiles: [["index.html"]],
+        codeHasBeenRun: true,
+        isEmbedded: false,
+      },
+    };
+    store = mockStore(initialState);
+    render(
+      <Provider store={store}>
+        <MemoryRouter>
+          <div id="app">
+            <HtmlRunner />
+          </div>
+        </MemoryRouter>
+      </Provider>,
+    );
+  });
+
+  test("displays link to open preview in another browser tab", () => {
+    expect(screen.queryByText("output.newTab")).toBeInTheDocument();
   });
 });
 

--- a/src/components/WebComponentProject/WebComponentProject.jsx
+++ b/src/components/WebComponentProject/WebComponentProject.jsx
@@ -31,6 +31,7 @@ const WebComponentProject = ({
   sidebarOptions = [],
   outputOnly = false,
   outputPanels = ["text", "visual"],
+  outputSplitView = false,
 }) => {
   const loading = useSelector((state) => state.editor.loading);
   const project = useSelector((state) => state.editor.project);
@@ -51,7 +52,7 @@ const WebComponentProject = ({
   const [codeHasRun, setCodeHasRun] = useState(codeHasBeenRun);
   const dispatch = useDispatch();
 
-  dispatch(setIsSplitView(false));
+  dispatch(setIsSplitView(outputSplitView));
   dispatch(setWebComponent(true));
   dispatch(setIsOutputOnly(outputOnly));
 

--- a/src/components/WebComponentProject/WebComponentProject.jsx
+++ b/src/components/WebComponentProject/WebComponentProject.jsx
@@ -108,13 +108,7 @@ const WebComponentProject = ({
         ))}
       {outputOnly && (
         <div className="embedded-viewer" data-testid="output-only">
-          {loading === "success" && (
-            <Output
-              embedded={true}
-              browserPreview={false}
-              outputPanels={outputPanels}
-            />
-          )}
+          {loading === "success" && <Output outputPanels={outputPanels} />}
         </div>
       )}
     </>

--- a/src/components/WebComponentProject/WebComponentProject.test.js
+++ b/src/components/WebComponentProject/WebComponentProject.test.js
@@ -255,6 +255,79 @@ describe("When output_only is true", () => {
   });
 });
 
+describe("outputSplitView property", () => {
+  beforeEach(() => {
+    const middlewares = [];
+    const mockStore = configureStore(middlewares);
+    const initialState = {
+      editor: {
+        project: {
+          components: [],
+        },
+        openFiles: [],
+        focussedFileIndices: [],
+      },
+      instructions: {},
+      auth: {},
+    };
+    store = mockStore(initialState);
+  });
+
+  describe("when property is not set", () => {
+    beforeEach(() => {
+      render(
+        <Provider store={store}>
+          <WebComponentProject />
+        </Provider>,
+      );
+    });
+
+    test("sets isSplitView state to false by default", () => {
+      expect(store.getActions()).toEqual(
+        expect.arrayContaining([
+          { type: "editor/setIsSplitView", payload: false },
+        ]),
+      );
+    });
+  });
+
+  describe("when property is false", () => {
+    beforeEach(() => {
+      render(
+        <Provider store={store}>
+          <WebComponentProject outputSplitView={false} />
+        </Provider>,
+      );
+    });
+
+    test("sets isSplitView state to false", () => {
+      expect(store.getActions()).toEqual(
+        expect.arrayContaining([
+          { type: "editor/setIsSplitView", payload: false },
+        ]),
+      );
+    });
+  });
+
+  describe("when property is true", () => {
+    beforeEach(() => {
+      render(
+        <Provider store={store}>
+          <WebComponentProject outputSplitView={true} />
+        </Provider>,
+      );
+    });
+
+    test("sets isSplitView state to true", () => {
+      expect(store.getActions()).toEqual(
+        expect.arrayContaining([
+          { type: "editor/setIsSplitView", payload: true },
+        ]),
+      );
+    });
+  });
+});
+
 afterAll(() => {
   document.removeEventListener("editor-codeChanged", codeChangedHandler);
   document.removeEventListener("editor-runStarted", runStartedHandler);

--- a/src/containers/WebComponentLoader.jsx
+++ b/src/containers/WebComponentLoader.jsx
@@ -43,6 +43,7 @@ const WebComponentLoader = (props) => {
     showSavePrompt = false,
     loadRemixDisabled = false,
     outputOnly = false,
+    outputSplitView = false,
   } = props;
 
   const dispatch = useDispatch();
@@ -164,6 +165,7 @@ const WebComponentLoader = (props) => {
               sidebarOptions={sidebarOptions}
               outputOnly={outputOnly}
               outputPanels={outputPanels}
+              outputSplitView={outputSplitView}
             />
             {errorModalShowing && <ErrorModal />}
             {newFileModalShowing && <NewFileModal />}

--- a/src/web-component.js
+++ b/src/web-component.js
@@ -69,6 +69,7 @@ class WebComponent extends HTMLElement {
         "show_save_prompt",
         "load_remix_disabled",
         "output_only",
+        "embedded",
       ].includes(name)
     ) {
       value = newVal !== "false";

--- a/src/web-component.js
+++ b/src/web-component.js
@@ -54,6 +54,7 @@ class WebComponent extends HTMLElement {
       "embedded",
       "show_save_prompt",
       "load_remix_disabled",
+      "output_split_view",
     ];
   }
 
@@ -70,6 +71,7 @@ class WebComponent extends HTMLElement {
         "load_remix_disabled",
         "output_only",
         "embedded",
+        "output_split_view",
       ].includes(name)
     ) {
       value = newVal !== "false";


### PR DESCRIPTION
This makes a number of changes to support the use of the web component in the embedded view of `editor-standalone`. See [this PR](https://github.com/RaspberryPiFoundation/editor-standalone/pull/164) for details.

In particular, I've tried to "tighten" up what we mean by the `isEmbedded` state (and its new corresponding `embedded` web component attribute). It's now very specifically intended to indicate that the we are in the embedded view i.e. on [the `/:locale/embed/viewer/:identifier` route](https://github.com/RaspberryPiFoundation/editor-standalone/blob/b38a307ea78ae672593befa0875fb550c9ba6689/src/components/AppRoutes.jsx#L75-L78).

In conjunction with [this block-to-text PR](https://github.com/RaspberryPiFoundation/block-to-text-alpha/pull/125), this has allowed me to remove some checks on the `webComponent` state which didn't completely make sense. This `webComponent` state now only indicates that we are in the context of the web component and should *not* be used as a proxy for e.g. whether we are in the context of the Block-to-Text app. There are some other usages of the `webComponent` state within the web component code, but I'm fairly confident they all still make sense.

As well as allowing us to use the web component for the embedded view in `editor-standalone`, the new `output_split_view` web component attribute will allow us to fix a minor difference in behaviour of the editor itself in `editor-standalone` versus `editor-ui`.

The changes are as follows:

* [Add boolean embedded attribute to web component](https://github.com/RaspberryPiFoundation/editor-ui/pull/1030/commits/7092ec6d10b367f05128e78053ffdd7bbe43e1a1)
* [Remove embedded & browserPreview props from Output](https://github.com/RaspberryPiFoundation/editor-ui/pull/1030/commits/c18d8f888786527c6a4ecd69ae6dce7ef9a381c5)
* [Ignore webComponent state for RunBar in Output](https://github.com/RaspberryPiFoundation/editor-ui/pull/1030/commits/73586cbe651ebd487158ec1498d89615f062dffb)
* [Ignore webComponent state for preview link in HtmlRunner](https://github.com/RaspberryPiFoundation/editor-ui/pull/1030/commits/a48eda50ac7f4fb1f551a18364d235532fea719c)
* [Add output_split_view attribute to web component](https://github.com/RaspberryPiFoundation/editor-ui/pull/1030/commits/1c4cdd241d7d01592e1123868c5252360bb09ff6)

See individual commit notes for details.

### Testing

I have tested these changes and those in RaspberryPiFoundation/editor-standalone#164 against the `editor-ui` app and the `editor-standalone` app and compared the behaviour against that currently deployed to [production](https://editor.raspberrypi.org):

#### Python project

* Editor: `/en/projects/<python-project-identifier>`
  * "Run" button in "editor-input" (below code)
  * No "Run" button in output panel
  * "Visual" & "Text" output panels (switchable between tabbed/split)
  * No preview link
* Embedded: `/en/embed/viewer/<python-project-identifier>`
  * Only output visible; no code/project
  * "Run" button at bottom of output
  * "Visual" & "Text" output panels (split view)

#### HTML project

* Editor: `/en/projects/<html-project-identifier>`
  * "Run" button in "editor-input" (below code)
  * No "Run" button in output
  * Preview of rendered HTML in output
  * Preview link opens in another browser tab
* Embedded: `/en/embed/viewer/<html-project-identifier>`
  * Only output visible; no code/project
  * "Run" button at bottom of output
  * Full page preview of rendered HTML in output (runs automatically)
* Preview: `/en/embed/viewer/<html-project-identifier>?browserPreview=true&page=index.html`
  * Only output visible; no code/project
  * No "Run" button at bottom of output
  * Full page preview of rendered HTML in output (runs automatically)
* Preview (other page): `/en/embed/viewer/<html-project-identifier>?browserPreview=true&page=other.html`
  * Only output visible; no code/project
  * No "Run" button at bottom of output
  * Full page preview of *other* rendered HTML in output (runs automatically)

Relates to #1010 & RaspberryPiFoundation/editor-standalone#16.
