### PR TITLE
Check instructions length before setting option value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fixed sidebar not correctly reopening (#1196)
+
 ## [0.29.0] - 2025-02-06
 
 ### Added

--- a/src/components/Menus/Sidebar/SidebarBar.jsx
+++ b/src/components/Menus/Sidebar/SidebarBar.jsx
@@ -25,10 +25,7 @@ const SidebarBar = (props) => {
   const isMobile = useMediaQuery({ query: MOBILE_MEDIA_QUERY });
 
   const expandPopOut = () => {
-    let option = "file";
-    if (instructions.length > 0) {
-      option = "instructions";
-    }
+    const option = instructions.length > 0 ? "instructions" : "file";
     toggleOption(option);
     if (window.plausible) {
       // TODO: Make dynamic events for each option or rename this event

--- a/src/components/Menus/Sidebar/SidebarBar.jsx
+++ b/src/components/Menus/Sidebar/SidebarBar.jsx
@@ -25,7 +25,10 @@ const SidebarBar = (props) => {
   const isMobile = useMediaQuery({ query: MOBILE_MEDIA_QUERY });
 
   const expandPopOut = () => {
-    const option = instructions ? "instructions" : "file";
+    let option = "file";
+    if (instructions.length > 0) {
+      option = "instructions";
+    }
     toggleOption(option);
     if (window.plausible) {
       // TODO: Make dynamic events for each option or rename this event

--- a/src/components/Menus/Sidebar/SidebarBar.test.js
+++ b/src/components/Menus/Sidebar/SidebarBar.test.js
@@ -73,7 +73,13 @@ describe("SidebarBar", () => {
           <SidebarBar
             menuOptions={menuOptions(true)}
             toggleOption={toggleOption}
-            instructions
+            instructions={[
+              {
+                title: "My testing title",
+                content: "My testing content",
+                quiz: false,
+              },
+            ]}
           />
         </Provider>,
       );


### PR DESCRIPTION
[closes](https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/443)

I found that `const option = instructions ? "instructions" : "file";` was always being set to true because it was receiving an empty array