### PR TITLE
Only register web component once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
-- Small fix to ensure webpack is using the correct webSocketURL for live reloading
+- Small fix to ensure webpack is using the correct webSocketURL for live reloading\
+- Only register `editor-wc` once (#1052)
 
 ## [0.25.4] - 2024-06-20
 

--- a/src/web-component.js
+++ b/src/web-component.js
@@ -170,4 +170,6 @@ class WebComponent extends HTMLElement {
   }
 }
 
-window.customElements.define("editor-wc", WebComponent);
+if (!window.customElements.get("editor-wc")) {
+  window.customElements.define("editor-wc", WebComponent);
+}


### PR DESCRIPTION
Fixes an error caused by attempting to register the web component multiple times ⤵️ 

![Screenshot 2024-07-02 at 12 40 53](https://github.com/RaspberryPiFoundation/editor-ui/assets/88904316/18b18a4a-68aa-4895-ad0d-157c234b81a7)
