### PR TITLE
Fallback when sidebar element does not exist | Scratch editor default behaviour collapsed

### DIFF
--- a/src/components/Menus/Sidebar/Sidebar.jsx
+++ b/src/components/Menus/Sidebar/Sidebar.jsx
@@ -162,6 +162,7 @@ const Sidebar = ({ options = [], plugins = [], allowMobileView = true }) => {
   const optionDict = menuOptions.find((menuOption) => {
     return menuOption.name === option;
   });
+  const activeOption = optionDict ? option : null;
 
   const CustomSidebarPanel =
     optionDict && optionDict.panel ? optionDict.panel : () => {};
@@ -175,12 +176,12 @@ const Sidebar = ({ options = [], plugins = [], allowMobileView = true }) => {
     >
       <SidebarBar
         menuOptions={menuOptions}
-        option={option}
+        option={activeOption}
         toggleOption={toggleOption}
         instructions={instructionsSteps}
         allowMobileView={allowMobileView}
       />
-      {option && <CustomSidebarPanel isMobile={isMobile} />}
+      {activeOption && <CustomSidebarPanel isMobile={isMobile} />}
     </div>
   );
 };

--- a/src/components/Menus/Sidebar/Sidebar.test.js
+++ b/src/components/Menus/Sidebar/Sidebar.test.js
@@ -16,7 +16,13 @@ let images = [
 ];
 
 const options = ["file", "images", "instructions", "info"];
-const optionsWithDownload = ["file", "images", "instructions", "download", "info"];
+const optionsWithDownload = [
+  "file",
+  "images",
+  "instructions",
+  "download",
+  "info",
+];
 
 describe("When project has images", () => {
   describe("and no instructions", () => {
@@ -448,9 +454,11 @@ describe("When the project type is code_editor_scratch", () => {
     expect(screen.queryByTitle("sidebar.information")).toBeInTheDocument();
   });
 
+  test("Starts in closed chevron state for scratch", () => {
+    expect(screen.queryByTitle("sidebar.expand")).toBeInTheDocument();
+  });
+
   test("Clicking expand opens the first available top panel when file is hidden", () => {
-    const collapseButton = screen.getByTitle("sidebar.collapse");
-    fireEvent.click(collapseButton);
     const expandButton = screen.getByTitle("sidebar.expand");
     fireEvent.click(expandButton);
     expect(screen.queryByText("downloadPanel.heading")).toBeInTheDocument();

--- a/src/components/Menus/Sidebar/SidebarBar.jsx
+++ b/src/components/Menus/Sidebar/SidebarBar.jsx
@@ -39,7 +39,8 @@ const SidebarBar = (props) => {
   };
 
   const expandPopOut = () => {
-    const hasInstructions = Array.isArray(instructions) && instructions.length > 0;
+    const hasInstructions =
+      Array.isArray(instructions) && instructions.length > 0;
     const expandOption = findFirstExistingOption([
       hasInstructions ? "instructions" : null,
       "file",

--- a/src/components/Menus/Sidebar/SidebarBar.test.js
+++ b/src/components/Menus/Sidebar/SidebarBar.test.js
@@ -25,9 +25,9 @@ const menuOptions = (instructions = false) => {
       panel: () => {},
     },
     {
-      name: "home",
+      name: "projects",
       position: "top",
-      title: "home_button",
+      title: "projects_button",
       panel: () => {},
     },
     ...(instructions
@@ -46,9 +46,9 @@ const menuOptions = (instructions = false) => {
 const menuOptionsWithoutFile = () => {
   return [
     {
-      name: "home",
+      name: "projects",
       position: "top",
-      title: "home_button",
+      title: "projects_button",
       panel: () => {},
     },
     {
@@ -76,10 +76,10 @@ describe("SidebarBar", () => {
       expect(toggleOption).toHaveBeenCalledWith("file");
     });
 
-    test("Clicking home button opens home panel", () => {
-      const homeButton = screen.getByTitle("home_button");
-      fireEvent.click(homeButton);
-      expect(toggleOption).toHaveBeenCalledWith("home");
+    test("Clicking projects button opens projects panel", () => {
+      const projectsButton = screen.getByTitle("projects_button");
+      fireEvent.click(projectsButton);
+      expect(toggleOption).toHaveBeenCalledWith("projects");
     });
   });
 
@@ -124,7 +124,7 @@ describe("SidebarBar", () => {
     test("Clicking expand button falls back to the first top panel", () => {
       const expandButton = screen.getByTitle("sidebar.expand");
       fireEvent.click(expandButton);
-      expect(toggleOption).toHaveBeenCalledWith("home");
+      expect(toggleOption).toHaveBeenCalledWith("projects");
     });
   });
 });

--- a/src/components/WebComponentProject/WebComponentProject.test.js
+++ b/src/components/WebComponentProject/WebComponentProject.test.js
@@ -260,7 +260,7 @@ describe("When withSidebar is true", () => {
   });
 
   test("Renders the sidebar", () => {
-    expect(screen.queryByTitle("sidebar.collapse")).toBeInTheDocument();
+    expect(screen.queryByTitle("sidebar.expand")).toBeInTheDocument();
   });
 
   test("Renders the correct sidebar options", () => {


### PR DESCRIPTION
It was reported:
- Clicking the chevron icons causes a "glitchy" visual effect.
- A strange grey line appears around the border of the sidebar during or after the interaction.
- The chevron icon itself appears to change shape or distort when clicked.

After investigation, it was found out:
- It normally defaults to instructions, file.
- it normally requires to be expanded but not in scratch-editor
- These two situations makes it feel glitchy

### Solution

- Let still use these as default, but has as fallback the first existing item (both from the top and bottom part)
- Let the editor now that in scratch we need to initiate collapsed
- Addded test to cover all of these cases


https://github.com/user-attachments/assets/bfac2af7-264b-4450-915f-5ab5484f6bf3

