### PR TITLE
Add render test helper to follow suggested Redux testing practices

### DIFF
--- a/src/components/SaveButton/SaveButton.test.js
+++ b/src/components/SaveButton/SaveButton.test.js
@@ -15,7 +15,7 @@ describe("When project is loaded", () => {
 
     describe("who doesn't own the project", () => {
       beforeEach(() => {
-        const initialState = {
+        const preloadedState = {
           editor: {
             loading: "success",
             webComponent: true,
@@ -33,7 +33,7 @@ describe("When project is loaded", () => {
           },
         };
         ({ store } = renderWithProviders(<SaveButton />, {
-          preloadedState: initialState,
+          preloadedState,
         }));
       });
 
@@ -62,7 +62,7 @@ describe("When project is loaded", () => {
 
     describe("who does own the project", () => {
       beforeEach(() => {
-        const initialState = {
+        const preloadedState = {
           editor: {
             loading: "success",
             webComponent: true,
@@ -80,7 +80,7 @@ describe("When project is loaded", () => {
           },
         };
         ({ store } = renderWithProviders(<SaveButton />, {
-          preloadedState: initialState,
+          preloadedState,
         }));
       });
 
@@ -100,7 +100,7 @@ describe("When project is loaded", () => {
     let store;
 
     beforeEach(() => {
-      const initialState = {
+      const preloadedState = {
         editor: {
           loading: "success",
           webComponent: false,
@@ -108,7 +108,7 @@ describe("When project is loaded", () => {
         auth: {},
       };
       ({ store } = renderWithProviders(<SaveButton />, {
-        preloadedState: initialState,
+        preloadedState,
       }));
     });
 
@@ -137,7 +137,7 @@ describe("When project is loaded", () => {
     let store;
 
     beforeEach(() => {
-      const initialState = {
+      const preloadedState = {
         editor: {
           loading: "success",
           webComponent: false,
@@ -145,7 +145,7 @@ describe("When project is loaded", () => {
         auth: {},
       };
       ({ store } = renderWithProviders(<SaveButton />, {
-        preloadedState: initialState,
+        preloadedState,
       }));
     });
 
@@ -159,7 +159,7 @@ describe("When project is loaded", () => {
     let store;
 
     beforeEach(() => {
-      const initialState = {
+      const preloadedState = {
         editor: {
           loading: "success",
           webComponent: true,
@@ -167,7 +167,7 @@ describe("When project is loaded", () => {
         auth: {},
       };
       ({ store } = renderWithProviders(<SaveButton />, {
-        preloadedState: initialState,
+        preloadedState,
       }));
     });
 

--- a/src/components/SaveButton/SaveButton.test.js
+++ b/src/components/SaveButton/SaveButton.test.js
@@ -6,6 +6,19 @@ import { triggerSave } from "../../redux/EditorSlice";
 import SaveButton from "./SaveButton";
 
 const logInHandler = jest.fn();
+const mockStore = configureStore([]);
+
+const renderSaveButton = (initialState) => {
+  const store = mockStore(initialState);
+
+  render(
+    <Provider store={store}>
+      <SaveButton />
+    </Provider>,
+  );
+
+  return store;
+};
 
 describe("When project is loaded", () => {
   beforeAll(() => {
@@ -17,8 +30,6 @@ describe("When project is loaded", () => {
 
     describe("who doesn't own the project", () => {
       beforeEach(() => {
-        const middlewares = [];
-        const mockStore = configureStore(middlewares);
         const initialState = {
           editor: {
             loading: "success",
@@ -36,12 +47,7 @@ describe("When project is loaded", () => {
             },
           },
         };
-        store = mockStore(initialState);
-        render(
-          <Provider store={store}>
-            <SaveButton />
-          </Provider>,
-        );
+        store = renderSaveButton(initialState);
       });
 
       test("Save button renders", () => {
@@ -69,8 +75,6 @@ describe("When project is loaded", () => {
 
     describe("who does own the project", () => {
       beforeEach(() => {
-        const middlewares = [];
-        const mockStore = configureStore(middlewares);
         const initialState = {
           editor: {
             loading: "success",
@@ -88,12 +92,7 @@ describe("When project is loaded", () => {
             },
           },
         };
-        store = mockStore(initialState);
-        render(
-          <Provider store={store}>
-            <SaveButton />
-          </Provider>,
-        );
+        store = renderSaveButton(initialState);
       });
 
       test("Does not render save button", () => {
@@ -112,8 +111,6 @@ describe("When project is loaded", () => {
     let store;
 
     beforeEach(() => {
-      const middlewares = [];
-      const mockStore = configureStore(middlewares);
       const initialState = {
         editor: {
           loading: "success",
@@ -121,12 +118,7 @@ describe("When project is loaded", () => {
         },
         auth: {},
       };
-      store = mockStore(initialState);
-      render(
-        <Provider store={store}>
-          <SaveButton />
-        </Provider>,
-      );
+      store = renderSaveButton(initialState);
     });
 
     test("Login to save button renders", () => {
@@ -154,8 +146,6 @@ describe("When project is loaded", () => {
     let store;
 
     beforeEach(() => {
-      const middlewares = [];
-      const mockStore = configureStore(middlewares);
       const initialState = {
         editor: {
           loading: "success",
@@ -163,12 +153,7 @@ describe("When project is loaded", () => {
         },
         auth: {},
       };
-      store = mockStore(initialState);
-      render(
-        <Provider store={store}>
-          <SaveButton />
-        </Provider>,
-      );
+      store = renderSaveButton(initialState);
     });
 
     test("Renders a secondary button", () => {
@@ -181,8 +166,6 @@ describe("When project is loaded", () => {
     let store;
 
     beforeEach(() => {
-      const middlewares = [];
-      const mockStore = configureStore(middlewares);
       const initialState = {
         editor: {
           loading: "success",
@@ -190,12 +173,7 @@ describe("When project is loaded", () => {
         },
         auth: {},
       };
-      store = mockStore(initialState);
-      render(
-        <Provider store={store}>
-          <SaveButton />
-        </Provider>,
-      );
+      store = renderSaveButton(initialState);
     });
 
     test("Renders a primary button", () => {
@@ -211,17 +189,10 @@ describe("When project is loaded", () => {
 
 describe("When project is not loaded", () => {
   beforeEach(() => {
-    const middlewares = [];
-    const mockStore = configureStore(middlewares);
-    const store = mockStore({
+    renderSaveButton({
       editor: {},
       auth: {},
     });
-    render(
-      <Provider store={store}>
-        <SaveButton />
-      </Provider>,
-    );
   });
 
   test("Does not render a login to save button", () => {

--- a/src/components/SaveButton/SaveButton.test.js
+++ b/src/components/SaveButton/SaveButton.test.js
@@ -1,21 +1,12 @@
 import React from "react";
-import { fireEvent, render, screen } from "@testing-library/react";
-import { Provider } from "react-redux";
-import { configureStore } from "@reduxjs/toolkit";
-import rootReducer from "../../redux/RootSlice";
+import { fireEvent, screen } from "@testing-library/react";
+import renderWithProviders from "../../utils/renderWithProviders";
 import SaveButton from "./SaveButton";
 
 const logInHandler = jest.fn();
 
 const renderSaveButton = (preloadedState) => {
-  const store = configureStore({ reducer: rootReducer, preloadedState });
-
-  render(
-    <Provider store={store}>
-      <SaveButton />
-    </Provider>,
-  );
-
+  const { store } = renderWithProviders(<SaveButton />, { preloadedState });
   return store;
 };
 

--- a/src/components/SaveButton/SaveButton.test.js
+++ b/src/components/SaveButton/SaveButton.test.js
@@ -134,8 +134,6 @@ describe("When project is loaded", () => {
   });
 
   describe("with webComponent=false", () => {
-    let store;
-
     beforeEach(() => {
       const preloadedState = {
         editor: {
@@ -144,9 +142,9 @@ describe("When project is loaded", () => {
         },
         auth: {},
       };
-      ({ store } = renderWithProviders(<SaveButton />, {
+      renderWithProviders(<SaveButton />, {
         preloadedState,
-      }));
+      });
     });
 
     test("Renders a secondary button", () => {
@@ -156,8 +154,6 @@ describe("When project is loaded", () => {
   });
 
   describe("with webComponent=true", () => {
-    let store;
-
     beforeEach(() => {
       const preloadedState = {
         editor: {
@@ -166,9 +162,9 @@ describe("When project is loaded", () => {
         },
         auth: {},
       };
-      ({ store } = renderWithProviders(<SaveButton />, {
+      renderWithProviders(<SaveButton />, {
         preloadedState,
-      }));
+      });
     });
 
     test("Renders a primary button", () => {

--- a/src/components/SaveButton/SaveButton.test.js
+++ b/src/components/SaveButton/SaveButton.test.js
@@ -1,15 +1,14 @@
 import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
-import configureStore from "redux-mock-store";
-import { triggerSave } from "../../redux/EditorSlice";
+import { configureStore } from "@reduxjs/toolkit";
+import rootReducer from "../../redux/RootSlice";
 import SaveButton from "./SaveButton";
 
 const logInHandler = jest.fn();
-const mockStore = configureStore([]);
 
-const renderSaveButton = (initialState) => {
-  const store = mockStore(initialState);
+const renderSaveButton = (preloadedState) => {
+  const store = configureStore({ reducer: rootReducer, preloadedState });
 
   render(
     <Provider store={store}>
@@ -60,10 +59,10 @@ describe("When project is loaded", () => {
         ).not.toBeInTheDocument();
       });
 
-      test("Clicking save dispatches trigger save action", () => {
+      test("Clicking save updates the save-triggered state", () => {
         const saveButton = screen.queryByText("header.save");
         fireEvent.click(saveButton);
-        expect(store.getActions()).toEqual([triggerSave()]);
+        expect(store.getState().editor.saveTriggered).toBe(true);
       });
 
       test("Clicking save triggers a logInHandler event", () => {
@@ -129,10 +128,10 @@ describe("When project is loaded", () => {
       expect(screen.queryByText("header.save")).not.toBeInTheDocument();
     });
 
-    test("Clicking save dispatches trigger save action", () => {
+    test("Clicking save updates the save-triggered state", () => {
       const saveButton = screen.queryByText("header.loginToSave");
       fireEvent.click(saveButton);
-      expect(store.getActions()).toEqual([triggerSave()]);
+      expect(store.getState().editor.saveTriggered).toBe(true);
     });
 
     test("Clicking save triggers a logInHandler event", () => {

--- a/src/components/SaveButton/SaveButton.test.js
+++ b/src/components/SaveButton/SaveButton.test.js
@@ -5,11 +5,6 @@ import SaveButton from "./SaveButton";
 
 const logInHandler = jest.fn();
 
-const renderSaveButton = (preloadedState) => {
-  const { store } = renderWithProviders(<SaveButton />, { preloadedState });
-  return store;
-};
-
 describe("When project is loaded", () => {
   beforeAll(() => {
     document.addEventListener("editor-logIn", logInHandler);
@@ -37,7 +32,9 @@ describe("When project is loaded", () => {
             },
           },
         };
-        store = renderSaveButton(initialState);
+        ({ store } = renderWithProviders(<SaveButton />, {
+          preloadedState: initialState,
+        }));
       });
 
       test("Save button renders", () => {
@@ -82,7 +79,9 @@ describe("When project is loaded", () => {
             },
           },
         };
-        store = renderSaveButton(initialState);
+        ({ store } = renderWithProviders(<SaveButton />, {
+          preloadedState: initialState,
+        }));
       });
 
       test("Does not render save button", () => {
@@ -108,7 +107,9 @@ describe("When project is loaded", () => {
         },
         auth: {},
       };
-      store = renderSaveButton(initialState);
+      ({ store } = renderWithProviders(<SaveButton />, {
+        preloadedState: initialState,
+      }));
     });
 
     test("Login to save button renders", () => {
@@ -143,7 +144,9 @@ describe("When project is loaded", () => {
         },
         auth: {},
       };
-      store = renderSaveButton(initialState);
+      ({ store } = renderWithProviders(<SaveButton />, {
+        preloadedState: initialState,
+      }));
     });
 
     test("Renders a secondary button", () => {
@@ -163,7 +166,9 @@ describe("When project is loaded", () => {
         },
         auth: {},
       };
-      store = renderSaveButton(initialState);
+      ({ store } = renderWithProviders(<SaveButton />, {
+        preloadedState: initialState,
+      }));
     });
 
     test("Renders a primary button", () => {
@@ -179,9 +184,11 @@ describe("When project is loaded", () => {
 
 describe("When project is not loaded", () => {
   beforeEach(() => {
-    renderSaveButton({
-      editor: {},
-      auth: {},
+    renderWithProviders(<SaveButton />, {
+      preloadedState: {
+        editor: {},
+        auth: {},
+      },
     });
   });
 

--- a/src/utils/renderWithProviders.js
+++ b/src/utils/renderWithProviders.js
@@ -1,0 +1,23 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { configureStore } from "@reduxjs/toolkit";
+import rootReducer from "../redux/RootSlice";
+
+const renderWithProviders = (
+  ui,
+  { preloadedState, store, reducer = rootReducer, ...renderOptions } = {},
+) => {
+  const testStore = store || configureStore({ reducer, preloadedState });
+
+  const Wrapper = ({ children }) => (
+    <Provider store={testStore}>{children}</Provider>
+  );
+
+  return {
+    store: testStore,
+    ...render(ui, { wrapper: Wrapper, ...renderOptions }),
+  };
+};
+
+export default renderWithProviders;


### PR DESCRIPTION
In our tests we have a lot of boilerplate to set up redux state and providers in order to render components.

Redux suggests adding a `renderWithProviders` helper to manage this and make testing easier. See https://redux.js.org/usage/writing-tests

These changes add a `renderWithProviders` helper and changes a spec to use it.

If we're happy with this approach we can gradually move our existing tests over as we work on them.

One thing I wasn't sure about was naming of the helper and props - I've followed the example from redux, but it might be simpler and fit in with our existing code better if we call it `render` and `initialState` than `preloadedState` (however `render` will need to be renamed when imported if we want to mix styles in single test file).