### PR TITLE
Apply part to run-bar element as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+## [0.25.6] - 2024-08-16
+
+### Changed
+
+- Attach part to a run-bar component to be able to hide it from Block To Text
+
 ## [0.25.5] - 2024-08-08
 
 ### Fixed

--- a/src/web-component.js
+++ b/src/web-component.js
@@ -153,7 +153,7 @@ class WebComponent extends HTMLElement {
     if (!this.mountPoint) {
       this.mountPoint = document.createElement("div");
       this.mountPoint.setAttribute("id", "root");
-      this.mountPoint.setAttribute("part", "editor-root");
+      this.mountPoint.setAttribute("part", "editor-root run bar");
       this.attachShadow({ mode: "open" }).appendChild(this.mountPoint);
       this.root = ReactDOMClient.createRoot(this.mountPoint);
     }


### PR DESCRIPTION
Related to a [Projects site issue](https://github.com/RaspberryPiFoundation/projects-ui/issues/2561). I'm trying to remove a button from Block-to-Text activity

![Uploading Screenshot 2024-08-16 at 11.36.51.png…]()
