### PR TITLE
Fix deploy main branch CI

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -2,11 +2,13 @@ name: CI-CD
 
 on:
   push:
+    branches:
+      - main
     tags:
       - "**"
   pull_request:
     branches:
-      - '**'
+      - "**"
 
 jobs:
   lint:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- Staging web component CI deployment
 - Fixes multiple dispatches on loadRemix
 - Ensures remix is loaded immediately after creation, to avoid state inconsistencies
 - Fixes error when clicking the `Go to your project` button


### PR DESCRIPTION
Accidentally broken the `main` branch deployment used for staging during a little innovation tidy up