### PR TITLE
Make dependabot PRs pass

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -148,15 +148,6 @@ jobs:
           REACT_APP_SENTRY_DSN: ${{ inputs.react_app_sentry_dsn }}
           REACT_APP_SENTRY_ENV: ${{ inputs.react_app_sentry_env }}
 
-      - name: Install AWS CLI v2.22.35
-        if: env.AWS_SECRET_ACCESS_KEY != ''
-        run: |
-          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.22.35.zip" -o "awscliv2.zip"
-          unzip awscliv2.zip
-          sudo ./aws/install --update
-        env:
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
       - name: Deploy site to S3 bucket
         if: env.AWS_SECRET_ACCESS_KEY != ''
         run: aws s3 sync ./build/ s3://${{ secrets.AWS_S3_BUCKET }}/${{ needs.setup-environment.outputs.deploy_dir }} --endpoint ${{ secrets.AWS_ENDPOINT }}


### PR DESCRIPTION
Currently dependabot PRs (and presumably other external PRs) don't have the credentials to deploy the site, so the 'build-deploy' step fails.

Update the script so that the build step can still pass (which is valuable as many of the updates are for items used in our build). We can check deployments in staging after merging/before promoting if we think it's important.

There's different approaches we could take for this in the future - such as give dependabot access to the secrets (which has some risk if items haven't been approved) or it should be possible to give access to secrets when the PR is approved.