### PR TITLE
Automatically close stale issue and PRs

### DIFF
--- a/.github/workflows/close_stale_issues_and_prs.yml
+++ b/.github/workflows/close_stale_issues_and_prs.yml
@@ -1,0 +1,19 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 2 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v10
+        with:
+          stale-issue-message: 'This issue is stale because it has been open for 90 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
+          stale-pr-message: 'This PR is stale because it has been open for 30 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
+          close-issue-message: 'This issue was closed because it has been open for more than 90 days with no activity.'
+          close-pr-message: 'This PR was closed because it has been open for more than 30 days with no activity.'
+          days-before-issue-stale: 90
+          days-before-pr-stale: 30
+          days-before-issue-close: 7
+          days-before-pr-close: 7


### PR DESCRIPTION
We have a backlog of old issues and PRs which make it harder to report on outstanding PRs and issues. By using this script, we will remove the backlog of old PRs and issues and keep on top them.

