### PR TITLE
Fix permissions on stale PR and issue action

### DIFF
--- a/.github/workflows/close_stale_issues_and_prs.yml
+++ b/.github/workflows/close_stale_issues_and_prs.yml
@@ -2,6 +2,7 @@ name: 'Close stale issues and PRs'
 on:
   schedule:
     - cron: '30 2 * * *'
+  workflow_dispatch:
 
 permissions:
   actions: write


### PR DESCRIPTION
It failed to run because it could not update issues or PRs. Add the correct permissions as documented at https://github.com/actions/stale?tab=readme-ov-file#recommended-permissions

Also change configuration so it can be run manually instead of waiting for a day to test.