### PR TITLE
Experiment with quicker way to bump versions before release

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,51 @@
+name: Bump version
+
+on:
+  workflow_dispatch:
+    inputs:
+      level:
+        description: Version bump level
+        required: true
+        type: choice
+        default: patch
+        options:
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+
+jobs:
+  bump-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Cache dependencies
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "yarn"
+          registry-url: "https://npm.pkg.github.com"
+          scope: "@RaspberryPiFoundation"
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump version
+        run: yarn version ${{ inputs.level }}
+
+      - name: Commit and push
+        run: |
+          if git diff --quiet; then
+            echo "No changes to commit"
+            exit 1
+          fi
+
+          git add -A
+          git commit -m "Bump version (${{ inputs.level }}) for release"
+          git push origin HEAD:${{ github.ref_name }}


### PR DESCRIPTION
We're currently creating PRs to manage this which require approval. This semi-automates it and hopefully makes it less error prone.

This action adds in a 'Bump version' action that we can trigger on main to bump the version by either a major, minor, or patch level and then commits it.

It seems you can't run manually triggered workflows on branches, so I think the only way of testing this is to merge it into main.

