### PR TITLE
Fix Skulpt External Files

### DIFF
--- a/.env.webcomponent.example
+++ b/.env.webcomponent.example
@@ -2,7 +2,7 @@ REACT_APP_AUTHENTICATION_URL='http://localhost:9001'
 REACT_APP_SENTRY_DSN=''
 REACT_APP_SENTRY_ENV='local'
 # NB This is the URL of react-ui, rather than the web component
-PUBLIC_URL=http://localhost:3010
+PUBLIC_URL=http://localhost:3012
 REACT_APP_IDENTITY_URL='http://localhost:3011'
 REACT_APP_API_ENDPOINT='http://localhost:3009'
-ASSETS_URL='http://localhost:3010'
+ASSETS_URL='http://localhost:3011'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- Attach Skulpt files to the `document.body` to avoid issues with the shadow DOM (#1062)
 - Small fix to ensure webpack is using the correct webSocketURL for live reloading\
 - Only register `editor-wc` once (#1052)
 

--- a/src/components/EmbeddedViewer/__snapshots__/EmbeddedViewer.test.js.snap
+++ b/src/components/EmbeddedViewer/__snapshots__/EmbeddedViewer.test.js.snap
@@ -6,10 +6,6 @@ exports[`Renders without crashing 1`] = `
     class="embedded-viewer"
   >
     <div
-      hidden=""
-      id="file-content"
-    />
-    <div
       class="proj-runner-container"
       data-testid="output"
     >

--- a/src/components/ExternalFiles/ExternalFiles.jsx
+++ b/src/components/ExternalFiles/ExternalFiles.jsx
@@ -1,10 +1,16 @@
 import React from "react";
 import { useSelector } from "react-redux";
+import { createPortal } from "react-dom";
 
 const ExternalFiles = () => {
   const project = useSelector((state) => state.editor.project);
+  const hostElement = document.body;
 
-  return (
+  if (!hostElement) {
+    return null;
+  }
+
+  return createPortal(
     <div id="file-content" hidden>
       {project.components?.map((file, i) => {
         if (["csv", "txt"].includes(file.extension)) {
@@ -16,7 +22,8 @@ const ExternalFiles = () => {
         }
         return null;
       })}
-    </div>
+    </div>,
+    hostElement,
   );
 };
 

--- a/webpack.component.config.js
+++ b/webpack.component.config.js
@@ -77,6 +77,12 @@ module.exports = {
     static: {
       directory: path.join(__dirname, "public"),
     },
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, PATCH, OPTIONS",
+      "Access-Control-Allow-Headers":
+        "X-Requested-With, content-type, Authorization",
+    },
   },
   plugins: [
     new Dotenv({


### PR DESCRIPTION
Fix:

- add external files to document body so it renders outside the shadow DOM

Why:

- Skulpt picks up files by adding them to the DOM (see https://github.com/skulpt/skulpt/issues/854#issuecomment-486135840)
- this doesn't play nice with the shadow DOM and Skulpt doesn't recoginse files like `.txt` and `.csv`
- `createPortal` enables us to pick a common host element (i.e. `body`) and attach the required div's there