### PR TITLE
Fix dark mode selection highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Fixed
+
+- Selected text background colour contrast in editor dark mode (#1150)
+
+### Changed
+
+- Toned down the match highlighting colour in editor dark mode (#1150)
+
 ## [0.28.11] - 2024-12-03
 
 ### Fixed

--- a/src/assets/themes/editorDarkTheme.js
+++ b/src/assets/themes/editorDarkTheme.js
@@ -42,5 +42,5 @@ export const editorDarkTheme = EditorView.theme(
     ".ͼj": { color: "#9EE8FF" },
     ".ͼm": { color: "#FFCA99" },
   },
-  { dark: true }
+  { dark: true },
 );

--- a/src/assets/themes/editorDarkTheme.js
+++ b/src/assets/themes/editorDarkTheme.js
@@ -20,6 +20,9 @@ export const editorDarkTheme = EditorView.theme(
     "&.cm-focused.ͼ3 .cm-selectionLayer .cm-selectionBackground": {
       backgroundColor: "#144866",
     },
+    ".cm-selectionMatch": {
+      backgroundColor: "rgba(153, 255, 119, 0.2)",
+    },
     "&.cm-focused .cm-cursor": {
       borderLeftColor: "white",
     },

--- a/src/assets/themes/editorDarkTheme.js
+++ b/src/assets/themes/editorDarkTheme.js
@@ -17,8 +17,8 @@ export const editorDarkTheme = EditorView.theme(
       "background-color": "inherit",
       color: "inherit",
     },
-    "&.cm-focused .cm-selectionBackground, ::selection": {
-      background: "#144866",
+    "&.cm-focused.ͼ3 .cm-selectionLayer .cm-selectionBackground": {
+      backgroundColor: "#144866",
     },
     "&.cm-focused .cm-cursor": {
       borderLeftColor: "white",
@@ -42,5 +42,5 @@ export const editorDarkTheme = EditorView.theme(
     ".ͼj": { color: "#9EE8FF" },
     ".ͼm": { color: "#FFCA99" },
   },
-  { dark: true },
+  { dark: true }
 );


### PR DESCRIPTION
- Fixed the selector specificity for selected text in the editor
- Toned down the match highlighting

### Before
![Screenshot 2024-12-05 at 14 31 10](https://github.com/user-attachments/assets/3a9fef84-8c1a-4884-a36e-9aae03fcf897)

### After
![Screenshot 2024-12-05 at 14 19 57](https://github.com/user-attachments/assets/c25aa412-8feb-4737-8295-05c7c2b6a8bd)
