### PR TITLE
Check loadRemixDisabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.28.9] - 2024-11-27
 
 ### Fixed
 
@@ -987,7 +987,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Events in Web Component indicating whether Mission Zero criteria have been met (#113)
 
-[unreleased]: https://github.com/RaspberryPiFoundation/editor-ui/compare/v0.28.8...HEAD
+[unreleased]: https://github.com/RaspberryPiFoundation/editor-ui/compare/v0.28.9...HEAD
+[0.28.9]: https://github.com/RaspberryPiFoundation/editor-ui/releases/tag/v0.28.9
 [0.28.8]: https://github.com/RaspberryPiFoundation/editor-ui/releases/tag/v0.28.8
 [0.28.7]: https://github.com/RaspberryPiFoundation/editor-ui/releases/tag/v0.28.7
 [0.28.6]: https://github.com/RaspberryPiFoundation/editor-ui/releases/tag/v0.28.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Fixed
+
+- Auto loading remixes when loadRemixDisabled is explicitly set (#1145)
+
 ## [0.28.8] - 2024-11-21
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raspberrypifoundation/editor-ui",
-  "version": "0.28.8",
+  "version": "0.28.9",
   "private": true,
   "dependencies": {
     "@apollo/client": "^3.7.8",

--- a/src/containers/WebComponentLoader.jsx
+++ b/src/containers/WebComponentLoader.jsx
@@ -137,6 +137,7 @@ const WebComponentLoader = (props) => {
     justLoaded,
     hasShownSavePrompt: hasShownSavePrompt || !showSavePrompt,
     saveTriggered,
+    loadRemix: loadRemix && !loadRemixDisabled,
   });
 
   useEffect(() => {

--- a/src/containers/WebComponentLoader.test.js
+++ b/src/containers/WebComponentLoader.test.js
@@ -200,6 +200,7 @@ describe("When no user is in state", () => {
         project: {
           components: [],
         },
+        loadRemix: false,
         hasShownSavePrompt: true,
         justLoaded: false,
         user: null,
@@ -337,6 +338,7 @@ describe("When no user is in state", () => {
       expect(useProjectPersistence).toHaveBeenCalledWith({
         user,
         project: { components: [] },
+        loadRemix: true,
         hasShownSavePrompt: true,
         justLoaded: false,
         saveTriggered: false,
@@ -496,6 +498,7 @@ describe("When user is in state", () => {
           reactAppApiEndpoint: "http://localhost:3009",
           user,
           project: { components: [] },
+          loadRemix: true,
           hasShownSavePrompt: true,
           justLoaded: false,
           saveTriggered: false,

--- a/src/hooks/useProjectPersistence.js
+++ b/src/hooks/useProjectPersistence.js
@@ -17,7 +17,7 @@ export const useProjectPersistence = ({
   hasShownSavePrompt,
   saveTriggered,
   reactAppApiEndpoint,
-  loadRemix = false,
+  loadRemix = true,
 }) => {
   const dispatch = useDispatch();
 
@@ -72,7 +72,7 @@ export const useProjectPersistence = ({
       }
     };
     saveProject();
-  }, [saveTriggered, project, user, dispatch, reactAppApiEndpoint]);
+  }, [saveTriggered, project, user, dispatch, reactAppApiEndpoint, loadRemix]);
 
   useEffect(() => {
     let debouncer = setTimeout(() => {

--- a/src/hooks/useProjectPersistence.js
+++ b/src/hooks/useProjectPersistence.js
@@ -17,6 +17,7 @@ export const useProjectPersistence = ({
   hasShownSavePrompt,
   saveTriggered,
   reactAppApiEndpoint,
+  loadRemix = false,
 }) => {
   const dispatch = useDispatch();
 
@@ -56,13 +57,15 @@ export const useProjectPersistence = ({
               }),
             );
             // Ensure the remixed project is loaded, otherwise we'll get in a mess
-            dispatch(
-              syncProject("loadRemix")({
-                reactAppApiEndpoint,
-                identifier: project.identifier,
-                accessToken: user.access_token,
-              }),
-            );
+            if (loadRemix) {
+              dispatch(
+                syncProject("loadRemix")({
+                  reactAppApiEndpoint,
+                  identifier: project.identifier,
+                  accessToken: user.access_token,
+                }),
+              );
+            }
           }
           localStorage.removeItem("awaitingSave");
         }

--- a/src/hooks/useProjectPersistence.test.js
+++ b/src/hooks/useProjectPersistence.test.js
@@ -248,6 +248,35 @@ describe("When logged in", () => {
       });
     });
 
+    describe("When project has identifier and save triggered without loadRemix", () => {
+      beforeEach(() => {
+        syncProject.mockImplementationOnce(jest.fn((_) => remixProject));
+        syncProject.mockImplementationOnce(jest.fn((_) => loadProject));
+
+        renderHook(() =>
+          useProjectPersistence({
+            user: user2,
+            project: project,
+            saveTriggered: true,
+            loadRemix: false,
+          }),
+        );
+        jest.runAllTimers();
+      });
+
+      test("Clicking save dispatches remixProject with correct parameters", async () => {
+        await expect(remixProject).toHaveBeenCalledWith({
+          project: project,
+          accessToken: user2.access_token,
+        });
+      });
+
+      test("loadRemix is not dispatched after project is remixed", async () => {
+        await remixProject();
+        await expect(loadProject).not.toHaveBeenCalled();
+      });
+    });
+
     describe("When project has no identifier and awaiting save", () => {
       beforeEach(() => {
         localStorage.setItem("awaitingSave", "true");


### PR DESCRIPTION
Initial attempt at a fix for auto loading remixes when we explicitly don't want to to avoid editor projects remixing, loading the remix then causing a url changed based off the load rather than remix response