### PR TITLE
1146 sidebar state mismatch on layout switch

### DIFF
--- a/src/components/Menus/Sidebar/Sidebar.jsx
+++ b/src/components/Menus/Sidebar/Sidebar.jsx
@@ -152,28 +152,30 @@ const Sidebar = ({ options = [], plugins = [] }) => {
     return defaultOption;
   };
 
-  const [option, setOption] = useState(() => {
-    const selectedTab = resolveSelectedOption();
-    return selectedTab; // Start with sidebar open by default
-  });
+  // Store the initial selected tab to handle first render timing
+  const [initialSelectedTab] = useState(() => resolveSelectedOption());
+  const [isOpen, setIsOpen] = useState(true);
+
+  // Derive option from open state and selected tab
+  const option = isOpen ? selectedSidebarTab || initialSelectedTab : null;
 
   const hasInstructions = instructionsSteps && instructionsSteps.length > 0;
 
   useEffect(() => {
     if (!autoOpenPlugin && (instructionsEditable || hasInstructions)) {
       dispatch(setSelectedSidebarTab("instructions"));
-      setOption("instructions");
+      setIsOpen(true);
     }
   }, [autoOpenPlugin, instructionsEditable, hasInstructions, dispatch]);
 
   const toggleOption = (newOption) => {
     if (option !== newOption) {
       // Switch to different sidebar panel
-      setOption(newOption);
       dispatch(setSelectedSidebarTab(newOption));
+      setIsOpen(true);
     } else if (!isMobile) {
       // Desktop: clicking same option toggles sidebar open/closed
-      setOption(option === null ? newOption : null);
+      setIsOpen(!isOpen);
     } else {
       // Mobile: clicking same option does nothing (no toggle behavior)
       return;

--- a/src/components/Menus/Sidebar/Sidebar.jsx
+++ b/src/components/Menus/Sidebar/Sidebar.jsx
@@ -23,7 +23,7 @@ import { MOBILE_MEDIA_QUERY } from "../../../utils/mediaQueryBreakpoints";
 import FileIcon from "../../../utils/FileIcon";
 import DownloadPanel from "./DownloadPanel/DownloadPanel";
 import InstructionsPanel from "./InstructionsPanel/InstructionsPanel";
-import { setSidebarOption } from "../../../redux/EditorSlice";
+import { setSelectedSidebarTab } from "../../../redux/EditorSlice";
 import SidebarPanel from "./SidebarPanel";
 
 const Sidebar = ({ options = [], plugins = [] }) => {
@@ -113,8 +113,8 @@ const Sidebar = ({ options = [], plugins = [] }) => {
   const instructionsEditable = useSelector(
     (state) => state.editor.instructionsEditable,
   );
-  const storedSidebarOption = useSelector(
-    (state) => state.editor.sidebarOption,
+  const selectedSidebarTab = useSelector(
+    (state) => state.editor.selectedSidebarTab,
   );
 
   const removeOption = (optionName, depArray = []) => {
@@ -137,10 +137,10 @@ const Sidebar = ({ options = [], plugins = [] }) => {
   // Use stored option if it exists and is valid, otherwise use default logic
   const resolveSelectedOption = () => {
     if (
-      storedSidebarOption &&
-      menuOptions.find((opt) => opt.name === storedSidebarOption)
+      selectedSidebarTab &&
+      menuOptions.find((opt) => opt.name === selectedSidebarTab)
     ) {
-      return storedSidebarOption;
+      return selectedSidebarTab;
     }
     // Calculate default
     const defaultOption = autoOpenPlugin
@@ -148,36 +148,36 @@ const Sidebar = ({ options = [], plugins = [] }) => {
       : instructionsEditable || instructionsSteps
       ? "instructions"
       : "file";
-    dispatch(setSidebarOption(defaultOption));
+    dispatch(setSelectedSidebarTab(defaultOption));
     return defaultOption;
   };
 
-  const [option, setOption] = useState(resolveSelectedOption);
+  const [option, setOption] = useState(() => {
+    const selectedTab = resolveSelectedOption();
+    return selectedTab; // Start with sidebar open by default
+  });
 
   const hasInstructions = instructionsSteps && instructionsSteps.length > 0;
 
   useEffect(() => {
     if (!autoOpenPlugin && (instructionsEditable || hasInstructions)) {
+      dispatch(setSelectedSidebarTab("instructions"));
       setOption("instructions");
-      dispatch(setSidebarOption("instructions"));
     }
   }, [autoOpenPlugin, instructionsEditable, hasInstructions, dispatch]);
 
   const toggleOption = (newOption) => {
-    let nextOption;
     if (option !== newOption) {
       // Switch to different sidebar panel
-      nextOption = newOption;
-      setOption(nextOption);
+      setOption(newOption);
+      dispatch(setSelectedSidebarTab(newOption));
     } else if (!isMobile) {
-      // Desktop: clicking same option toggles sidebar closed
-      nextOption = null;
-      setOption(nextOption);
+      // Desktop: clicking same option toggles sidebar open/closed
+      setOption(option === null ? newOption : null);
     } else {
       // Mobile: clicking same option does nothing (no toggle behavior)
       return;
     }
-    dispatch(setSidebarOption(nextOption));
   };
 
   const optionDict = menuOptions.find((menuOption) => {

--- a/src/components/Menus/Sidebar/Sidebar.test.js
+++ b/src/components/Menus/Sidebar/Sidebar.test.js
@@ -331,7 +331,7 @@ describe("Redux sidebar state persistence", () => {
             image_list: [],
           },
           instructionsEditable: false,
-          sidebarOption: null,
+          selectedSidebarTab: null,
         },
         instructions: {},
       };

--- a/src/components/Menus/Sidebar/Sidebar.test.js
+++ b/src/components/Menus/Sidebar/Sidebar.test.js
@@ -345,12 +345,12 @@ describe("Redux sidebar state persistence", () => {
       );
     });
 
-    test("Dispatches setSidebarOption with default value", () => {
+    test("Dispatches setSelectedSidebarTab with default value", () => {
       const actions = store.getActions();
       expect(actions).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            type: "editor/setSidebarOption",
+            type: "editor/setSelectedSidebarTab",
             payload: "file", // Default when no special conditions are met
           }),
         ]),
@@ -369,7 +369,7 @@ describe("Redux sidebar state persistence", () => {
             image_list: images,
           },
           instructionsEditable: false,
-          sidebarOption: "images",
+          selectedSidebarTab: "images",
         },
         instructions: {},
       };
@@ -387,11 +387,11 @@ describe("Redux sidebar state persistence", () => {
       expect(screen.queryByText("imagePanel.gallery")).toBeInTheDocument();
     });
 
-    test("Does not dispatch setSidebarOption when using valid stored option", () => {
-      const setSidebarActions = store
+    test("Does not dispatch setSelectedSidebarTab when using valid stored option", () => {
+      const setSelectedSidebarActions = store
         .getActions()
-        .filter((action) => action.type === "editor/setSidebarOption");
-      expect(setSidebarActions).toHaveLength(0);
+        .filter((action) => action.type === "editor/setSelectedSidebarTab");
+      expect(setSelectedSidebarActions).toHaveLength(0);
     });
   });
 
@@ -406,7 +406,7 @@ describe("Redux sidebar state persistence", () => {
             image_list: images,
           },
           instructionsEditable: false,
-          sidebarOption: "file",
+          selectedSidebarTab: "file",
         },
         instructions: {},
       };
@@ -428,7 +428,7 @@ describe("Redux sidebar state persistence", () => {
       expect(actions).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            type: "editor/setSidebarOption",
+            type: "editor/setSelectedSidebarTab",
             payload: "images",
           }),
         ]),
@@ -445,7 +445,7 @@ describe("When plugins are provided", () => {
         image_list: [],
       },
       instructionsEditable: false,
-      sidebarOption: null,
+      selectedSidebarTab: null,
     },
     instructions: {},
   };
@@ -488,7 +488,7 @@ describe("When plugins are provided", () => {
       expect(actions).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            type: "editor/setSidebarOption",
+            type: "editor/setSelectedSidebarTab",
             payload: "my-amazing-plugin",
           }),
         ]),

--- a/src/components/Menus/Sidebar/SidebarBar.jsx
+++ b/src/components/Menus/Sidebar/SidebarBar.jsx
@@ -24,9 +24,15 @@ const SidebarBar = (props) => {
   );
   const isMobile = useMediaQuery({ query: MOBILE_MEDIA_QUERY });
 
+  const selectedSidebarTab = useSelector(
+    (state) => state.editor.selectedSidebarTab,
+  );
+
   const expandPopOut = () => {
-    const option = instructions.length > 0 ? "instructions" : "file";
-    toggleOption(option);
+    // Use stored option if available, otherwise fall back to default logic
+    const optionToExpand =
+      selectedSidebarTab || (instructions.length > 0 ? "instructions" : "file");
+    toggleOption(optionToExpand);
     if (window.plausible) {
       // TODO: Make dynamic events for each option or rename this event
       window.plausible("Expand file pane");
@@ -34,6 +40,7 @@ const SidebarBar = (props) => {
   };
 
   const collapsePopOut = () => {
+    // Toggle the currently selected option to close the sidebar
     toggleOption(option);
     if (window.plausible) {
       window.plausible("Collapse file pane");

--- a/src/components/Menus/Sidebar/SidebarBar.jsx
+++ b/src/components/Menus/Sidebar/SidebarBar.jsx
@@ -29,9 +29,17 @@ const SidebarBar = (props) => {
   );
 
   const expandPopOut = () => {
-    // Use stored option if available, otherwise fall back to default logic
-    const optionToExpand =
-      selectedSidebarTab || (instructions.length > 0 ? "instructions" : "file");
+    // Use stored option if available and valid, otherwise fall back to default logic
+    const validMenuOptionNames = menuOptions.map(
+      (menuOption) => menuOption.name,
+    );
+    const isStoredTabValid =
+      selectedSidebarTab && validMenuOptionNames.includes(selectedSidebarTab);
+    const optionToExpand = isStoredTabValid
+      ? selectedSidebarTab
+      : instructions.length > 0
+      ? "instructions"
+      : "file";
     toggleOption(optionToExpand);
     if (window.plausible) {
       // TODO: Make dynamic events for each option or rename this event

--- a/src/components/Mobile/MobileProject/MobileProject.jsx
+++ b/src/components/Mobile/MobileProject/MobileProject.jsx
@@ -12,7 +12,7 @@ import StepsIcon from "../../../assets/icons/steps.svg";
 import PreviewIcon from "../../../assets/icons/preview.svg";
 import { useTranslation } from "react-i18next";
 import Sidebar from "../../Menus/Sidebar/Sidebar";
-import { showSidebar } from "../../../redux/EditorSlice";
+import { showSidebar, setSelectedSidebarTab } from "../../../redux/EditorSlice";
 
 const MobileProject = ({
   withSidebar,
@@ -30,7 +30,13 @@ const MobileProject = ({
   const { t } = useTranslation();
   const dispatch = useDispatch();
 
-  const openSidebar = () => dispatch(showSidebar());
+  const openSidebar = () => {
+    // Set the default sidebar option to the first available option
+    const defaultOption =
+      sidebarOptions.length > 0 ? sidebarOptions[0] : "file";
+    dispatch(setSelectedSidebarTab(defaultOption));
+    dispatch(showSidebar());
+  };
 
   useEffect(() => {
     if (codeRunTriggered) {

--- a/src/components/Mobile/MobileProject/MobileProject.test.js
+++ b/src/components/Mobile/MobileProject/MobileProject.test.js
@@ -133,7 +133,7 @@ describe("When withSidebar is true", () => {
     expect(store.getActions()).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          type: "editor/setSidebarOption",
+          type: "editor/setSelectedSidebarTab",
           payload: "settings",
         }),
         expect.objectContaining({

--- a/src/components/Mobile/MobileProject/MobileProject.test.js
+++ b/src/components/Mobile/MobileProject/MobileProject.test.js
@@ -3,7 +3,6 @@ import React from "react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 import MobileProject from "./MobileProject";
-import { showSidebar } from "../../../redux/EditorSlice";
 
 window.HTMLElement.prototype.scrollIntoView = jest.fn();
 
@@ -131,7 +130,18 @@ describe("When withSidebar is true", () => {
   test("clicking sidebar open button dispatches action to open the sidebar", () => {
     const sidebarOpenButton = screen.getByText("mobile.menu");
     fireEvent.click(sidebarOpenButton);
-    expect(store.getActions()).toEqual([showSidebar()]);
+    expect(store.getActions()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "editor/setSidebarOption",
+          payload: "settings",
+        }),
+        expect.objectContaining({
+          type: "editor/showSidebar",
+          payload: undefined,
+        }),
+      ]),
+    );
   });
 });
 

--- a/src/redux/EditorSlice.js
+++ b/src/redux/EditorSlice.js
@@ -135,7 +135,7 @@ export const editorInitialState = {
   newFileModalShowing: false,
   renameFileModalShowing: false,
   sidebarShowing: true,
-  sidebarOption: null,
+  selectedSidebarTab: null,
   modals: {},
   errorDetails: {},
   runnerBeingLoaded: null | "pyodide" | "skulpt",
@@ -376,11 +376,11 @@ export const EditorSlice = createSlice({
     hideSidebar: (state) => {
       state.sidebarShowing = false;
     },
-    setSidebarOption: (state, action) => {
-      state.sidebarOption = action.payload;
+    setSelectedSidebarTab: (state, action) => {
+      state.selectedSidebarTab = action.payload;
     },
-    clearSidebarOption: (state) => {
-      state.sidebarOption = null;
+    clearSelectedSidebarTab: (state) => {
+      state.selectedSidebarTab = null;
     },
     disableTheming: (state) => {
       state.isThemeable = false;
@@ -490,8 +490,8 @@ export const {
   closeRenameFileModal,
   showSidebar,
   hideSidebar,
-  setSidebarOption,
-  clearSidebarOption,
+  setSelectedSidebarTab,
+  clearSelectedSidebarTab,
   disableTheming,
   setErrorDetails,
 } = EditorSlice.actions;

--- a/src/redux/EditorSlice.js
+++ b/src/redux/EditorSlice.js
@@ -135,6 +135,7 @@ export const editorInitialState = {
   newFileModalShowing: false,
   renameFileModalShowing: false,
   sidebarShowing: true,
+  sidebarOption: null,
   modals: {},
   errorDetails: {},
   runnerBeingLoaded: null | "pyodide" | "skulpt",
@@ -375,6 +376,12 @@ export const EditorSlice = createSlice({
     hideSidebar: (state) => {
       state.sidebarShowing = false;
     },
+    setSidebarOption: (state, action) => {
+      state.sidebarOption = action.payload;
+    },
+    clearSidebarOption: (state) => {
+      state.sidebarOption = null;
+    },
     disableTheming: (state) => {
       state.isThemeable = false;
     },
@@ -483,6 +490,8 @@ export const {
   closeRenameFileModal,
   showSidebar,
   hideSidebar,
+  setSidebarOption,
+  clearSidebarOption,
   disableTheming,
   setErrorDetails,
 } = EditorSlice.actions;

--- a/src/redux/EditorSlice.js
+++ b/src/redux/EditorSlice.js
@@ -379,9 +379,6 @@ export const EditorSlice = createSlice({
     setSelectedSidebarTab: (state, action) => {
       state.selectedSidebarTab = action.payload;
     },
-    clearSelectedSidebarTab: (state) => {
-      state.selectedSidebarTab = null;
-    },
     disableTheming: (state) => {
       state.isThemeable = false;
     },
@@ -491,7 +488,6 @@ export const {
   showSidebar,
   hideSidebar,
   setSelectedSidebarTab,
-  clearSelectedSidebarTab,
   disableTheming,
   setErrorDetails,
 } = EditorSlice.actions;


### PR DESCRIPTION
## Summary

Adds selected sidebar option (tab) to Redux state to persist he selected sidebar tab ensuring that the user's sidebar selection is maintained across renders and can be programmatically controlled.

- Adds selected option to Redux
- Refactors sidebar behavior to utilise the new state
- Adds related test

## Detail

- Added `selectedSidebarTab` to the Redux state in `EditorSlice`, along with new actions `setSelectedSidebarTab` and `clearSelectedSidebarTab` to manage the selected tab.
- Updated `Sidebar.jsx` to use the Redux `selectedSidebarTab` as the source of truth for the currently selected sidebar option, falling back to default logic if not set, and dispatching Redux actions when the selection changes. 
- Modified `SidebarBar.jsx` to use the Redux `selectedSidebarTab` when collapsing/expanding the sidebar manually, ensuring previous option is shown when re-expanded.

**Sidebar behavior improvements:**

- Ensured that sidebar selection is correctly initialized based on plugins with `autoOpen`, instructions, or defaulting to "file", and that Redux is updated accordingly.
- Adjusted sidebar toggle logic to update Redux state on user interaction, and to prevent toggling on mobile for the same option.

**Mobile sidebar integration:**

- Updated `MobileProject.jsx` so that opening the sidebar on first load sets the `selectedSidebarTab` in Redux to the first available option, improving consistency with desktop behavior.

**Testing and validation:**

- Added tests in `Sidebar.test.js` to verify Redux state persistence, correct dispatching of actions, and priority of plugin `autoOpen` over stored state.
- Updated mobile sidebar tests to expect both `setSelectedSidebarTab` and `showSidebar` actions when the sidebar is opened.