### PR TITLE
Refactor to split scratch.jsx into clearer parts

### DIFF
--- a/src/components/ScratchEditor/ScratchEditor.jsx
+++ b/src/components/ScratchEditor/ScratchEditor.jsx
@@ -1,0 +1,74 @@
+import scratchProjectSave from "../../utils/scratchProjectSave.js";
+import { useCallback } from "react";
+
+import WrapperdScratchGui from "./WrappedScratchGui.jsx";
+import { postScratchGuiEvent } from "./events.js";
+
+const handleUpdateProjectId = (updatedProjectId) => {
+  postScratchGuiEvent("scratch-gui-project-id-updated", {
+    projectId: updatedProjectId,
+  });
+};
+
+const handleRemixingStarted = () =>
+  postScratchGuiEvent("scratch-gui-remixing-started");
+
+const handleRemixingSucceeded = () =>
+  postScratchGuiEvent("scratch-gui-remixing-succeeded");
+
+const handleSavingStarted = () =>
+  postScratchGuiEvent("scratch-gui-saving-started");
+
+const handleSavingSucceeded = () =>
+  postScratchGuiEvent("scratch-gui-saving-succeeded");
+
+const handleScratchGuiAlert = (alertType) => {
+  if (alertType === "savingError") {
+    postScratchGuiEvent("scratch-gui-saving-failed");
+  } else if (alertType === "creatingError") {
+    postScratchGuiEvent("scratch-gui-remixing-failed");
+  }
+};
+
+let scratchFetchApi = null;
+
+const ScratchEditor = ({ projectId, locale, apiUrl, accessToken }) => {
+  const handleUpdateProjectData = useCallback(
+    async (currentProjectId, vmState, params) => {
+      return scratchProjectSave({
+        scratchFetchApi,
+        apiUrl,
+        currentProjectId,
+        vmState,
+        params,
+      });
+    },
+    [apiUrl],
+  );
+
+  return (
+    <WrapperdScratchGui
+      projectId={projectId}
+      locale={locale}
+      menuBarHidden={true}
+      projectHost={`${apiUrl}/api/scratch/projects`}
+      assetHost={`${apiUrl}/api/scratch/assets`}
+      basePath={`${process.env.ASSETS_URL}/scratch-gui/`}
+      onStorageInit={(storage) => {
+        scratchFetchApi = storage.scratchFetch;
+        if (accessToken) {
+          scratchFetchApi.setMetadata("Authorization", accessToken);
+        }
+      }}
+      onUpdateProjectData={handleUpdateProjectData}
+      onUpdateProjectId={handleUpdateProjectId}
+      onShowCreatingRemixAlert={handleRemixingStarted}
+      onShowRemixSuccessAlert={handleRemixingSucceeded}
+      onShowSavingAlert={handleSavingStarted}
+      onShowSaveSuccessAlert={handleSavingSucceeded}
+      onShowAlert={handleScratchGuiAlert}
+    />
+  );
+};
+
+export default ScratchEditor;

--- a/src/components/ScratchEditor/ScratchEditor.jsx
+++ b/src/components/ScratchEditor/ScratchEditor.jsx
@@ -1,5 +1,5 @@
 import scratchProjectSave from "../../utils/scratchProjectSave.js";
-import { useCallback } from "react";
+import { useCallback, useRef } from "react";
 
 import WrapperdScratchGui from "./WrappedScratchGui.jsx";
 import { postScratchGuiEvent } from "./events.js";
@@ -30,13 +30,13 @@ const handleScratchGuiAlert = (alertType) => {
   }
 };
 
