### PR TITLE
FIx module export bug in PyodideWorker

### DIFF
--- a/src/PyodideWorker.js
+++ b/src/PyodideWorker.js
@@ -546,9 +546,3 @@ const PyodideWorker = () => {
 };
 
 globalThis.PyodideWorker = PyodideWorker;
-
-if (typeof module !== "undefined") {
-  module.exports = {
-    PyodideWorker,
-  };
-}

--- a/src/components/Editor/Runners/PythonRunner/PyodideRunner/PyodideWorker.test.js
+++ b/src/components/Editor/Runners/PythonRunner/PyodideRunner/PyodideWorker.test.js
@@ -1,3 +1,5 @@
+/* global globalThis */
+
 import { waitFor } from "@testing-library/react";
 import { TextEncoder } from "util";
 class MockPythonArray extends Array {
@@ -45,8 +47,8 @@ describe("PyodideWorker", () => {
       setStdin: jest.fn(),
     };
     global.loadPyodide = jest.fn().mockResolvedValue(pyodide);
-    const { PyodideWorker } = require("../../../../../PyodideWorker.js");
-    worker = PyodideWorker();
+    require("../../../../../PyodideWorker.js");
+    worker = globalThis.PyodideWorker();
   });
 
   test("it imports the pyodide script", () => {


### PR DESCRIPTION
This caused a bug in our staging environment that was stopping python execution, possibly due to a recently updated NPM package defining module.

"Uncaught Error: ES Modules may not assign module.exports or exports.*, Use ESM export syntax, instead: 23206"

I believe we were only setting module.exports so the file could be imported in a test. Instead we can use the globalThis to access the imported worker.

It would still be good later investigate why this caused a problem in live but not in our tests as there might be something we could do to warn us about this in the future.