### PR TITLE
Enable 'landing-page only' view via Editor attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ The `editor-wc` tag accepts the following attributes, which must be provided as 
 - `host_styles`: Styles passed into the web component from the host page
 - `identifier`: Load the project with this identifier from the database
 - `instructions`: Stringified JSON containing steps to be displayed in the instructions panel in the sidebar
+- `landing_content`: String (of HTML content) to display if `landing_page_only` is set to `true`.
+- `landing_page_only`: Only display the contents of `landing.md` (defaults to `false`)
 - `load_cache`: Load latest version of project code from local storage (defaults to `true`)
 - `load_remix_disabled`: Do not load a logged-in user's remixed version of the project specified by `identifier` even if one exists (defaults to `false`)
 - `locale`: Locale for UI elements and to determine the language of projects loaded from the API (defaults to `en`)

--- a/src/components/WebComponentProject/WebComponentProject.jsx
+++ b/src/components/WebComponentProject/WebComponentProject.jsx
@@ -36,6 +36,8 @@ const WebComponentProject = ({
   outputPanels = ["text", "visual"],
   outputSplitView = false,
   sidebarPlugins = [],
+  landingPageOnly = false,
+  landingContent = null,
 }) => {
   const loading = useSelector((state) => state.editor.loading);
   const project = useSelector((state) => state.editor.project);
@@ -85,13 +87,13 @@ const WebComponentProject = ({
     }
   }, [projectIdentifier]);
 
-  renderer.link = function (data) {
-    return `<a href="${data.href}" target="_blank" rel="noreferrer"
+  renderer.link = (
+    data,
+  ) => `<a href="${data.href}" target="_blank" rel="noreferrer"
     }">${data.text}</a>`;
-  };
 
   marked.setOptions({
-    renderer: renderer,
+    renderer,
   });
 
   useEffect(() => {
@@ -155,6 +157,7 @@ const WebComponentProject = ({
   return (
     <>
       {!outputOnly &&
+        !landingPageOnly &&
         (isMobile ? (
           <MobileProject
             withSidebar={withSidebar}
@@ -170,6 +173,12 @@ const WebComponentProject = ({
             sidebarPlugins={sidebarPlugins}
           />
         ))}
+      {landingPageOnly && landingContent && (
+        <div
+          data-testid="landing-only"
+          dangerouslySetInnerHTML={{ __html: landingContent }}
+        />
+      )}
       {outputOnly && (
         <div className="embedded-viewer" data-testid="output-only">
           {loading === "success" && <Output outputPanels={outputPanels} />}

--- a/src/components/WebComponentProject/WebComponentProject.test.js
+++ b/src/components/WebComponentProject/WebComponentProject.test.js
@@ -315,10 +315,63 @@ describe("When output_only is true", () => {
       expect(screen.queryByTestId("output")).toBeInTheDocument();
       expect(screen.queryByTestId("project")).not.toBeInTheDocument();
       expect(screen.queryByTestId("mobile-project")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("landing-only")).not.toBeInTheDocument();
     });
 
     test("styles output like embedded viewer", () => {
       expect(screen.getByTestId("output-only")).toHaveClass("embedded-viewer");
+    });
+  });
+});
+
+describe("When landing_page_only is true", () => {
+  describe("when loading is pending", () => {
+    beforeEach(() => {
+      renderWebComponentProject({
+        loading: "pending",
+        props: { landingPageOnly: true },
+      });
+    });
+
+    test("does not render anything", () => {
+      expect(screen.queryByTestId("landing-only")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("when landingPageContent is not set", () => {
+    beforeEach(() => {
+      renderWebComponentProject({
+        loading: "success",
+        props: { landingPageOnly: true },
+      });
+    });
+
+    test("does not render anything", () => {
+      expect(screen.queryByTestId("landing-only")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("when landing_content is provided", () => {
+    beforeEach(() => {
+      renderWebComponentProject({
+        loading: "success",
+        props: {
+          landingPageOnly: true,
+          landingContent:
+            '<h2 id="what-you-will-make">What you will make</h2>\n',
+        },
+      });
+    });
+
+    test("only renders the landing content", () => {
+      expect(screen.queryByTestId("landing-only")).toBeInTheDocument();
+      expect(screen.queryByTestId("project")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("output-only")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("mobile-project")).not.toBeInTheDocument();
+
+      expect(
+        screen.queryByRole("heading", { name: /What you will make/ }),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/src/containers/WebComponentLoader.jsx
+++ b/src/containers/WebComponentLoader.jsx
@@ -42,6 +42,8 @@ const WebComponentLoader = (props) => {
     identifier,
     instructions,
     theme,
+    landingPageOnly = false,
+    landingContent = null,
     loadRemixDisabled = false,
     locale = "en",
     outputOnly = false,
@@ -231,6 +233,8 @@ const WebComponentLoader = (props) => {
               outputSplitView={outputSplitView}
               editableInstructions={editableInstructions}
               sidebarPlugins={sidebarPlugins}
+              landingPageOnly={landingPageOnly}
+              landingContent={landingContent}
             />
             {errorModalShowing && <ErrorModal />}
             {newFileModalShowing && <NewFileModal />}

--- a/src/web-component.js
+++ b/src/web-component.js
@@ -58,6 +58,8 @@ class WebComponent extends HTMLElement {
       "identifier",
       "initial_project",
       "instructions",
+      "landing_page_only",
+      "landing_content",
       "load_remix_disabled",
       "locale",
       "output_only",
@@ -84,6 +86,7 @@ class WebComponent extends HTMLElement {
       [
         "embedded",
         "editable_instructions",
+        "landing_page_only",
         "load_remix_disabled",
         "output_only",
         "output_split_view",
@@ -104,6 +107,7 @@ class WebComponent extends HTMLElement {
         "sidebar_options",
         "host_styles",
         "output_panels",
+        "landing_content",
       ].includes(name)
     ) {
       value = JSON.parse(newVal);


### PR DESCRIPTION
In the projects site, we are creating a new "landing page" for projects that include the integrated editor. We want to show a new editor view on this page, which only includes the content of `landing.md` (usually an intro to the project, plus the expected visual output of the project). 

This PR adds two new attributes to the editor web component to enable the 'landing page only' view to be toggled and populated with content.

Corresponding PR in projects-ui: https://github.com/RaspberryPiFoundation/projects-ui/pull/3642

⚠️ This PR must be merged first.

## Design:
<img width="997" height="703" alt="Screenshot 2026-02-19 at 15 53 59" src="https://github.com/user-attachments/assets/88fbb59f-509f-4a6b-9ec8-6549abd85f75" />
