### PR TITLE
1257: allow cloudflare insights on all environments in CSP

### DIFF
--- a/src/scratch.html
+++ b/src/scratch.html
@@ -9,7 +9,7 @@
         default-src 'self';
         base-uri 'none';
         object-src 'none';
-        script-src 'self' 'unsafe-inline' 'unsafe-eval';
+        script-src 'self' 'unsafe-inline' 'unsafe-eval' https://static.cloudflareinsights.com;
         style-src 'self' 'unsafe-inline';
         worker-src 'self' blob:;
         child-src 'self' blob:;


### PR DESCRIPTION
part of issue: [1257](https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1257)

Part of the CSP work - notice that we get CSP on the testing and staging environments for cloudflare insights code

<img width="647" height="72" alt="missing-CSP-for cloudflare-insights" src="https://github.com/user-attachments/assets/d7de79a4-dc3b-485b-983e-de1b984152c8" />

This change will allow that to be loaded and execute
