### PR TITLE
Broaden scope of localstorage keys disallowed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
-- Disabling of `localstorage.getItem()` access to `authKey`, `oidc.user:https://staging-auth-v1.raspberrypi.org:editor-api` and `oidc.user:https://auth-v1.raspberrypi.org:editor-api` at runtime (#1079)
+- Disabling of `localstorage` access to `authKey` and `oidc.*` keys at runtime (#1079, #1080)
 
 ## [0.26.0] - 2024-09-13
 

--- a/cypress/e2e/spec-html.cy.js
+++ b/cypress/e2e/spec-html.cy.js
@@ -25,13 +25,10 @@ it("blocks access to specific localStorage keys but allows other keys", () => {
   localStorage.setItem("foo", "bar");
   localStorage.setItem("authKey", "secret");
   localStorage.setItem(
-    "oidc.user:https://staging-auth-v1.raspberrypi.org:editor-api",
-    "staging-token",
-  );
-  localStorage.setItem(
     "oidc.user:https://auth-v1.raspberrypi.org:editor-api",
-    "prod-token",
+    "token",
   );
+  localStorage.setItem("oidc.something:else", "another-token");
 
   cy.visit(baseUrl);
   cy.get(".btn--run").click();
@@ -45,13 +42,11 @@ it("blocks access to specific localStorage keys but allows other keys", () => {
       expect(authKeyResult).to.equal(null);
 
       const stagingOidcResult = win.localStorage.getItem(
-        "oidc.user:https://staging-auth-v1.raspberrypi.org:editor-api",
+        "oidc.user:https://auth-v1.raspberrypi.org:editor-api",
       );
       expect(stagingOidcResult).to.equal(null);
 
-      const prodOidcResult = win.localStorage.getItem(
-        "oidc.user:https://auth-v1.raspberrypi.org:editor-api",
-      );
+      const prodOidcResult = win.localStorage.getItem("oidc.something:else");
       expect(prodOidcResult).to.equal(null);
 
       const fooResult = win.localStorage.getItem("foo");

--- a/src/components/Editor/Runners/HtmlRunner/HtmlRunner.jsx
+++ b/src/components/Editor/Runners/HtmlRunner/HtmlRunner.jsx
@@ -302,31 +302,31 @@ function HtmlRunner() {
       const disableLocalStorageScript = `
       <script>
         (function() {
-          const disallowedKeys = ['authKey', 'oidc.user:https://staging-auth-v1.raspberrypi.org:editor-api', 'oidc.user:https://auth-v1.raspberrypi.org:editor-api'];
-
           const originalGetItem = window.localStorage.getItem.bind(window.localStorage);
           const originalSetItem = window.localStorage.setItem.bind(window.localStorage);
           const originalRemoveItem = window.localStorage.removeItem.bind(window.localStorage);
           const originalClear = window.localStorage.clear.bind(window.localStorage);
 
+          const isDisallowedKey = (key) => key === 'authKey' || key.startsWith('oidc.');
+
           Object.defineProperty(window, 'localStorage', {
             value: {
               getItem: function(key) {
-                if (disallowedKeys.includes(key)) {
+                if (isDisallowedKey(key)) {
                   console.log(\`localStorage.getItem for "\${key}" is disabled\`);
                   return null;
                 }
                 return originalGetItem(key);
               },
               setItem: function(key, value) {
-                if (disallowedKeys.includes(key)) {
+                if (isDisallowedKey(key)) {
                   console.log(\`localStorage.setItem for "\${key}" is disabled\`);
                   return;
                 }
                 return originalSetItem(key, value);
               },
               removeItem: function(key) {
-                if (disallowedKeys.includes(key)) {
+                if (isDisallowedKey(key)) {
                   console.log(\`localStorage.removeItem for "\${key}" is disabled\`);
                   return;
                 }

--- a/src/components/Editor/Runners/HtmlRunner/HtmlRunner.test.js
+++ b/src/components/Editor/Runners/HtmlRunner/HtmlRunner.test.js
@@ -299,7 +299,7 @@ describe("When run is triggered", () => {
     );
     expect(generatedHtml).toContain("if (isDisallowedKey(key))");
     expect(generatedHtml).toContain(
-      'localStorage.getItem for "${key}" is disabled',
+      'localStorage.getItem for "${key}" is disabled', // eslint-disable-line no-template-curly-in-string
     );
     expect(generatedHtml).toContain("return null;");
     expect(generatedHtml).toContain("</script>");

--- a/src/components/Editor/Runners/HtmlRunner/HtmlRunner.test.js
+++ b/src/components/Editor/Runners/HtmlRunner/HtmlRunner.test.js
@@ -295,9 +295,9 @@ describe("When run is triggered", () => {
     expect(generatedHtml).toContain("getItem: function(key) {");
 
     expect(generatedHtml).toContain(
-      "const disallowedKeys = ['authKey', 'oidc.user:https://staging-auth-v1.raspberrypi.org:editor-api', 'oidc.user:https://auth-v1.raspberrypi.org:editor-api']",
+      "const isDisallowedKey = (key) => key === 'authKey' || key.startsWith('oidc.');",
     );
-    expect(generatedHtml).toContain("if (disallowedKeys.includes(key))");
+    expect(generatedHtml).toContain("if (isDisallowedKey(key))");
     expect(generatedHtml).toContain(
       'localStorage.getItem for "${key}" is disabled',
     );


### PR DESCRIPTION
Access to all localstorage keys starting with `oidc.` will be disallowed when executing code.

Improves: https://github.com/RaspberryPiFoundation/editor-ui/pull/1079