### PR TITLE
fix: login to save button overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Change tab `block-size` to `min-block-size` to allow for height increase when text wraps (#1219)
 - Changed `SkulptRunner.jsx` implementation of hiding elements to use `display: none` rather than `block-size: 0` (#1219)
 - Enabled `hyphens: auto` globally (with exceptions) to prevent overflow with longer words (#1215)
+- Removed fixed size from `ProjectBar` to prevent overflow when text wraps (#1221)
+
+## Changed
+
+- Improved status bar styling (#1221)
 
 ## [0.30.1] - 2025-06-09
 

--- a/src/assets/stylesheets/ProjectBar.scss
+++ b/src/assets/stylesheets/ProjectBar.scss
@@ -6,7 +6,6 @@
   display: flex;
   align-items: center;
   z-index: 1;
-  block-size: $space-4;
   container-type: inline-size;
   background-color: var(--editor-color-layer-3);
   border: 1px solid var(--editor-color-outline);
@@ -39,6 +38,7 @@
   }
 
   .project-bar__btn-wrapper {
+    display: flex;
     block-size:  100%;
   }
 

--- a/src/assets/stylesheets/SaveStatus.scss
+++ b/src/assets/stylesheets/SaveStatus.scss
@@ -5,7 +5,7 @@
 .save-status {
   align-items: center;
   display: flex;
-  gap: $space-0-25;
+  gap: var(--space-1);
   justify-content: flex-end;
   margin-block: 0;
   padding-inline: var(--space-2);
@@ -14,6 +14,7 @@
 .save-status--mobile {
   margin: unset;
   padding-inline: 0;
+  gap: var(--space-0-5);
 
   .save-status__text {
     @include font-size-0-75(regular);

--- a/src/assets/stylesheets/SaveStatus.scss
+++ b/src/assets/stylesheets/SaveStatus.scss
@@ -8,7 +8,7 @@
   gap: $space-0-25;
   justify-content: flex-end;
   margin-block: 0;
-  padding-inline: var(--space-1);
+  padding-inline: var(--space-2);
 }
 
 .save-status--mobile {


### PR DESCRIPTION
## Summary

- Removed fixed ProjectBar height to allow button it to grow if needed
- Centre aligned buttons
- Tweak save status space for better aesthetics when wrapping (and in general)

## Demo

**English**

https://github.com/user-attachments/assets/e0539516-ccaf-4281-8ce6-c9b348c11237

**German / Longer text (logged out)**

https://github.com/user-attachments/assets/825e46dc-4d72-4c42-b289-05fd2cc472b3

**German / Longer text (logged in)**

https://github.com/user-attachments/assets/002d7a18-fc24-4241-b222-1d47b3f0e868

## Other

Did consider changing the text box to fill available space but decided against it.

![image](https://github.com/user-attachments/assets/f82565da-18eb-4125-bb97-f849cd9d393b)



