### PR TITLE
fix: image gallery capitalisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Removed fixed size from `ProjectBar` to prevent overflow when text wraps (#1221)
 - Added missing translation strings (#1222)
 - CrowdIn issue for pluralised strings with no `one` version (#1234)
+- Update `imagePanel.gallery` string to remove Title Casing for consistency (#1238)
+
+### Removed
+
+- Remove unused translation string `filePanel.images` (#1238)
 
 ## [0.30.1] - 2025-06-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added missing translation strings (#1222)
 - CrowdIn issue for pluralised strings with no `one` version (#1234)
 - Update `imagePanel.gallery` string to remove Title Casing for consistency (#1238)
+- Update `imageUploadButton.uploadImage` string to remove Title Casing for consistency (#1238)
 
 ### Removed
 

--- a/public/translations/en.json
+++ b/public/translations/en.json
@@ -237,7 +237,7 @@
     "failed": "Load failed"
   },
   "imageUploadButton": {
-    "uploadImage": "Upload Image",
+    "uploadImage": "Upload image",
     "uploadAnImage": "Upload an image",
     "info": "Drag and drop images here, or click to select images from file",
     "cancel": "Cancel",

--- a/public/translations/en.json
+++ b/public/translations/en.json
@@ -73,7 +73,7 @@
     "loginToSave": "Log in to save"
   },
   "imagePanel": {
-    "gallery": "Image Gallery"
+    "gallery": "Image gallery"
   },
   "infoPanel": {
     "info": "Information"

--- a/public/translations/en.json
+++ b/public/translations/en.json
@@ -26,7 +26,6 @@
       "unsupportedExtension": "File names must end in {{allowedExtensions}}."
     },
     "files": "Project files",
-    "images": "Image gallery",
     "newFileButton": "Add file",
     "newFileModal": {
       "cancel": "Cancel",

--- a/public/translations/xx-XX.json
+++ b/public/translations/xx-XX.json
@@ -25,7 +25,6 @@
       "unsupportedExtension": "Dateinamen müssen mit {{allowedExtensions}} enden."
     },
     "files": "Projektdateien",
-    "images": "Bildergalerie",
     "newFileButton": "Datei hinzufügen",
     "newFileModal": {
       "cancel": "Abbrechen",


### PR DESCRIPTION
closes https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/808

## Summary

- Updated `imagePanel.gallery` to sentence case
- Updated `imageUploadButton.uploadImage` to sentence case
- Removed unused string (I found while searching)

## Notes

Unused string:

<img width="408" height="162" alt="Screenshot 2025-07-29 at 17 01 34" src="https://github.com/user-attachments/assets/8adc7a44-535d-467e-bb4a-42386eff900a" />
