### PR TITLE
Disable specific localstorage access at runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Disabling of localstorage access at runtime (#1079)
+
 ## [0.26.0] - 2024-09-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
-- Disabling of `localstorage.getItem()` access to `authKey` at runtime (#1079)
+- Disabling of `localstorage.getItem()` access to `authKey`, `oidc.user:https://staging-auth-v1.raspberrypi.org:editor-api` and `oidc.user:https://auth-v1.raspberrypi.org:editor-api` at runtime (#1079)
 
 ## [0.26.0] - 2024-09-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
-- Disabling of localstorage access at runtime (#1079)
+- Disabling of `localstorage.getItem()` access to `authKey` at runtime (#1079)
 
 ## [0.26.0] - 2024-09-13
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,11 @@ See the section about [deployment](https://facebook.github.io/create-react-app/d
 
 Automated unit tests can be run via the `yarn test` command. These unit tests are written using the JavaScript testing framework `Jest` and make use of the tools provided by the [React Testing Library](https://testing-library.com/docs/). Automated accessibility testing for components is available via the `jest-axe` library. This can be achieved using the `haveNoViolations` matcher provided by `jest-axe`, although this does not guarantee that the tested components have no accessibility issues.
 
-Integration testing is carried out via `cypress` and can be run using the `yarn exec cypress run` commmand. Currently, there are basic `cypress` tests for the standalone editor site, the web component and Mission Zero-related functionality. These can be found in the `cypress/e2e` directory. Screenshots and videos related to the most recent `cypress` test run can be found in `cypress/screenshots` and `cypress/videos` respectively.
+Integration testing is carried out via `cypress` and can be run using:
+* `yarn exec cypress run` to run in the CLI
+* `yarn exec cypress open` to run in the GUI
+
+Currently, there are basic `cypress` tests for the standalone editor site, the web component and Mission Zero-related functionality. These can be found in the `cypress/e2e` directory. Screenshots and videos related to the most recent `cypress` test run can be found in `cypress/screenshots` and `cypress/videos` respectively.
 
 ## Web Component
 

--- a/cypress/e2e/spec-html.cy.js
+++ b/cypress/e2e/spec-html.cy.js
@@ -20,20 +20,24 @@ const makeNewFile = (filename = "new.html") => {
   cy.get("div[class=modal-content__buttons]").contains("Add file").click();
 };
 
-it("blocks access to localStorage", () => {
+it("blocks access to localStorage 'authKey' but allows other keys", () => {
   localStorage.clear();
   localStorage.setItem("foo", "bar");
+  localStorage.setItem("authKey", "secret");
 
   cy.visit(baseUrl);
   cy.get(".btn--run").click();
   cy.get("iframe#output-frame").should("exist");
 
-  cy.get('iframe#output-frame').then(($iframe) => {
+  cy.get("iframe#output-frame").then(($iframe) => {
     const iframeWindow = $iframe[0].contentWindow;
 
     cy.wrap(iframeWindow).then((win) => {
-      const result = win.localStorage.getItem("foo");
-      expect(result).to.equal(null);
+      const authKeyResult = win.localStorage.getItem("authKey");
+      expect(authKeyResult).to.equal(null);
+
+      const fooResult = win.localStorage.getItem("foo");
+      expect(fooResult).to.equal("bar");
     });
   });
 });

--- a/cypress/e2e/spec-html.cy.js
+++ b/cypress/e2e/spec-html.cy.js
@@ -20,10 +20,18 @@ const makeNewFile = (filename = "new.html") => {
   cy.get("div[class=modal-content__buttons]").contains("Add file").click();
 };
 
-it("blocks access to localStorage 'authKey' but allows other keys", () => {
+it("blocks access to specific localStorage keys but allows other keys", () => {
   localStorage.clear();
   localStorage.setItem("foo", "bar");
   localStorage.setItem("authKey", "secret");
+  localStorage.setItem(
+    "oidc.user:https://staging-auth-v1.raspberrypi.org:editor-api",
+    "staging-token",
+  );
+  localStorage.setItem(
+    "oidc.user:https://auth-v1.raspberrypi.org:editor-api",
+    "prod-token",
+  );
 
   cy.visit(baseUrl);
   cy.get(".btn--run").click();
@@ -35,6 +43,16 @@ it("blocks access to localStorage 'authKey' but allows other keys", () => {
     cy.wrap(iframeWindow).then((win) => {
       const authKeyResult = win.localStorage.getItem("authKey");
       expect(authKeyResult).to.equal(null);
+
+      const stagingOidcResult = win.localStorage.getItem(
+        "oidc.user:https://staging-auth-v1.raspberrypi.org:editor-api",
+      );
+      expect(stagingOidcResult).to.equal(null);
+
+      const prodOidcResult = win.localStorage.getItem(
+        "oidc.user:https://auth-v1.raspberrypi.org:editor-api",
+      );
+      expect(prodOidcResult).to.equal(null);
 
       const fooResult = win.localStorage.getItem("foo");
       expect(fooResult).to.equal("bar");

--- a/cypress/e2e/spec-html.cy.js
+++ b/cypress/e2e/spec-html.cy.js
@@ -20,6 +20,24 @@ const makeNewFile = (filename = "new.html") => {
   cy.get("div[class=modal-content__buttons]").contains("Add file").click();
 };
 
+it("blocks access to localStorage", () => {
+  localStorage.clear();
+  localStorage.setItem("foo", "bar");
+
+  cy.visit(baseUrl);
+  cy.get(".btn--run").click();
+  cy.get("iframe#output-frame").should("exist");
+
+  cy.get('iframe#output-frame').then(($iframe) => {
+    const iframeWindow = $iframe[0].contentWindow;
+
+    cy.wrap(iframeWindow).then((win) => {
+      const result = win.localStorage.getItem("foo");
+      expect(result).to.equal(null);
+    });
+  });
+});
+
 it("renders the html runner", () => {
   cy.visit(baseUrl);
   cy.get(".btn--run").click();

--- a/src/components/Editor/Runners/HtmlRunner/HtmlRunner.jsx
+++ b/src/components/Editor/Runners/HtmlRunner/HtmlRunner.jsx
@@ -302,6 +302,8 @@ function HtmlRunner() {
       const disableLocalStorageScript = `
       <script>
         (function() {
+          const disallowedKeys = ['authKey', 'oidc.user:https://staging-auth-v1.raspberrypi.org:editor-api', 'oidc.user:https://auth-v1.raspberrypi.org:editor-api'];
+
           const originalGetItem = window.localStorage.getItem.bind(window.localStorage);
           const originalSetItem = window.localStorage.setItem.bind(window.localStorage);
           const originalRemoveItem = window.localStorage.removeItem.bind(window.localStorage);
@@ -310,22 +312,22 @@ function HtmlRunner() {
           Object.defineProperty(window, 'localStorage', {
             value: {
               getItem: function(key) {
-                if (key === 'authKey') {
-                  console.log('localStorage.getItem for "authKey" is disabled');
+                if (disallowedKeys.includes(key)) {
+                  console.log(\`localStorage.getItem for "\${key}" is disabled\`);
                   return null;
                 }
                 return originalGetItem(key);
               },
               setItem: function(key, value) {
-                if (key === 'authKey') {
-                  console.log('localStorage.setItem for "authKey" is disabled');
+                if (disallowedKeys.includes(key)) {
+                  console.log(\`localStorage.setItem for "\${key}" is disabled\`);
                   return;
                 }
                 return originalSetItem(key, value);
               },
               removeItem: function(key) {
-                if (key === 'authKey') {
-                  console.log('localStorage.removeItem for "authKey" is disabled');
+                if (disallowedKeys.includes(key)) {
+                  console.log(\`localStorage.removeItem for "\${key}" is disabled\`);
                   return;
                 }
                 return originalRemoveItem(key);

--- a/src/components/Editor/Runners/HtmlRunner/HtmlRunner.jsx
+++ b/src/components/Editor/Runners/HtmlRunner/HtmlRunner.jsx
@@ -300,28 +300,47 @@ function HtmlRunner() {
       // insert script to disable access to localStorage
       // localstorage.getItem() is a potential security risk when executing untrusted code
       const disableLocalStorageScript = `
-        <script>
+      <script>
+        (function() {
+          const originalGetItem = window.localStorage.getItem.bind(window.localStorage);
+          const originalSetItem = window.localStorage.setItem.bind(window.localStorage);
+          const originalRemoveItem = window.localStorage.removeItem.bind(window.localStorage);
+          const originalClear = window.localStorage.clear.bind(window.localStorage);
+
           Object.defineProperty(window, 'localStorage', {
             value: {
-              getItem: function() {
-                console.log('localStorage.getItem is disabled');
-                return null;
+              getItem: function(key) {
+                if (key === 'authKey') {
+                  console.log('localStorage.getItem for "authKey" is disabled');
+                  return null;
+                }
+                return originalGetItem(key);
               },
-              setItem: function() {
-                console.log('localStorage.setItem is disabled');
+              setItem: function(key, value) {
+                if (key === 'authKey') {
+                  console.log('localStorage.setItem for "authKey" is disabled');
+                  return;
+                }
+                return originalSetItem(key, value);
               },
-              removeItem: function() {
-                console.log('localStorage.removeItem is disabled');
+              removeItem: function(key) {
+                if (key === 'authKey') {
+                  console.log('localStorage.removeItem for "authKey" is disabled');
+                  return;
+                }
+                return originalRemoveItem(key);
               },
               clear: function() {
                 console.log('localStorage.clear is disabled');
+                return;
               }
             },
             writable: false,
             configurable: false
           });
-        </script>
-      `;
+        })();
+      </script>
+    `;
 
       body.insertAdjacentHTML("afterbegin", disableLocalStorageScript);
 

--- a/src/components/Editor/Runners/HtmlRunner/HtmlRunner.jsx
+++ b/src/components/Editor/Runners/HtmlRunner/HtmlRunner.jsx
@@ -297,6 +297,34 @@ function HtmlRunner() {
       const indexPage = parse(focussedComponent(previewFile).content);
       const body = indexPage.querySelector("body") || indexPage;
 
+      // insert script to disable access to localStorage
+      // localstorage.getItem() is a potential security risk when executing untrusted code
+      const disableLocalStorageScript = `
+        <script>
+          Object.defineProperty(window, 'localStorage', {
+            value: {
+              getItem: function() {
+                console.log('localStorage.getItem is disabled');
+                return null;
+              },
+              setItem: function() {
+                console.log('localStorage.setItem is disabled');
+              },
+              removeItem: function() {
+                console.log('localStorage.removeItem is disabled');
+              },
+              clear: function() {
+                console.log('localStorage.clear is disabled');
+              }
+            },
+            writable: false,
+            configurable: false
+          });
+        </script>
+      `;
+
+      body.insertAdjacentHTML("afterbegin", disableLocalStorageScript);
+
       replaceHrefNodes(indexPage, projectCode);
       replaceSrcNodes(indexPage, projectImages, projectCode);
       replaceSrcNodes(indexPage, projectImages, projectCode, "data-src");

--- a/src/components/Editor/Runners/HtmlRunner/HtmlRunner.test.js
+++ b/src/components/Editor/Runners/HtmlRunner/HtmlRunner.test.js
@@ -285,16 +285,17 @@ describe("When run is triggered", () => {
     );
   });
 
-  test("Includes localStorage disabling script in the iframe", () => {
+  test("Includes localStorage disabling script for 'authKey' in the iframe", () => {
     const [generatedHtml] = Blob.mock.calls[0][0];
 
     expect(generatedHtml).toContain("<script>");
     expect(generatedHtml).toContain(
       "Object.defineProperty(window, 'localStorage'",
     );
-    expect(generatedHtml).toContain("getItem: function() {");
+    expect(generatedHtml).toContain("getItem: function(key) {");
+    expect(generatedHtml).toContain("if (key === 'authKey')");
     expect(generatedHtml).toContain(
-      "console.log('localStorage.getItem is disabled')",
+      'localStorage.getItem for "authKey" is disabled',
     );
     expect(generatedHtml).toContain("return null;");
     expect(generatedHtml).toContain("</script>");

--- a/src/components/Editor/Runners/HtmlRunner/HtmlRunner.test.js
+++ b/src/components/Editor/Runners/HtmlRunner/HtmlRunner.test.js
@@ -285,7 +285,7 @@ describe("When run is triggered", () => {
     );
   });
 
-  test("Includes localStorage disabling script for 'authKey' in the iframe", () => {
+  test("Includes localStorage disabling script for 'authKey' and other disallowed keys in the iframe", () => {
     const [generatedHtml] = Blob.mock.calls[0][0];
 
     expect(generatedHtml).toContain("<script>");
@@ -293,10 +293,26 @@ describe("When run is triggered", () => {
       "Object.defineProperty(window, 'localStorage'",
     );
     expect(generatedHtml).toContain("getItem: function(key) {");
+
     expect(generatedHtml).toContain("if (key === 'authKey')");
     expect(generatedHtml).toContain(
       'localStorage.getItem for "authKey" is disabled',
     );
+
+    expect(generatedHtml).toContain(
+      "if (key === 'oidc.user:https://staging-auth-v1.raspberrypi.org:editor-api')",
+    );
+    expect(generatedHtml).toContain(
+      'localStorage.getItem for "oidc.user:https://staging-auth-v1.raspberrypi.org:editor-api" is disabled',
+    );
+
+    expect(generatedHtml).toContain(
+      "if (key === 'oidc.user:https://auth-v1.raspberrypi.org:editor-api')",
+    );
+    expect(generatedHtml).toContain(
+      'localStorage.getItem for "oidc.user:https://auth-v1.raspberrypi.org:editor-api" is disabled',
+    );
+
     expect(generatedHtml).toContain("return null;");
     expect(generatedHtml).toContain("</script>");
   });

--- a/src/components/Editor/Runners/HtmlRunner/HtmlRunner.test.js
+++ b/src/components/Editor/Runners/HtmlRunner/HtmlRunner.test.js
@@ -284,6 +284,21 @@ describe("When run is triggered", () => {
       expect.arrayContaining([codeRunHandled()]),
     );
   });
+
+  test("Includes localStorage disabling script in the iframe", () => {
+    const [generatedHtml] = Blob.mock.calls[0][0];
+
+    expect(generatedHtml).toContain("<script>");
+    expect(generatedHtml).toContain(
+      "Object.defineProperty(window, 'localStorage'",
+    );
+    expect(generatedHtml).toContain("getItem: function() {");
+    expect(generatedHtml).toContain(
+      "console.log('localStorage.getItem is disabled')",
+    );
+    expect(generatedHtml).toContain("return null;");
+    expect(generatedHtml).toContain("</script>");
+  });
 });
 
 describe("When a non-permitted external link is rendered", () => {

--- a/src/components/Editor/Runners/HtmlRunner/HtmlRunner.test.js
+++ b/src/components/Editor/Runners/HtmlRunner/HtmlRunner.test.js
@@ -285,7 +285,7 @@ describe("When run is triggered", () => {
     );
   });
 
-  test("Includes localStorage disabling script for 'authKey' and other disallowed keys in the iframe", () => {
+  test("Includes localStorage disabling script for disallowed keys in the iframe", () => {
     const [generatedHtml] = Blob.mock.calls[0][0];
 
     expect(generatedHtml).toContain("<script>");
@@ -294,25 +294,13 @@ describe("When run is triggered", () => {
     );
     expect(generatedHtml).toContain("getItem: function(key) {");
 
-    expect(generatedHtml).toContain("if (key === 'authKey')");
     expect(generatedHtml).toContain(
-      'localStorage.getItem for "authKey" is disabled',
+      "const disallowedKeys = ['authKey', 'oidc.user:https://staging-auth-v1.raspberrypi.org:editor-api', 'oidc.user:https://auth-v1.raspberrypi.org:editor-api']",
     );
-
+    expect(generatedHtml).toContain("if (disallowedKeys.includes(key))");
     expect(generatedHtml).toContain(
-      "if (key === 'oidc.user:https://staging-auth-v1.raspberrypi.org:editor-api')",
+      'localStorage.getItem for "${key}" is disabled',
     );
-    expect(generatedHtml).toContain(
-      'localStorage.getItem for "oidc.user:https://staging-auth-v1.raspberrypi.org:editor-api" is disabled',
-    );
-
-    expect(generatedHtml).toContain(
-      "if (key === 'oidc.user:https://auth-v1.raspberrypi.org:editor-api')",
-    );
-    expect(generatedHtml).toContain(
-      'localStorage.getItem for "oidc.user:https://auth-v1.raspberrypi.org:editor-api" is disabled',
-    );
-
     expect(generatedHtml).toContain("return null;");
     expect(generatedHtml).toContain("</script>");
   });


### PR DESCRIPTION
Accessing localstorage (eg. `localstorage.getItem('authKey')`) is a potential security risk when running code that has been shared between individuals / is untrusted.

This change overrides the specific localstorage method / key access and provides feedback in the browser console.

Access to localstorage is not entirely blocked as it is used in many projects / resources eg. [Share Your World](https://projects.raspberrypi.org/en/projects/share-your-world) (https://github.com/search?q=repo%3Araspberrypilearning%2Fshare-your-world%20localstorage&type=code)

For more context, see: https://github.com/RaspberryPiFoundation/documentation/pull/112/files

***

The change can be tested by creating a new HTML project in the editor, inputting the following and inspecting the console for the output:

```
<script>
localStorage.setItem("foo", "bar")
console.log(localStorage.getItem("foo"))
localStorage.setItem("authKey", "secret")
console.log(localStorage.getItem("authKey"))
</script>
```

As demonstrated here:

![Screenshot 2024-09-25 at 11 47 54](https://github.com/user-attachments/assets/c145fc04-e2c2-4df6-bb87-5d88ee8ea5e5)
