### PR TITLE
Update deploy-job to be noisy on purge-cache fail

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -109,6 +109,8 @@ jobs:
     environment:
       name: ${{ inputs.environment }}
       url: ${{ needs.setup-environment.outputs.public_url }}
+    env:
+      HAS_CLOUDFLARE_SECRETS: ${{ secrets.CLOUDFLARE_ZONE_ID != '' && secrets.CLOUDFLARE_API_TOKEN != '' }}
     steps:
       - name: Check deployment path
         run: |
@@ -160,10 +162,8 @@ jobs:
           AWS_REGION: ${{ secrets.AWS_REGION }}
 
       - name: Purge Cloudflare cache
+        if: env.HAS_CLOUDFLARE_SECRETS == 'true'
         run: |
-          [ -n "${CLOUDFLARE_ZONE_ID}" ] || { echo "Missing CLOUDFLARE_ZONE_ID secret"; exit 1; }
-          [ -n "${CLOUDFLARE_API_TOKEN}" ] || { echo "Missing CLOUDFLARE_API_TOKEN secret"; exit 1; }
-
           response="$(
             curl -sS --fail-with-body -X POST "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/purge_cache" \
               -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
@@ -180,6 +180,8 @@ jobs:
             echo "$response"
             exit 1
           }
+
+          echo "Cloudflare purge succeeded for ${{ needs.setup-environment.outputs.public_url }}"
         env:
           CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
- Added check to ensure ENV variables are SET instead of if (skips)
- Added to the curl -f makes curl exit non-zero on HTTP 4xx/5xx.
- Added -s hides progress meter noise in logs.
- Added -S still prints error text when -s is used.
- Include files scratch.html, scratch.js
- Include jq parsing since included in ubuntu-latest
- on key success in the json true -> succeds silently
- otherwise fails noisely

From the todo:

- [x] Make the job fail if purging fails so it's more obvious
- [x] Also add /branches/main/scratch.js and /branches/main/scratch.html to command