### PR TITLE
Quick fix for expired access token problem in web component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+### Changed
+
+### Fixed
+
+- Quick fix for expired access token problem in web component (#1046)
+
 ## [0.25.2] - 2024-13-06
 
 ### Added

--- a/cypress/e2e/spec-wc.cy.js
+++ b/cypress/e2e/spec-wc.cy.js
@@ -94,7 +94,8 @@ describe("default behaviour", () => {
 describe("when load_remix_disabled is true, e.g. in editor-standalone", () => {
   const authKey = `oidc.user:https://auth-v1.raspberrypi.org:editor-api`;
 
-  const user = { access_token: "dummy-access-token" };
+  const oneHourFromNow = (new Date().getTime() + 60 * 60 * 1000) / 1000;
+  const user = { access_token: "dummy-access-token", expires_at: oneHourFromNow };
   const originalIdentifier = "blank-python-starter";
 
   const urlFor = (identifier) => {

--- a/src/containers/WebComponentLoader.jsx
+++ b/src/containers/WebComponentLoader.jsx
@@ -48,13 +48,24 @@ const WebComponentLoader = (props) => {
     useEditorStyles = false, // If true use the standard editor styling for the web component
   } = props;
 
+  const getLocalStorageUser = (authKey) => {
+    if (authKey) {
+      const user = JSON.parse(localStorage.getItem(authKey));
+      if (user) {
+        return user;
+      } else {
+        return null;
+      }
+    } else {
+      return null;
+    }
+  };
+
   const dispatch = useDispatch();
   const { t } = useTranslation();
   const [projectIdentifier, setProjectIdentifier] = useState(identifier);
   localStorage.setItem("authKey", authKey);
-  const localStorageUser = authKey
-    ? JSON.parse(localStorage.getItem(authKey))
-    : null;
+  const localStorageUser = getLocalStorageUser(authKey);
   const user = useSelector((state) => state.auth.user || localStorageUser);
   const [loadCache, setLoadCache] = useState(!!!user);
   const [loadRemix, setLoadRemix] = useState(!!user);

--- a/src/containers/WebComponentLoader.jsx
+++ b/src/containers/WebComponentLoader.jsx
@@ -52,7 +52,12 @@ const WebComponentLoader = (props) => {
     if (authKey) {
       const user = JSON.parse(localStorage.getItem(authKey));
       if (user) {
-        return user;
+        const expiresAt = new Date(user.expires_at * 1000);
+        if (new Date() < expiresAt) {
+          return user;
+        } else {
+          return null;
+        }
       } else {
         return null;
       }


### PR DESCRIPTION
This is a quick fix for https://github.com/RaspberryPiFoundation/editor-ui/issues/1044.

We've been seeing quite a few [`Faraday::Unauthorized` exceptions reported by Sentry in Editor API][1]. These errors are being caused by expired access tokens being sent in the requests from the web component.

This can happen if a user is logged in and is viewing a non-public project, but they close their browser and return to the project some time (1 hour?) later when their access token has expired. In this scenario the project will not load, because of the exception and the user will see the "Loading" text instead of the editor.

This commit prevents the web component from using an expired access token in `WebComponentLoader` and should thus avoid the exeptions we've been seeing.

However, it's not clear this is actually the correct place to fix the problem, because this ignoring/removal of expired access tokens must already be happening (maybe in `oidc-client`, `redux-oidc`, or associated code?). It might be better if the `WebComponentLoader` only reads the `user` from the redux state (and not also from local storage) and then rely on the component re-rendering when the `user` becomes available in the state.

We know that the `WebComponentLoader` component renders (and therefore makes a request to `editor-api` with no `Authorization` header) before the user is available in state. This is fine for public projects (i.e. those where `user_id` is `null`) but fails for user projects (i.e. those where `user_id` is set). When the user becomes available in state we'd expect the component to re-render and make a request to `editor-api` with the `Authorization` header set correctly. However, this second request doesn't currently happen because of the condition in [this line][2] of `syncProject` in `EditorSlice`, so we'd need to make a change there too.

The main downside of not making the proper fix is that there may be times when the logged-in "state" of different bits of the UI (e.g. the "Save" button, the global nav, etc) might be inconsistent in some circumstances. However, since the proper fix is likely to be a more significant bit of work, it seems sensible to ship this change to prevent the exceptions now and tackle the proper fix separately.

[1]: https://rpf.sentry.io/issues/5135885959/
[2]: https://github.com/RaspberryPiFoundation/editor-ui/blob/e3495a24ff296cf0c3c22910db25d02547c6dfd9/src/redux/EditorSlice.js#L65