### PR TITLE
Only deploy to staging if tests pass

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -131,6 +131,7 @@ jobs:
 
   deploy-main:
     if: github.ref_type == 'branch' && github.ref_name == 'main'
+    needs: [lint, test, test-cypress]
     uses: ./.github/workflows/deploy.yml
     with:
       environment: staging


### PR DESCRIPTION
I recently changed our github branch setting to allow merges without the branch being up to date with main as this made merging branches harder and take more time. This increases the risks of test failing on main due to behaviour conflicts after merging.

Because of this, it would be safer to block deploys if the tests fail.

I've decided not to have this check to the deploy branch job as it's helpful to get this deployed and usable on a PR even if there are some errors in the build.