-let scratchFetchApi = null;
-
 const ScratchEditor = ({ projectId, locale, apiUrl, accessToken }) => {
+  const scratchFetchApiRef = useRef(null);
+
   const handleUpdateProjectData = useCallback(
     async (currentProjectId, vmState, params) => {
       return scratchProjectSave({
-        scratchFetchApi,
+        scratchFetchApi: scratchFetchApiRef.current,
         apiUrl,
         currentProjectId,
         vmState,
@@ -55,9 +55,9 @@ const ScratchEditor = ({ projectId, locale, apiUrl, accessToken }) => {
       assetHost={`${apiUrl}/api/scratch/assets`}
       basePath={`${process.env.ASSETS_URL}/scratch-gui/`}
       onStorageInit={(storage) => {
-        scratchFetchApi = storage.scratchFetch;
+        scratchFetchApiRef.current = storage.scratchFetch;
         if (accessToken) {
-          scratchFetchApi.setMetadata("Authorization", accessToken);
+          scratchFetchApiRef.current.setMetadata("Authorization", accessToken);
         }
       }}
       onUpdateProjectData={handleUpdateProjectData}

--- a/src/components/ScratchEditor/ScratchEditor.test.jsx
+++ b/src/components/ScratchEditor/ScratchEditor.test.jsx
@@ -1,0 +1,73 @@
+import { render, cleanup } from "@testing-library/react";
+import ScratchEditor from "./ScratchEditor.jsx";
+
+const mockWrappedScratchGui = jest.fn();
+const mockScratchProjectSave = jest.fn();
+
+jest.mock("../../utils/scratchProjectSave.js", () => ({
+  __esModule: true,
+  default: (params) => mockScratchProjectSave(params),
+}));
+
+jest.mock("./WrappedScratchGui.jsx", () => (props) => {
+  mockWrappedScratchGui(props);
+  return <div data-testid="wrapped-scratch-gui" />;
+});
+
+describe("ScratchEditor", () => {
+  afterEach(() => {
+    cleanup();
+    mockWrappedScratchGui.mockClear();
+    mockScratchProjectSave.mockClear();
+  });
+
+  test("renders WrappedScratchGui when editor is rendered", () => {
+    const { getByTestId } = render(
+      <ScratchEditor
+        projectId="project-123"
+        locale="en"
+        apiUrl="https://api.example.com"
+        accessToken="token-123"
+      />,
+    );
+
+    expect(getByTestId("wrapped-scratch-gui")).toBeTruthy();
+  });
+
+  test("routes project saves through scratchFetch metadata after storage init", async () => {
+    render(
+      <ScratchEditor
+        projectId="project-123"
+        locale="en"
+        apiUrl="https://api.example.com"
+        accessToken="token-123"
+      />,
+    );
+
+    const scratchGuiProps = mockWrappedScratchGui.mock.calls[0][0];
+    const scratchStorage = {
+      scratchFetch: {
+        setMetadata: jest.fn(),
+      },
+    };
+
+    scratchGuiProps.onStorageInit(scratchStorage);
+    await scratchGuiProps.onUpdateProjectData("project-123", '{"targets":[]}', {
+      title: "Saved from test",
+    });
+
+    expect(scratchStorage.scratchFetch.setMetadata).toHaveBeenCalledWith(
+      "Authorization",
+      "token-123",
+    );
+    expect(mockScratchProjectSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scratchFetchApi: scratchStorage.scratchFetch,
+        apiUrl: "https://api.example.com",
+        currentProjectId: "project-123",
+        vmState: '{"targets":[]}',
+        params: { title: "Saved from test" },
+      }),
+    );
+  });
+});

--- a/src/components/ScratchEditor/WrappedScratchGui.jsx
+++ b/src/components/ScratchEditor/WrappedScratchGui.jsx
@@ -1,0 +1,9 @@
+import GUI, { AppStateHOC } from "@scratch/scratch-gui";
+import ScratchIntegrationHOC from "./ScratchIntegrationHOC.jsx";
+import { compose } from "redux";
+
+const appTarget = document.getElementById("app");
+GUI.setAppElement(appTarget);
+const WrappedScratchGui = compose(AppStateHOC, ScratchIntegrationHOC)(GUI);
+
+export default WrappedScratchGui;

--- a/src/components/ScratchEditor/events.js
+++ b/src/components/ScratchEditor/events.js
@@ -1,0 +1,7 @@
+export const postScratchGuiEvent = (type, payload = {}) => {
+  const searchParams = new URLSearchParams(window.location.search);
+  const parentOriginFromQuery = searchParams.get("parent_origin");
+  const allowedParentOrigin = parentOriginFromQuery || window.location.origin;
+
+  window.parent.postMessage({ type, ...payload }, allowedParentOrigin);
+};

--- a/src/scratch.jsx
+++ b/src/scratch.jsx
@@ -1,21 +1,15 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
 import process from "process";
-import { compose } from "redux";
-
-import GUI, { AppStateHOC } from "@scratch/scratch-gui";
-import ScratchIntegrationHOC from "./components/ScratchEditor/ScratchIntegrationHOC.jsx";
 import dedupeScratchWarnings from "./utils/dedupeScratchWarnings.js";
-import scratchProjectSave from "./utils/scratchProjectSave.js";
 
 import ScratchStyles from "./assets/stylesheets/Scratch.scss";
-
+import ScratchEditor from "./components/ScratchEditor/ScratchEditor.jsx";
+import { postScratchGuiEvent } from "./components/ScratchEditor/events.js";
 dedupeScratchWarnings();
 
 const appTarget = document.getElementById("app");
 const scratchLoading = document.getElementById("scratch-loading");
-GUI.setAppElement(appTarget);
-const WrappedGui = compose(AppStateHOC, ScratchIntegrationHOC)(GUI);
 
 if (process.env.NODE_ENV === "production" && typeof window === "object") {
   // Warn before navigating away
@@ -30,36 +24,6 @@ const allowedParentOrigin = parentOriginFromQuery || window.location.origin;
 
 const defaultLocale = "en";
 const locale = appTarget.dataset.locale || defaultLocale;
-
-const postScratchGuiEvent = (type, payload = {}) => {
-  window.parent.postMessage({ type, ...payload }, allowedParentOrigin);
-};
-
-const handleUpdateProjectId = (updatedProjectId) => {
-  postScratchGuiEvent("scratch-gui-project-id-updated", {
-    projectId: updatedProjectId,
-  });
-};
-
-const handleRemixingStarted = () =>
-  postScratchGuiEvent("scratch-gui-remixing-started");
-
-const handleRemixingSucceeded = () =>
-  postScratchGuiEvent("scratch-gui-remixing-succeeded");
-
-const handleSavingStarted = () =>
-  postScratchGuiEvent("scratch-gui-saving-started");
-
-const handleSavingSucceeded = () =>
-  postScratchGuiEvent("scratch-gui-saving-succeeded");
-
-const handleScratchGuiAlert = (alertType) => {
-  if (alertType === "savingError") {
-    postScratchGuiEvent("scratch-gui-saving-failed");
-  } else if (alertType === "creatingError") {
-    postScratchGuiEvent("scratch-gui-remixing-failed");
-  }
-};
 
 const generateNonce = () =>
   `${Math.random().toString(36).slice(2)}-${Date.now().toString(36)}`;
@@ -81,8 +45,6 @@ if (!projectId) {
     requiresAuth: false,
     latestAccessToken: null,
   };
-  let scratchFetchApi = null;
-
   const getTimeoutMessage = (handshake) =>
     handshake.requiresAuth && !handshake.latestAccessToken
       ? "[scratch iframe] auth required but access token missing before timeout"
@@ -94,16 +56,6 @@ if (!projectId) {
     event.data?.type === "scratch-gui-set-token" &&
     event.data?.nonce === nonce;
 
-  const handleUpdateProjectData = async (currentProjectId, vmState, params) => {
-    return scratchProjectSave({
-      scratchFetchApi,
-      apiUrl,
-      currentProjectId,
-      vmState,
-      params,
-    });
-  };
-
   const mountGui = (accessToken) => {
     if (isMounted) return;
     isMounted = true;
@@ -112,26 +64,11 @@ if (!projectId) {
     root.render(
       <>
         <style>{ScratchStyles}</style>
-        <WrappedGui
+        <ScratchEditor
           projectId={projectId}
           locale={locale}
-          menuBarHidden={true}
-          projectHost={`${apiUrl}/api/scratch/projects`}
-          assetHost={`${apiUrl}/api/scratch/assets`}
-          basePath={`${process.env.ASSETS_URL}/scratch-gui/`}
-          onStorageInit={(storage) => {
-            scratchFetchApi = storage.scratchFetch;
-            if (accessToken) {
-              scratchFetchApi.setMetadata("Authorization", accessToken);
-            }
-          }}
-          onUpdateProjectData={handleUpdateProjectData}
-          onUpdateProjectId={handleUpdateProjectId}
-          onShowCreatingRemixAlert={handleRemixingStarted}
-          onShowRemixSuccessAlert={handleRemixingSucceeded}
-          onShowSavingAlert={handleSavingStarted}
-          onShowSaveSuccessAlert={handleSavingSucceeded}
-          onShowAlert={handleScratchGuiAlert}
+          apiUrl={apiUrl}
+          accessToken={accessToken}
         />
       </>,
     );

--- a/src/scratch.test.js
+++ b/src/scratch.test.js
@@ -1,22 +1,7 @@
 jest.mock("./utils/dedupeScratchWarnings.js", () => jest.fn());
 jest.mock("./assets/stylesheets/Scratch.scss", () => "");
-jest.mock("./components/ScratchEditor/ScratchIntegrationHOC.jsx", () => ({
-  __esModule: true,
-  default: (WrappedComponent) => WrappedComponent,
-}));
-const mockScratchProjectSave = jest.fn();
-jest.mock("./utils/scratchProjectSave.js", () => ({
-  __esModule: true,
-  default: (params) => mockScratchProjectSave(params),
-}));
-jest.mock("@scratch/scratch-gui", () => {
-  const MockGui = () => null;
-  MockGui.setAppElement = jest.fn();
-  return {
-    __esModule: true,
-    default: MockGui,
-    AppStateHOC: (WrappedComponent) => WrappedComponent,
-  };
+jest.mock("./components/ScratchEditor/WrappedScratchGui.jsx", () => (props) => {
+  return null;
 });
 
 const mockRenderRoot = jest.fn();
@@ -77,7 +62,6 @@ describe("scratch handshake retries", () => {
     jest.useFakeTimers();
     jest.resetModules();
     mockRenderRoot.mockClear();
-    mockScratchProjectSave.mockClear();
     process.env = {
       ...originalEnv,
       ASSETS_URL: "https://assets.example.com",
@@ -133,40 +117,16 @@ describe("scratch handshake retries", () => {
     expectRetriesStopped(callsAfterHandshake);
   });
 
-  test("routes project saves through scratchFetch metadata after storage init", async () => {
+  test("passes accessToken as a prop", async () => {
     loadScratchModule();
 
     const nonce = getHandshakeNonce();
     dispatchSetTokenMessage({ nonce, accessToken: "token-123" });
 
     const renderedTree = mockRenderRoot.mock.calls[0][0];
-    const scratchGuiElement = renderedTree.props.children[1];
-    const scratchStorage = {
-      scratchFetch: {
-        setMetadata: jest.fn(),
-      },
-    };
+    const scratchEditorComponent = renderedTree.props.children[1];
 
-    scratchGuiElement.props.onStorageInit(scratchStorage);
-    await scratchGuiElement.props.onUpdateProjectData(
-      "project-123",
-      '{"targets":[]}',
-      { title: "Saved from test" },
-    );
-
-    expect(scratchStorage.scratchFetch.setMetadata).toHaveBeenCalledWith(
-      "Authorization",
-      "token-123",
-    );
-    expect(mockScratchProjectSave).toHaveBeenCalledWith(
-      expect.objectContaining({
-        scratchFetchApi: scratchStorage.scratchFetch,
-        apiUrl: "https://api.example.com",
-        currentProjectId: "project-123",
-        vmState: '{"targets":[]}',
-        params: { title: "Saved from test" },
-      }),
-    );
+    expect(scratchEditorComponent.props.accessToken).toBe("token-123");
   });
 
   test("keeps retrying when auth is required but token is missing", () => {


### PR DESCRIPTION
Related to: https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1197

Refactor to split scratch.jsx now that it's responsibilities have grown and simplify tests

In https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1197 I'll need to update the access token that's passed into Scratch. This should make that easier.

I've kept `scratch.jsx` as responsible for initializing the page and setting up authentication. ScratchEditor is responsible for rendering the Scratch editor component and setting up the handlers it needs.

I've also extracted `WrappedScratchGui` as it makes the tests easier to set up when you don't need to mock the process of setting up the higher order component.