### PR TITLE
Fix p5 run errors

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,7 @@
 
   // The 'service' property is the name of the service for the container that VS Code should
   // use. Update this value and .devcontainer/docker-compose.yml to the real service name.
-  "service": "react-ui",
+  "service": "app",
 
   // The optional 'workspaceFolder' property is the path VS Code should open by default when
   // connected. This is typically a file mount in .devcontainer/docker-compose.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Enable p5 code to be ran multiple times without runner errors (#1147)
+
 ## [0.28.9] - 2024-11-27
 
 ### Fixed

--- a/src/components/Editor/Runners/PythonRunner/SkulptRunner/SkulptRunner.jsx
+++ b/src/components/Editor/Runners/PythonRunner/SkulptRunner/SkulptRunner.jsx
@@ -106,8 +106,6 @@ const SkulptRunner = ({ active, outputPanels = ["text", "visual"] }) => {
     if (active) {
       if (codeRunTriggered) {
         runCode();
-      } else if (!senseHatAlwaysEnabled) {
-        setCodeHasVisualOutput(false);
       }
     }
   }, [codeRunTriggered, active]);
@@ -403,7 +401,6 @@ const SkulptRunner = ({ active, outputPanels = ["text", "visual"] }) => {
       })
       .finally(() => {
         dispatch(codeRunHandled());
-        setCodeHasVisualOutput(false);
       });
     myPromise.then(function (_mod) {});
   };


### PR DESCRIPTION
Reported that when running p5 code more than once the runner breaks and errors.

This remove setting visualOutput to false and uses initial state and rerenders to set the correct visual output behaviour.

This is still dynamic and works well when adding code that requires visualisation as well as always showing for the sense hat model