### PR TITLE
UAT web component fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
 ### Added
+
+- Web component now supports using standard editor-ui styles if useEditorStyles is true
 
 ### Changed
 

--- a/src/assets/stylesheets/Sidebar.scss
+++ b/src/assets/stylesheets/Sidebar.scss
@@ -2,40 +2,6 @@
 @use "./rpf_design_system/font-size" as *;
 @use "./rpf_design_system/colours" as *;
 
-:root,
-:host {
-  .--light {
-    --sidebar-border: var(--rpf-grey-150);
-    --sidebar-background: var(--rpf-white);
-    --sidebar-background-selected: var(--rpf-off-white);
-    --sidebar-panel-background: var(--rpf-white);
-    --sidebar-option-hover: var(--rpf-grey-100);
-    --sidebar-option-selected-icon: var(--rpf-black);
-  }
-
-  .--dark {
-    --sidebar-border: var(--rpf-grey-600);
-    --sidebar-background: var(--rpf-grey-800);
-    --sidebar-background-selected: var(--rpf-grey-800);
-    --sidebar-panel-background: var(--rpf-grey-700);
-    --sidebar-option-hover: var(--rpf-grey-600);
-    --sidebar-option-selected-icon: var(--rpf-white);
-  }
-}
-
-:root {
-  .--light {
-    --sidebar-option-selected-border: var(--editor-color-theme);
-    --sidebar-option-selected-background: var(--editor-color-theme-tertiary);
-    --sidebar-option-selected-background-hover: var(--rpf-teal-200);
-  }
-  .--dark {
-    --sidebar-option-selected-border: var(--editor-color-theme);
-    --sidebar-option-selected-background: var(--editor-color-theme-tertiary);
-    --sidebar-option-selected-background-hover: var(--rpf-teal-800);
-  }
-}
-
 /* Sidebar */
 .sidebar {
   display: flex;

--- a/src/assets/stylesheets/Tabs.scss
+++ b/src/assets/stylesheets/Tabs.scss
@@ -2,20 +2,6 @@
 @use "./rpf_design_system/font-weight" as *;
 @use "./rpf_design_system/colours" as *;
 
-:root {
-  .--light {
-    --rpf-tab-button-hover: var(--rpf-grey-100);
-    --rpf-tab-button-background: inherit;
-    --rpf-tab-border-bottom-selected: var(--rpf-teal-900);
-  }
-
-  .--dark {
-    --rpf-tab-button-hover: var(--rpf-grey-900);
-    --rpf-tab-button-background: var(--rpf-grey-800);
-    --rpf-tab-border-bottom-selected: var(--rpf-teal-800);
-  }
-}
-
 #app,
 #wc {
   .react-tabs {

--- a/src/assets/stylesheets/index.scss
+++ b/src/assets/stylesheets/index.scss
@@ -25,6 +25,7 @@ code {
 #app {
   min-block-size: 100dvh;
 }
+
 .--light, #wc.--light {
   --editor-color-layer-1: #{$rpf-teal-100};
   --editor-color-layer-2: #{$rpf-black};
@@ -37,6 +38,18 @@ code {
   --editor-color-text-secondary: #{$rpf-text-secondary};
   --rpf-files-list-item-active: #{$rpf-teal-secondary-tertiary-active};
   --rpf-files-list-item-hover: #{$rpf-teal-secondary-tertiary-hover};
+  --rpf-tab-button-hover: var(--rpf-grey-100);
+  --rpf-tab-button-background: inherit;
+  --rpf-tab-border-bottom-selected: var(--rpf-teal-900);
+  --sidebar-border: var(--rpf-grey-150);
+  --sidebar-background: var(--rpf-white);
+  --sidebar-background-selected: var(--rpf-off-white);
+  --sidebar-panel-background: var(--rpf-white);
+  --sidebar-option-hover: var(--rpf-grey-100);
+  --sidebar-option-selected-icon: var(--rpf-black);
+  --sidebar-option-selected-border: var(--editor-color-theme);
+  --sidebar-option-selected-background: var(--editor-color-theme-tertiary);
+  --sidebar-option-selected-background-hover: var(--rpf-teal-200);
 }
 
 .--dark, #wc.--dark {
@@ -51,6 +64,18 @@ code {
   --editor-color-text-secondary: #{$rpf-text-secondary-darkmode};
   --rpf-files-list-item-active: #{$rpf-grey-secondary-tertiary-active};
   --rpf-files-list-item-hover: #{$rpf-grey-secondary-tertiary-hover};
+  --rpf-tab-button-hover: var(--rpf-grey-900);
+  --rpf-tab-button-background: var(--rpf-grey-800);
+  --rpf-tab-border-bottom-selected: var(--rpf-teal-800);
+  --sidebar-border: var(--rpf-grey-600);
+  --sidebar-background: var(--rpf-grey-800);
+  --sidebar-background-selected: var(--rpf-grey-800);
+  --sidebar-panel-background: var(--rpf-grey-700);
+  --sidebar-option-hover: var(--rpf-grey-600);
+  --sidebar-option-selected-icon: var(--rpf-white);
+  --sidebar-option-selected-border: var(--editor-color-theme);
+  --sidebar-option-selected-background: var(--editor-color-theme-tertiary);
+  --sidebar-option-selected-background-hover: var(--rpf-teal-800);
 
   .btn,
   .rpf-button {
@@ -94,9 +119,7 @@ code {
   --rpf-button-secondary-background-color-hover: var(--rpf-teal-100);
   --rpf-button-secondary-border-color-hover: var(--rpf-teal-900);
   --rpf-button-secondary-background-color-active: var(--rpf-teal-900);
-  --rpf-button-secondary-background-color-disabled: var(
-    --rpf-grey-50
-  ); // might not exist
+  --rpf-button-secondary-background-color-disabled: var(--rpf-grey-50); // might not exist
   --rpf-button-secondary-text-color: var(--rpf-black);
 
   --rpf-button-tertiary-text-color-hover: var(--rpf-grey-600);

--- a/src/assets/stylesheets/index.scss
+++ b/src/assets/stylesheets/index.scss
@@ -25,9 +25,9 @@ code {
 #app {
   min-block-size: 100dvh;
 }
-.--light {
+.--light, #wc.--light {
   --editor-color-layer-1: #{$rpf-teal-100};
-  --editor-color-layer-2: #{$rpf-white};
+  --editor-color-layer-2: #{$rpf-black};
   --editor-color-layer-3: #{$rpf-white};
   --editor-color-outline: #{$rpf-grey-150};
   --editor-color-theme: #{$rpf-teal-800};
@@ -35,9 +35,11 @@ code {
   --editor-color-theme-tertiary: #{$rpf-teal-100};
   --editor-color-text: #{$rpf-text-primary};
   --editor-color-text-secondary: #{$rpf-text-secondary};
+  --rpf-files-list-item-active: #{$rpf-teal-secondary-tertiary-active};
+  --rpf-files-list-item-hover: #{$rpf-teal-secondary-tertiary-hover};
 }
 
-.--dark {
+.--dark, #wc.--dark {
   --editor-color-layer-1: #{$rpf-grey-850};
   --editor-color-layer-2: #{$rpf-grey-800};
   --editor-color-layer-3: #{$rpf-grey-700};
@@ -47,6 +49,34 @@ code {
   --editor-color-theme-tertiary: #{$rpf-teal-900};
   --editor-color-text: #{$rpf-white};
   --editor-color-text-secondary: #{$rpf-text-secondary-darkmode};
+  --rpf-files-list-item-active: #{$rpf-grey-secondary-tertiary-active};
+  --rpf-files-list-item-hover: #{$rpf-grey-secondary-tertiary-hover};
+
+  .btn,
+  .rpf-button {
+    --rpf-button-primary-background-color: var(--rpf-teal-400);
+    --rpf-button-primary-background-color-focus: var(--rpf-teal-400);
+    --rpf-button-primary-background-color-active: var(--rpf-teal-200);
+    --rpf-button-primary-background-color-disabled: var(--rpf-grey-200);
+    --rpf-button-primary-color-disabled: var(--rpf-grey-700);
+    --rpf-button-primary-color-disabled-focus: var(--rpf-teal-400);
+    --rpf-button-primary-background-color-hover: var(--rpf-teal-600);
+
+    --rpf-button-secondary-background-color: var(--rpf-grey-800);
+    --rpf-button-secondary-background-color-active: var(--rpf-teal-200);
+    --rpf-button-secondary-color-disabled-background: var(--rpf-grey-700);
+    --rpf-button-secondary-background-color-hover: var(--rpf-grey-600);
+    --rpf-button-secondary-border-color-hover: var(--rpf-teal-400);
+    --rpf-button-secondary-color-disabled: var(--rpf-grey-100);
+    --rpf-button-secondary-color: var(--rpf-white);
+    --rpf-button-secondary-text-color: var(--rpf-white);
+
+    --rpf-button-tertiary-text-color-hover: var(--rpf-grey-200);
+  }
+
+  .rpf-button--secondary {
+    border-color: var(--rpf-teal-400);
+  }
 }
 
 .btn,
@@ -70,29 +100,9 @@ code {
   --rpf-button-secondary-text-color: var(--rpf-black);
 
   --rpf-button-tertiary-text-color-hover: var(--rpf-grey-600);
-}
 
-.--dark {
-  .btn,
-  .rpf-button {
-    --rpf-button-primary-background-color: var(--rpf-teal-400);
-    --rpf-button-primary-background-color-focus: var(--rpf-teal-400);
-    --rpf-button-primary-background-color-active: var(--rpf-teal-200);
-    --rpf-button-primary-background-color-disabled: var(--rpf-grey-200);
-    --rpf-button-primary-color-disabled: var(--rpf-grey-700);
-    --rpf-button-primary-color-disabled-focus: var(--rpf-teal-400);
-    --rpf-button-primary-background-color-hover: var(--rpf-teal-600);
-
-    --rpf-button-secondary-background-color: var(--rpf-grey-800);
-    --rpf-button-secondary-background-color-active: var(--rpf-teal-200);
-    --rpf-button-secondary-color-disabled-background: var(--rpf-grey-700);
-    --rpf-button-secondary-background-color-hover: var(--rpf-grey-600);
-    --rpf-button-secondary-border-color-hover: var(--rpf-teal-400);
-    --rpf-button-secondary-color-disabled: var(--rpf-grey-100);
-    --rpf-button-secondary-color: var(--rpf-white);
-    --rpf-button-secondary-text-color: var(--rpf-white);
-
-    --rpf-button-tertiary-text-color-hover: var(--rpf-grey-200);
+  .rpf-button--secondary {
+    border-color: var(--rpf-teal-800);
   }
 }
 
@@ -102,14 +112,4 @@ code {
 
 .modal-overlay {
   --rpf-input-active-border: var(--editor-color-theme)
-}
-
-.--light {
-  --rpf-files-list-item-active: #{$rpf-teal-secondary-tertiary-active};
-  --rpf-files-list-item-hover: #{$rpf-teal-secondary-tertiary-hover};
-}
-
-.--dark {
-  --rpf-files-list-item-active: #{$rpf-grey-secondary-tertiary-active};
-  --rpf-files-list-item-hover: #{$rpf-grey-secondary-tertiary-hover};
 }

--- a/src/containers/WebComponentLoader.jsx
+++ b/src/containers/WebComponentLoader.jsx
@@ -21,6 +21,7 @@ import ToastCloseButton from "../utils/ToastCloseButton";
 
 import internalStyles from "../assets/stylesheets/InternalStyles.scss";
 import externalStyles from "../assets/stylesheets/ExternalStyles.scss";
+import editorStyles from "../assets/stylesheets/index.scss";
 import "../assets/stylesheets/Notifications.scss";
 import Style from "style-it";
 
@@ -39,11 +40,12 @@ const WebComponentLoader = (props) => {
     theme,
     outputPanels = ["text", "visual"],
     embedded = false,
-    hostStyles,
+    hostStyles, // Pass in styles from the host
     showSavePrompt = false,
     loadRemixDisabled = false,
     outputOnly = false,
     outputSplitView = false,
+    useEditorStyles = false, // If true use the standard editor styling for the web component
   } = props;
 
   const dispatch = useDispatch();
@@ -147,7 +149,8 @@ const WebComponentLoader = (props) => {
         }}
       >
         <style>{externalStyles.toString()}</style>
-        <style>{hostStyles}</style>
+        {useEditorStyles && <style>{editorStyles.toString()}</style>}
+        {hostStyles && <style>{hostStyles}</style>}
         <Style>
           {internalStyles.toString()}
           <div id="wc" className={`--${cookies.theme || themeDefault}`}>

--- a/src/containers/WebComponentLoader.test.js
+++ b/src/containers/WebComponentLoader.test.js
@@ -120,6 +120,30 @@ describe("When no user is in state", () => {
         expect.arrayContaining([setUser(null)]),
       );
     });
+
+    test("Renders editor styles when useEditorStyles is true", () => {
+      const { container } = render(
+        <Provider store={store}>
+          <CookiesProvider cookies={cookies}>
+            <WebComponentLoader
+              code={code}
+              identifier={identifier}
+              senseHatAlwaysEnabled={true}
+              instructions={instructions}
+              authKey={authKey}
+              theme="light"
+              useEditorStyles={true}
+            />
+          </CookiesProvider>
+        </Provider>,
+      );
+
+      const styleTags = container.querySelectorAll("style");
+      const editorStyles = Array.from(styleTags).find((tag) =>
+        tag.textContent.includes("editorStyles"),
+      );
+      expect(editorStyles).not.toBeNull();
+    });
   });
 
   describe("with assetsIdentifier set", () => {

--- a/src/web-component.html
+++ b/src/web-component.html
@@ -52,6 +52,7 @@
           "download",
           "settings",
           "info",
+          "use_editor_styles"
         ]),
       );
 

--- a/src/web-component.js
+++ b/src/web-component.js
@@ -56,6 +56,7 @@ class WebComponent extends HTMLElement {
       "show_save_prompt",
       "load_remix_disabled",
       "output_split_view",
+      "use_editor_styles",
     ];
   }
 
@@ -73,6 +74,7 @@ class WebComponent extends HTMLElement {
         "output_only",
         "embedded",
         "output_split_view",
+        "use_editor_styles",
       ].includes(name)
     ) {
       value = newVal !== "false";


### PR DESCRIPTION
Adds support to use built in editor styles in web component, currently defaults to general design system colours. If the flag is true, import those styles and applies them, else falls back to design system styling.