### PR TITLE
fix: showing scrollbar even when there is no overflow in sidebar

### DIFF
--- a/src/assets/stylesheets/Sidebar.scss
+++ b/src/assets/stylesheets/Sidebar.scss
@@ -127,7 +127,7 @@
 .sidebar__panel-content {
   flex: 1;
   padding: $space-1 0;
-  overflow-y: scroll;
+  overflow-y: auto;
   scrollbar-width: thin;
 }
 


### PR DESCRIPTION
## Summary

Fix issue introduced in [here](https://github.com/RaspberryPiFoundation/editor-ui/pull/1216/files#diff-ca3efa6151de5b9eb9e9ec3815456a513b350a25fa6e7819a647bc503bf670bdL131),

Perm scrollbars:
![Screenshot 2025-06-17 at 15 45 31](https://github.com/user-attachments/assets/ab6e886b-137c-4cfe-a2f4-412823bdd9b2)

Auto should mean that scrollbar is only shown when needed