### PR TITLE
Bump version to prep for release v0.34.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raspberrypifoundation/editor-ui",
-  "version": "0.34.3",
+  "version": "0.34.4",
   "private": true,
   "dependencies": {
     "@apollo/client": "^3.7.8",


### PR DESCRIPTION
Not including changes in the changelog, as per recent change to the README.md.