### PR TITLE
Investigate broken projects site editor web component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+- P5/Py5 scope related errors when using the web component in different contexts (#1075)
 - Staging web component CI deployment
 - Fixes multiple dispatches on loadRemix
 - Ensures remix is loaded immediately after creation, to avoid state inconsistencies

--- a/public/shims/processing/p5/p5-shim.js
+++ b/public/shims/processing/p5/p5-shim.js
@@ -193,7 +193,7 @@ const $builtinmodule = function (name) {
   // Shadow root manipulation
   const webComponent = document.querySelector("editor-wc");
   const element = !!webComponent ? webComponent.shadowRoot : document;
-  const p5Sketch = element.getElementById(Sk.p5.sketch);
+  const p5Sketch = element.getElementById("p5Sketch");
 
   // eslint-disable-next-line no-native-reassign
 
@@ -1554,7 +1554,7 @@ const $builtinmodule = function (name) {
         }
       };
 
-      Sk.p5.stop = function () {
+      window.p5.stop = function () {
         mod.pInst.noLoop();
 
         for (const cb of Object.keys(callBacks)) {
@@ -1692,7 +1692,7 @@ const $builtinmodule = function (name) {
   };
 
   mod.load_image = new Sk.builtin.func(function (path) {
-    const asset = Sk.p5.assets.find((el) => el.filename === path.v);
+    const asset = window.assets.find((el) => el.filename === path.v);
     if (asset) {
       path.v = asset.url;
     }

--- a/public/shims/processing/py5/py5-shim.js
+++ b/public/shims/processing/py5/py5-shim.js
@@ -1338,7 +1338,7 @@ const $builtinmodule = function (name) {
   };
 
   document
-    .getElementById(Sk.py5.sketch)
+    .getElementById("p5Sketch")
     .addEventListener("mousemove", updateMouseCoords);
 
   // NOTE: difference with ProcessingJS
@@ -1495,7 +1495,7 @@ const $builtinmodule = function (name) {
         }
       };
 
-      Sk.py5.stop = function () {
+      window.py5.stop = function () {
         mod.pInst.noLoop();
 
         for (const cb of Object.keys(callBacks)) {
@@ -1506,7 +1506,7 @@ const $builtinmodule = function (name) {
       };
     };
 
-    const p5Sketch = document.getElementById(Sk.py5.sketch);
+    const p5Sketch = document.getElementById("p5Sketch");
 
     window.p5._friendlyError = function (message, func, color) {
       throw new Sk.builtin.Exception(message);
@@ -1632,7 +1632,7 @@ const $builtinmodule = function (name) {
   };
 
   mod.load_image = new Sk.builtin.func(function (path) {
-    const asset = Sk.py5.assets.find((el) => el.filename === path.v);
+    const asset = window.assets.find((el) => el.filename === path.v);
     if (asset) {
       path.v = asset.url;
     }

--- a/src/components/Editor/Runners/PythonRunner/VisualOutputPane.jsx
+++ b/src/components/Editor/Runners/PythonRunner/VisualOutputPane.jsx
@@ -59,11 +59,7 @@ const VisualOutputPane = () => {
       p5Output.current &&
       p5Output.current.innerHTML !== ""
     ) {
-      if (Sk.py5?.stop) {
-        Sk.py5.stop();
-      } else if (Sk.p5?.stop) {
-        Sk.p5.stop();
-      } else if (window.p5?.stop) {
+      if (window.p5?.stop) {
         window.p5.stop();
       } else if (window.py5?.stop) {
         window.py5.stop();

--- a/src/components/Editor/Runners/PythonRunner/VisualOutputPane.jsx
+++ b/src/components/Editor/Runners/PythonRunner/VisualOutputPane.jsx
@@ -30,13 +30,16 @@ const VisualOutputPane = () => {
       pygalOutput.current.innerHTML = "";
       p5Output.current.innerHTML = "";
 
-      Sk.py5 = {};
-      Sk.py5.sketch = "p5Sketch";
-      Sk.py5.assets = projectImages;
+      if (!window.py5) {
+        window.py5 = {};
+      }
+      window.py5.sketch = "p5Sketch";
 
-      Sk.p5 = {};
-      Sk.p5.sketch = "p5Sketch";
-      Sk.p5.assets = projectImages;
+      if (!window.p5) {
+        window.p5 = {};
+      }
+      window.p5.sketch = "p5Sketch";
+      window.assets = projectImages;
 
       (Sk.pygal || (Sk.pygal = {})).outputCanvas = pygalOutput.current;
 
@@ -56,10 +59,14 @@ const VisualOutputPane = () => {
       p5Output.current &&
       p5Output.current.innerHTML !== ""
     ) {
-      if (Sk.py5.stop) {
+      if (Sk.py5?.stop) {
         Sk.py5.stop();
-      } else {
+      } else if (Sk.p5?.stop) {
         Sk.p5.stop();
+      } else if (window.p5?.stop) {
+        window.p5.stop();
+      } else if (window.py5?.stop) {
+        window.py5.stop();
       }
 
       if (error === "") {

--- a/src/components/Editor/Runners/PythonRunner/VisualOutputPane.test.js
+++ b/src/components/Editor/Runners/PythonRunner/VisualOutputPane.test.js
@@ -91,11 +91,12 @@ describe("When code run is triggered", () => {
       },
     };
     store = mockStore(initialState);
-    container = render(
+    const renderResult = render(
       <Provider store={store}>
         <VisualOutputPane />
       </Provider>,
     );
+    container = renderResult.container;
   });
 
   test("Sets up p5 canvas", () => {

--- a/src/components/Editor/Runners/PythonRunner/VisualOutputPane.test.js
+++ b/src/components/Editor/Runners/PythonRunner/VisualOutputPane.test.js
@@ -76,6 +76,7 @@ describe("When Sense Hat library not used", () => {
 
 describe("When code run is triggered", () => {
   let store;
+  let container;
 
   beforeEach(() => {
     const middlewares = [];
@@ -90,7 +91,7 @@ describe("When code run is triggered", () => {
       },
     };
     store = mockStore(initialState);
-    render(
+    container = render(
       <Provider store={store}>
         <VisualOutputPane />
       </Provider>,
@@ -98,7 +99,8 @@ describe("When code run is triggered", () => {
   });
 
   test("Sets up p5 canvas", () => {
-    expect(Sk.py5.sketch).not.toBeNull();
+    const p5Sketch = container.querySelector("#p5Sketch");
+    expect(p5Sketch).not.toBeNull();
   });
 
   test("Sets up pygal canvas", () => {


### PR DESCRIPTION
Currently p5 related projects using the web component in the projects site are broken

### Current findings

- Integrated editor projects in the projects site that utilise p5 error on run (see https://projects.raspberrypi.org/en/projects/editor-target-practice/editor)
- The same editor projects loaded directly in on the editor domain run fine (see https://editor.raspberrypi.org/en/projects/editor-target-practice-starter)
- When break points are added its clear the aspects loaded into p5 via the p5-shim aren't loaded (or in scope at least) when ran in the projects-ui code (i.e. http://localhost:3001/en/projects/editor-rocket-launch/editor) and errors are seen
- Aspects can be initialised in different places or altered slightly so there's less of a dependency on the order they're ran (i.e. removing `Sk.p5.sketch` in place of hardcoding the element ID)
- Moving certain aspects can get a p5 canvas to be rendered in the DOM but fails to load assets or breaks the stop functionality

### Unknowns

- What actually caused this change?
- Why `p5.js` and `p5-shim.js` are being ran in a different order or using difference scopes between projects.raspberrypi.org and editor.raspberrypi.org?
- Both are using the same version web component so why is there a difference?