### PR TITLE
Add scheduled Pull Request Reminder workflow

### DIFF
--- a/.github/workflows/pull-request-reminder.yml
+++ b/.github/workflows/pull-request-reminder.yml
@@ -15,8 +15,8 @@ jobs:
         with:
           github-access-token: ${{ secrets.GITHUB_TOKEN }}
           github-repos: ${{ github.repository }}
-          include-wip: 'true'
-          include-draft: 'true'
+          include-wip: 'false'
+          include-draft: 'false'
           # mandatory-labels: 'your-label-1,your-label-2'
           # excluded-labels: 'wip,do-not-merge'
           slack-webhook-url: ${{ secrets.PR_REMINDER_SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Add a GitHub Actions workflow that runs a Pull Request reminder on weekdays at 08:00, 12:00, and 16:00. 

It uses BottlecapDave/GitHub-Pull-Request-Reminder@v1, 
sends notifications to a Slack webhook (PR_REMINDER_SLACK_WEBHOOK_URL)
- this variable is created in Github actions BUT is currently not set. Awaiting correct value from IT.
and includes WIP and draft PRs. 

Repository and token are passed via github.repository and secrets.GITHUB_TOKEN. 
Optional label filters are left commented for future configuration.