### PR TITLE
v0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-### Changed
-
-- Updated the ImportErrors message
-- In ErrorMessage component added the way to display html elements in string
+## [0.28.0] - 2024-10-22 
 
 ### Added
 
@@ -25,6 +22,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Upgrade to `webpack 5` (#1096)
 - Bump `pyodide` to `v0.26.2` (#1098)
+- Updated the ImportErrors message (#1105)
+- In ErrorMessage component added the way to display html elements in string (#1105)
 
 ### Fixed
 
@@ -917,7 +916,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Events in Web Component indicating whether Mission Zero criteria have been met (#113)
 
-[unreleased]: https://github.com/RaspberryPiFoundation/editor-ui/compare/v0.27.1...HEAD
+[unreleased]: https://github.com/RaspberryPiFoundation/editor-ui/compare/v0.28.0...HEAD
+[0.28.0]: https://github.com/RaspberryPiFoundation/editor-ui/releases/tag/v0.28.0
 [0.27.1]: https://github.com/RaspberryPiFoundation/editor-ui/releases/tag/v0.27.1
 [0.27.0]: https://github.com/RaspberryPiFoundation/editor-ui/releases/tag/v0.27.0
 [0.26.0]: https://github.com/RaspberryPiFoundation/editor-ui/releases/tag/v0.26.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raspberrypifoundation/editor-ui",
-  "version": "0.27.1",
+  "version": "0.28.0",
   "private": true,
   "dependencies": {
     "@apollo/client": "^3.7.8",


### PR DESCRIPTION
## [0.28.0] - 2024-10-22 

### Added

- PyodideWorker setup for the editor (#1104)
- Enabling `pyodide` support in the web component (#1090)
- `Pyodide` `matplotlib` support (#1087)
- Tests for running simple programs in `pyodide` and `skulpt` (#1100)
- Fall back to `skulpt` if the host is not `crossOriginIsolated` (#1107)
- `Pyodide` `seaborn` support (#1106)
- `Pyodide` module caching (#1113)

### Changed

- Upgrade to `webpack 5` (#1096)
- Bump `pyodide` to `v0.26.2` (#1098)
- Updated the ImportErrors message (#1105)
- In ErrorMessage component added the way to display html elements in string (#1105)

### Fixed

- Dynamic runner switching with more than one `python` file (#1097)
- Pyodide running the correct file (`main.py`) when there are multiple `python` files (#1097)
- Build to include public files (#1112)
- Persisting choice of tabbed/split view when running `python` code (#1114)