### PR TITLE
Fix web-component context

### DIFF
--- a/src/web-component.js
+++ b/src/web-component.js
@@ -9,6 +9,7 @@ import { Provider } from "react-redux";
 import "./utils/i18n";
 import camelCase from "camelcase";
 import { stopCodeRun, stopDraw, triggerCodeRun } from "./redux/EditorSlice";
+import { BrowserRouter } from "react-router-dom";
 
 Sentry.init({
   dsn: process.env.REACT_APP_SENTRY_DSN,
@@ -158,7 +159,9 @@ class WebComponent extends HTMLElement {
     this.root.render(
       <React.StrictMode>
         <Provider store={store}>
-          <WebComponentLoader {...this.reactProps()} />
+          <BrowserRouter>
+            <WebComponentLoader {...this.reactProps()} />
+          </BrowserRouter>
         </Provider>
       </React.StrictMode>,
     );


### PR DESCRIPTION
Currently the web component doesn't have access to the browser context. This typically isn't an issue until we utilise components like `Link` which soft reloads pages and keeps state with a `useContext` hook.

https://github.com/RaspberryPiFoundation/editor-ui/assets/74183390/40ee68a3-287c-4c01-820b-1b90cc06bbcb

### Fix

I wasn't expecting wrapping the web component in a `BrowserRouter` to work but it does and means this issue is relatively trivial. I do suspect this comes with caveats and its worth being mindful there may be differences in the implementation in a web component we're not expecting