### PR TITLE
V0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.27.0] - 2024-09-26
 
 ### Added
 
@@ -879,7 +879,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Events in Web Component indicating whether Mission Zero criteria have been met (#113)
 
-[unreleased]: https://github.com/RaspberryPiFoundation/editor-ui/compare/v0.26.0...HEAD
+[unreleased]: https://github.com/RaspberryPiFoundation/editor-ui/compare/v0.27.0...HEAD
+[0.27.0]: https://github.com/RaspberryPiFoundation/editor-ui/releases/tag/v0.27.0
 [0.26.0]: https://github.com/RaspberryPiFoundation/editor-ui/releases/tag/v0.26.0
 [0.25.5]: https://github.com/RaspberryPiFoundation/editor-ui/releases/tag/v0.25.5
 [0.25.4]: https://github.com/RaspberryPiFoundation/editor-ui/releases/tag/v0.25.4

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raspberrypifoundation/editor-ui",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "private": true,
   "dependencies": {
     "@apollo/client": "^3.7.8",


### PR DESCRIPTION
## [0.27.0] - 2024-09-26

### Added

- Disabling of `localstorage` access to `authKey` and `oidc.*` keys at runtime (#1079, #1080)