### PR TITLE
Cache `pyodide` modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - `Pyodide` `matplotlib` support (#1087)
 - Tests for running simple programs in `pyodide` and `skulpt` (#1100)
 - Fall back to `skulpt` if the host is not `crossOriginIsolated` (#1107)
+- `Pyodide` module caching (#1113)
 
 ### Changed
 

--- a/cypress/e2e/spec-wc-pyodide.cy.js
+++ b/cypress/e2e/spec-wc-pyodide.cy.js
@@ -120,4 +120,43 @@ describe("Running the code with pyodide", () => {
         "ModuleNotFoundError: No module named 'i_do_not_exist' on line 1 of main.py",
       );
   });
+
+  it("clears user-defined variables between code runs", () => {
+    runCode("a = 1\nprint(a)");
+    cy.get("editor-wc")
+      .shadow()
+      .find(".pythonrunner-console-output-line")
+      .should("contain", "1");
+    runCode("print(a)");
+    cy.get("editor-wc")
+      .shadow()
+      .find(".error-message__content")
+      .should("contain", "NameError: name 'a' is not defined");
+  });
+
+  it("clears user-defined functions between code runs", () => {
+    runCode("def my_function():\n\treturn 1\nprint(my_function())");
+    cy.get("editor-wc")
+      .shadow()
+      .find(".pythonrunner-console-output-line")
+      .should("contain", "1");
+    runCode("print(my_function())");
+    cy.get("editor-wc")
+      .shadow()
+      .find(".error-message__content")
+      .should("contain", "NameError: name 'my_function' is not defined");
+  });
+
+  it("clears user-imported modules between code runs", () => {
+    runCode("import math\nprint(math.floor(math.pi))");
+    cy.get("editor-wc")
+      .shadow()
+      .find(".pythonrunner-console-output-line")
+      .should("contain", "3");
+    runCode("print(math.floor(math.pi))");
+    cy.get("editor-wc")
+      .shadow()
+      .find(".error-message__content")
+      .should("contain", "NameError: name 'math' is not defined");
+  });
 });

--- a/src/PyodideWorker.js
+++ b/src/PyodideWorker.js
@@ -60,6 +60,12 @@ const PyodideWorker = () => {
 
   const runPython = async (python) => {
     stopped = false;
+    await pyodide.loadPackage("pyodide_http");
+
+    await pyodide.runPythonAsync(`
+    import pyodide_http
+    pyodide_http.patch_all()
+  `);
 
     try {
       await withSupportForPackages(python, async () => {
@@ -341,12 +347,8 @@ const PyodideWorker = () => {
     });
 
     pyodide = await pyodidePromise;
-    await pyodide.loadPackage("pyodide_http");
 
     await pyodide.runPythonAsync(`
-    import pyodide_http
-    pyodide_http.patch_all()
-
     __old_input__ = input
     def __patched_input__(prompt=False):
         if (prompt):

--- a/src/components/Editor/Runners/PythonRunner/PyodideRunner/PyodideWorker.test.js
+++ b/src/components/Editor/Runners/PythonRunner/PyodideRunner/PyodideWorker.test.js
@@ -96,7 +96,7 @@ describe("PyodideWorker", () => {
       },
     });
     expect(pyodide.runPythonAsync).toHaveBeenCalledWith(
-      expect.stringMatching(/__builtins__.input = patched_input/),
+      expect.stringMatching(/__builtins__.input = __patched_input__/),
     );
   });
 
@@ -178,17 +178,18 @@ describe("PyodideWorker", () => {
     });
   });
 
-  test("it reloads pyodide after running the code", async () => {
-    global.loadPyodide.mockClear();
+  test("it clears the pyodide variables after running the code", async () => {
     await worker.onmessage({
       data: {
         method: "runPython",
         python: "print('hello')",
       },
     });
-    await waitFor(() => {
-      expect(global.loadPyodide).toHaveBeenCalled();
-    });
+    await waitFor(() =>
+      expect(pyodide.runPythonAsync).toHaveBeenCalledWith(
+        expect.stringContaining("del globals()[name]"),
+      ),
+    );
   });
 
   test("it handles stopping by notifying component of an error", async () => {


### PR DESCRIPTION
Refactored the `PyodideWorker` so that `pyodide` is not completely reloaded on each code run, but rather the globals representing user-defined variables and user-imported modules are cleared. This allows the modules that have already been loaded into `pyodide` to be cached, massively reducing the latency on subsequent code runs.