### PR TITLE
Fixing the append file write mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Bugs in append mode for writing to files in python (#1200)
+
 ## [0.29.1] - 2025-02-21
 
 ### Fixed

--- a/src/PyodideWorker.js
+++ b/src/PyodideWorker.js
@@ -116,7 +116,7 @@ const PyodideWorker = () => {
                       self.content += content
                       if len(self.content) > MAX_FILE_SIZE:
                           raise OSError(f"File '{self.filename}' exceeds maximum file size of {MAX_FILE_SIZE} bytes")
-                      with _original_open(self.filename, "w") as f:
+                      with _original_open(self.filename, mode) as f:
                           f.write(self.content)
                       basthon.kernel.write_file({ "filename": self.filename, "content": self.content, "mode": mode })
 

--- a/src/components/Editor/Runners/PythonRunner/PyodideRunner/PyodideRunner.jsx
+++ b/src/components/Editor/Runners/PythonRunner/PyodideRunner/PyodideRunner.jsx
@@ -223,7 +223,7 @@ const PyodideRunner = ({ active, outputPanels = ["text", "visual"] }) => {
       updatedContent = content;
     } else if (mode === "a") {
       updatedContent =
-        (componentToUpdate ? componentToUpdate.content + "\n" : "") + content;
+        (componentToUpdate ? componentToUpdate.content : "") + content;
     }
 
     if (componentToUpdate) {

--- a/src/components/Editor/Runners/PythonRunner/PyodideRunner/PyodideRunner.test.js
+++ b/src/components/Editor/Runners/PythonRunner/PyodideRunner/PyodideRunner.test.js
@@ -307,7 +307,7 @@ describe("When file write event is received", () => {
     worker.postMessageFromWorker({
       method: "handleFileWrite",
       filename: "existing_file.txt",
-      content: "new content",
+      content: "\nnew content",
       mode: "a",
     });
     expect(dispatchSpy).toHaveBeenCalledWith({
@@ -364,7 +364,7 @@ describe("When file write event is received", () => {
     worker.postMessageFromWorker({
       method: "handleFileWrite",
       filename: "existing_file.txt",
-      content: "new content",
+      content: "\nnew content",
       mode: "a",
     });
     expect(dispatchSpy).toHaveBeenCalledWith({


### PR DESCRIPTION
## What's Changed?

- Fixed the mode on the `pyodide` side - it was always using `w` rather than the mode provided in the code
- Fixed the file write append mode on the frontend - it was incorrectly adding a newline character before anything was appended.