### PR TITLE
1236: allow iframe communication in test

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,7 +60,7 @@ on:
         type: string
       react_app_allowed_iframe_origins:
         required: false
-        default: "https://staging-editor.raspberrypi.org,https://staging-editor-static.raspberrypi.org"
+        default: "https://staging-editor.raspberrypi.org,https://staging-editor-static.raspberrypi.org,https://test-editor.raspberrypi.org"
         type: string
         
     secrets:


### PR DESCRIPTION
relates to issue: [1236](https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1236)

Deploy is currently not configured to allow the scratch iframe to use the postmessage api to communication with editor-ui.

Adding in the domain with the env variable should enable this on test.