### PR TITLE
Make it easier to run a single Jest test file in vscode

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -21,6 +21,52 @@
         "clear": true
       },
       "problemMatcher": []
+    },
+    {
+      "label": "Test Current File (Cypress Headless)",
+      "type": "shell",
+      "command": "yarn",
+      "args": [
+        "run",
+        "cypress",
+        "run",
+        "--spec",
+        "${file}",
+        "--headless"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "group": "test",
+      "presentation": {
+        "reveal": "always",
+        "panel": "dedicated",
+        "clear": true
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Test Current File (Cypress Headed)",
+      "type": "shell",
+      "command": "yarn",
+      "args": [
+        "run",
+        "cypress",
+        "run",
+        "--spec",
+        "${file}",
+        "--headed"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "group": "test",
+      "presentation": {
+        "reveal": "always",
+        "panel": "dedicated",
+        "clear": true
+      },
+      "problemMatcher": []
     }
   ]
 }


### PR DESCRIPTION
Vscode already hooks in to npm tasks, but I don't think there's a way to make it work with an npm task that runs on the current file.

I've added tasks for running the current jest file and the current cypress file (both headed and headless)

Individuals can assign this as shortcut key if they want.