### PR TITLE
set task block background colour to white in instructions

### DIFF
--- a/src/assets/stylesheets/Instructions.scss
+++ b/src/assets/stylesheets/Instructions.scss
@@ -256,7 +256,7 @@
       display: none;
     }
     &__body {
-      background-color: $rpf-white;
+      background-color: var(--sidebar-panel-background);
     }
   }
 


### PR DESCRIPTION
Adds styling for task block body (previously didn't exist) and sets background colour to rpf-white to match the instruction panel background