### PR TITLE
Set selectionMatch to be transparent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Issue where clicking the tick icon would not save a filename when editing (#1237)
 
+### Changed
+
+- Set selectionMatch to be transpartent so not all instances of a word are highlighted when selected(#1239)
+
 ## [0.30.2] - 2025-07-22
 
 ### Fixed

--- a/src/assets/themes/editorDarkTheme.js
+++ b/src/assets/themes/editorDarkTheme.js
@@ -21,7 +21,7 @@ export const editorDarkTheme = EditorView.theme(
       backgroundColor: "#144866",
     },
     ".cm-selectionMatch": {
-      backgroundColor: "rgba(153, 255, 119, 0.2)",
+      backgroundColor: "transparent",
     },
     "&.cm-focused .cm-cursor": {
       borderLeftColor: "white",

--- a/src/assets/themes/editorLightTheme.js
+++ b/src/assets/themes/editorLightTheme.js
@@ -22,6 +22,9 @@ export const editorLightTheme = EditorView.theme(
         "border-inline-start": "solid grey",
       },
     },
+    ".cm-selectionMatch": {
+      backgroundColor: "transparent",
+    },
     ".ͼf": { color: "#AA1111" },
   },
   { dark: false },


### PR DESCRIPTION
closes https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/721