### PR TITLE
Improve the look of editor preview

### DIFF
--- a/src/web-component.html
+++ b/src/web-component.html
@@ -101,6 +101,7 @@
         
         newWebComp.setAttribute("with_projectbar", "true");
         newWebComp.setAttribute("with_sidebar", "true");
+        newWebComp.setAttribute("use_editor_styles", "true");
         newWebComp.setAttribute(
           "sidebar_options",
           JSON.stringify([


### PR DESCRIPTION
Use the with_editor_styles setting by default.

The editor looks broken without these styles - items with poor contrast and elements without the correct padding.

In the longer term we may want to have a simpler 'default' styling that looks good.

As before you can still configure use_editor_styles it by using a URL param if you want to see the editor without styles.

|before|after|
|---|---|
|<img width="2732" height="2048" alt="localhost_3011_web-component html(iPad Pro) (2)" src="https://github.com/user-attachments/assets/08df2996-027b-4508-8bc4-b5553146a84b" />|<img width="2732" height="2048" alt="localhost_3011_web-component html(iPad Pro)" src="https://github.com/user-attachments/assets/49de88d3-3c7b-4a59-a6fb-db00ac1d4d7f" />|
