### PR TITLE
1261: fix for turtle target reference error

### DIFF
--- a/src/components/Editor/Runners/PythonRunner/SkulptRunner/SkulptRunner.jsx
+++ b/src/components/Editor/Runners/PythonRunner/SkulptRunner/SkulptRunner.jsx
@@ -87,7 +87,6 @@ const SkulptRunner = ({ active, outputPanels = ["text", "visual"] }) => {
   const senseHatAlwaysEnabled = useSelector(
     (state) => state.editor.senseHatAlwaysEnabled,
   );
-  const projectImages = useSelector((state) => state.editor.project.image_list);
   const reactAppApiEndpoint = useSelector((s) => s.editor.reactAppApiEndpoint);
   const output = useRef();
   const dispatch = useDispatch();
@@ -127,38 +126,6 @@ const SkulptRunner = ({ active, outputPanels = ["text", "visual"] }) => {
       ? document.querySelector("editor-wc").shadowRoot.getElementById("input")
       : null;
     return pageInput || webComponentInput;
-  };
-
-  const getTurtleOutputTarget = () => {
-    const connectedEditors = [...document.querySelectorAll("editor-wc")]
-      .reverse()
-      .filter((element) => element.isConnected);
-
-    for (const editor of connectedEditors) {
-      const target = editor.shadowRoot?.getElementById("turtleOutput");
-      if (target) {
-        return target;
-      }
-    }
-
-    return null;
-  };
-
-  const setTurtleGraphicsTarget = () => {
-    const target = getTurtleOutputTarget();
-    if (!target) {
-      return false;
-    }
-
-    const turtleGraphics = Sk.TurtleGraphics || (Sk.TurtleGraphics = {});
-    turtleGraphics.target = target;
-    turtleGraphics.assets = Object.assign(
-      {},
-      ...projectImages.map((image) => ({
-        [`${image.name}.${image.extension}`]: image.url,
-      })),
-    );
-    return true;
   };
 
   useEffect(() => {
@@ -223,10 +190,6 @@ const SkulptRunner = ({ active, outputPanels = ["text", "visual"] }) => {
   };
 
   const builtinRead = (library) => {
-    if (library.includes("turtle")) {
-      setTurtleGraphicsTarget();
-    }
-
     if (library === "./_internal_sense_hat/__init__.js") {
       dispatch(setSenseHatEnabled(true));
     }
@@ -472,27 +435,6 @@ const SkulptRunner = ({ active, outputPanels = ["text", "visual"] }) => {
       }
     }
 
-    const executeProgram = () => {
-      var myPromise = Sk.misceval
-        .asyncToPromise(
-          () => Sk.importMainWithBody("main", false, prog, true),
-          {
-            "*": () => {
-              if (store.getState().editor.codeRunStopped) {
-                throw new Error(t("output.errors.interrupted"));
-              }
-            },
-          },
-        )
-        .catch((err) => {
-          handleError(err);
-        })
-        .finally(() => {
-          dispatch(codeRunHandled());
-        });
-      myPromise.then(function (_mod) {});
-    };
-
     Sk.configure({
       inputfun: inf,
       output: outf,
@@ -502,20 +444,21 @@ const SkulptRunner = ({ active, outputPanels = ["text", "visual"] }) => {
       uncaughtException: handleError,
     });
 
-    const usesTurtle = /\b(?:from\s+turtle\s+import|import\s+turtle\b)/.test(
-      prog,
-    );
-    const targetReady = setTurtleGraphicsTarget();
-
-    if (usesTurtle && !targetReady) {
-      requestAnimationFrame(() => {
-        setTurtleGraphicsTarget();
-        executeProgram();
+    var myPromise = Sk.misceval
+      .asyncToPromise(() => Sk.importMainWithBody("main", false, prog, true), {
+        "*": () => {
+          if (store.getState().editor.codeRunStopped) {
+            throw new Error(t("output.errors.interrupted"));
+          }
+        },
+      })
+      .catch((err) => {
+        handleError(err);
+      })
+      .finally(() => {
+        dispatch(codeRunHandled());
       });
-      return;
-    }
-
-    executeProgram();
+    myPromise.then(function (_mod) {});
   };
 
   function shiftFocusToInput(e) {

--- a/src/components/Editor/Runners/PythonRunner/SkulptRunner/SkulptRunner.jsx
+++ b/src/components/Editor/Runners/PythonRunner/SkulptRunner/SkulptRunner.jsx
@@ -65,6 +65,7 @@ const VISUAL_LIBRARIES = [
   "sense_hat",
   "turtle",
 ];
+let turtleGraphicsTargetRef = null;
 
 const SkulptRunner = ({ active, outputPanels = ["text", "visual"] }) => {
   const loadedRunner = useSelector((state) => state.editor.loadedRunner);
@@ -87,6 +88,7 @@ const SkulptRunner = ({ active, outputPanels = ["text", "visual"] }) => {
   const senseHatAlwaysEnabled = useSelector(
     (state) => state.editor.senseHatAlwaysEnabled,
   );
+  const projectImages = useSelector((state) => state.editor.project.image_list);
   const reactAppApiEndpoint = useSelector((s) => s.editor.reactAppApiEndpoint);
   const output = useRef();
   const dispatch = useDispatch();
@@ -126,6 +128,82 @@ const SkulptRunner = ({ active, outputPanels = ["text", "visual"] }) => {
       ? document.querySelector("editor-wc").shadowRoot.getElementById("input")
       : null;
     return pageInput || webComponentInput;
+  };
+
+  const getTurtleOutputTarget = () => {
+    const connectedEditors = [...document.querySelectorAll("editor-wc")]
+      .reverse()
+      .filter((element) => element.isConnected);
+
+    for (const editor of connectedEditors) {
+      const target = editor.shadowRoot?.getElementById("turtleOutput");
+      if (target) {
+        return target;
+      }
+    }
+
+    return null;
+  };
+
+  const setTurtleGraphicsTarget = () => {
+    const target = getTurtleOutputTarget();
+    if (!target) {
+      return false;
+    }
+
+    turtleGraphicsTargetRef = target;
+    window.__editorTurtleTarget = target;
+    const turtleGraphics = Sk.TurtleGraphics || (Sk.TurtleGraphics = {});
+
+    Object.defineProperty(turtleGraphics, "target", {
+      configurable: true,
+      get() {
+        return turtleGraphicsTargetRef;
+      },
+      set(value) {
+        if (value && typeof value !== "string") {
+          turtleGraphicsTargetRef = value;
+          return;
+        }
+        // Skulpt sometimes switches this back to the string "turtle".
+        // In Shadow DOM that lookup fails, so we ignore it and keep our existing node.
+        return;
+      },
+    });
+    turtleGraphics.assets = Object.assign(
+      {},
+      ...projectImages.map((image) => ({
+        [`${image.name}.${image.extension}`]: image.url,
+      })),
+    );
+    return true;
+  };
+
+  const withTurtleDomTargetShim = (execute) => {
+    const originalGetElementById = document.getElementById.bind(document);
+
+    document.getElementById = (id) => {
+      if (id === "turtle" && window.__editorTurtleTarget) {
+        return window.__editorTurtleTarget;
+      }
+      return originalGetElementById(id);
+    };
+
+    const restore = () => {
+      document.getElementById = originalGetElementById;
+    };
+
+    try {
+      const result = execute();
+      if (result && typeof result.finally === "function") {
+        return result.finally(restore);
+      }
+      restore();
+      return result;
+    } catch (error) {
+      restore();
+      throw error;
+    }
   };
 
   useEffect(() => {
@@ -190,6 +268,10 @@ const SkulptRunner = ({ active, outputPanels = ["text", "visual"] }) => {
   };
 
   const builtinRead = (library) => {
+    if (library.includes("turtle")) {
+      setTurtleGraphicsTarget();
+    }
+
     if (library === "./_internal_sense_hat/__init__.js") {
       dispatch(setSenseHatEnabled(true));
     }
@@ -435,6 +517,28 @@ const SkulptRunner = ({ active, outputPanels = ["text", "visual"] }) => {
       }
     }
 
+    const executeProgram = () => {
+      var myPromise = withTurtleDomTargetShim(() =>
+        Sk.misceval.asyncToPromise(
+          () => Sk.importMainWithBody("main", false, prog, true),
+          {
+            "*": () => {
+              if (store.getState().editor.codeRunStopped) {
+                throw new Error(t("output.errors.interrupted"));
+              }
+            },
+          },
+        ),
+      )
+        .catch((err) => {
+          handleError(err);
+        })
+        .finally(() => {
+          dispatch(codeRunHandled());
+        });
+      myPromise.then(function (_mod) {});
+    };
+
     Sk.configure({
       inputfun: inf,
       output: outf,
@@ -444,21 +548,20 @@ const SkulptRunner = ({ active, outputPanels = ["text", "visual"] }) => {
       uncaughtException: handleError,
     });
 
-    var myPromise = Sk.misceval
-      .asyncToPromise(() => Sk.importMainWithBody("main", false, prog, true), {
-        "*": () => {
-          if (store.getState().editor.codeRunStopped) {
-            throw new Error(t("output.errors.interrupted"));
-          }
-        },
-      })
-      .catch((err) => {
-        handleError(err);
-      })
-      .finally(() => {
-        dispatch(codeRunHandled());
+    const usesTurtle = /\b(?:from\s+turtle\s+import|import\s+turtle\b)/.test(
+      prog,
+    );
+    const targetReady = setTurtleGraphicsTarget();
+
+    if (usesTurtle && !targetReady) {
+      requestAnimationFrame(() => {
+        setTurtleGraphicsTarget();
+        executeProgram();
       });
-    myPromise.then(function (_mod) {});
+      return;
+    }
+
+    executeProgram();
   };
 
   function shiftFocusToInput(e) {

--- a/src/components/Editor/Runners/PythonRunner/SkulptRunner/SkulptRunner.jsx
+++ b/src/components/Editor/Runners/PythonRunner/SkulptRunner/SkulptRunner.jsx
@@ -65,7 +65,6 @@ const VISUAL_LIBRARIES = [
   "sense_hat",
   "turtle",
 ];
-let turtleGraphicsTargetRef = null;
 
 const SkulptRunner = ({ active, outputPanels = ["text", "visual"] }) => {
   const loadedRunner = useSelector((state) => state.editor.loadedRunner);
@@ -88,7 +87,6 @@ const SkulptRunner = ({ active, outputPanels = ["text", "visual"] }) => {
   const senseHatAlwaysEnabled = useSelector(
     (state) => state.editor.senseHatAlwaysEnabled,
   );
-  const projectImages = useSelector((state) => state.editor.project.image_list);
   const reactAppApiEndpoint = useSelector((s) => s.editor.reactAppApiEndpoint);
   const output = useRef();
   const dispatch = useDispatch();
@@ -128,82 +126,6 @@ const SkulptRunner = ({ active, outputPanels = ["text", "visual"] }) => {
       ? document.querySelector("editor-wc").shadowRoot.getElementById("input")
       : null;
     return pageInput || webComponentInput;
-  };
-
-  const getTurtleOutputTarget = () => {
-    const connectedEditors = [...document.querySelectorAll("editor-wc")]
-      .reverse()
-      .filter((element) => element.isConnected);
-
-    for (const editor of connectedEditors) {
-      const target = editor.shadowRoot?.getElementById("turtleOutput");
-      if (target) {
-        return target;
-      }
-    }
-
-    return null;
-  };
-
-  const setTurtleGraphicsTarget = () => {
-    const target = getTurtleOutputTarget();
-    if (!target) {
-      return false;
-    }
-
-    turtleGraphicsTargetRef = target;
-    window.__editorTurtleTarget = target;
-    const turtleGraphics = Sk.TurtleGraphics || (Sk.TurtleGraphics = {});
-
-    Object.defineProperty(turtleGraphics, "target", {
-      configurable: true,
-      get() {
-        return turtleGraphicsTargetRef;
-      },
-      set(value) {
-        if (value && typeof value !== "string") {
-          turtleGraphicsTargetRef = value;
-          return;
-        }
-        // Skulpt sometimes switches this back to the string "turtle".
-        // In Shadow DOM that lookup fails, so we ignore it and keep our existing node.
-        return;
-      },
-    });
-    turtleGraphics.assets = Object.assign(
-      {},
-      ...projectImages.map((image) => ({
-        [`${image.name}.${image.extension}`]: image.url,
-      })),
-    );
-    return true;
-  };
-
-  const withTurtleDomTargetShim = (execute) => {
-    const originalGetElementById = document.getElementById.bind(document);
-
-    document.getElementById = (id) => {
-      if (id === "turtle" && window.__editorTurtleTarget) {
-        return window.__editorTurtleTarget;
-      }
-      return originalGetElementById(id);
-    };
-
-    const restore = () => {
-      document.getElementById = originalGetElementById;
-    };
-
-    try {
-      const result = execute();
-      if (result && typeof result.finally === "function") {
-        return result.finally(restore);
-      }
-      restore();
-      return result;
-    } catch (error) {
-      restore();
-      throw error;
-    }
   };
 
   useEffect(() => {
@@ -268,10 +190,6 @@ const SkulptRunner = ({ active, outputPanels = ["text", "visual"] }) => {
   };
 
   const builtinRead = (library) => {
-    if (library.includes("turtle")) {
-      setTurtleGraphicsTarget();
-    }
-
     if (library === "./_internal_sense_hat/__init__.js") {
       dispatch(setSenseHatEnabled(true));
     }
@@ -517,28 +435,6 @@ const SkulptRunner = ({ active, outputPanels = ["text", "visual"] }) => {
       }
     }
 
-    const executeProgram = () => {
-      var myPromise = withTurtleDomTargetShim(() =>
-        Sk.misceval.asyncToPromise(
-          () => Sk.importMainWithBody("main", false, prog, true),
-          {
-            "*": () => {
-              if (store.getState().editor.codeRunStopped) {
-                throw new Error(t("output.errors.interrupted"));
-              }
-            },
-          },
-        ),
-      )
-        .catch((err) => {
-          handleError(err);
-        })
-        .finally(() => {
-          dispatch(codeRunHandled());
-        });
-      myPromise.then(function (_mod) {});
-    };
-
     Sk.configure({
       inputfun: inf,
       output: outf,
@@ -548,20 +444,21 @@ const SkulptRunner = ({ active, outputPanels = ["text", "visual"] }) => {
       uncaughtException: handleError,
     });
 
-    const usesTurtle = /\b(?:from\s+turtle\s+import|import\s+turtle\b)/.test(
-      prog,
-    );
-    const targetReady = setTurtleGraphicsTarget();
-
-    if (usesTurtle && !targetReady) {
-      requestAnimationFrame(() => {
-        setTurtleGraphicsTarget();
-        executeProgram();
+    var myPromise = Sk.misceval
+      .asyncToPromise(() => Sk.importMainWithBody("main", false, prog, true), {
+        "*": () => {
+          if (store.getState().editor.codeRunStopped) {
+            throw new Error(t("output.errors.interrupted"));
+          }
+        },
+      })
+      .catch((err) => {
+        handleError(err);
+      })
+      .finally(() => {
+        dispatch(codeRunHandled());
       });
-      return;
-    }
-
-    executeProgram();
+    myPromise.then(function (_mod) {});
   };
 
   function shiftFocusToInput(e) {

--- a/src/components/Editor/Runners/PythonRunner/SkulptRunner/SkulptRunner.jsx
+++ b/src/components/Editor/Runners/PythonRunner/SkulptRunner/SkulptRunner.jsx
@@ -75,6 +75,7 @@ const SkulptRunner = ({ active, outputPanels = ["text", "visual"] }) => {
   const projectIdentifier = useSelector(
     (state) => state.editor.project.identifier,
   );
+  const projectImages = useSelector((state) => state.editor.project.image_list);
   const user = useSelector((state) => state.auth.user);
   const isSplitView = useSelector((state) => state.editor.isSplitView);
   const isEmbedded = useSelector((state) => state.editor.isEmbedded);
@@ -89,6 +90,7 @@ const SkulptRunner = ({ active, outputPanels = ["text", "visual"] }) => {
   );
   const reactAppApiEndpoint = useSelector((s) => s.editor.reactAppApiEndpoint);
   const output = useRef();
+  const visualOutputPaneRef = useRef(null);
   const dispatch = useDispatch();
   const { t } = useTranslation();
   const settings = useContext(SettingsContext);
@@ -126,6 +128,41 @@ const SkulptRunner = ({ active, outputPanels = ["text", "visual"] }) => {
       ? document.querySelector("editor-wc").shadowRoot.getElementById("input")
       : null;
     return pageInput || webComponentInput;
+  };
+
+  const getTurtleOutputTarget = () => {
+    return visualOutputPaneRef.current?.getTurtleTarget?.() || null;
+  };
+
+  const bindTurtleGraphics = () => {
+    const target = getTurtleOutputTarget();
+    if (!target) {
+      return false;
+    }
+
+    configureTurtleGraphics({
+      targetEl: target,
+      projectImages,
+    });
+
+    return true;
+  };
+
+  const installTurtleDomTargetFallback = () => {
+    const originalGetElementById = document.getElementById.bind(document);
+
+    document.getElementById = (id) => {
+      if (id === "turtle") {
+        const turtleTarget = getTurtleOutputTarget();
+        if (turtleTarget) {
+          return turtleTarget;
+        }
+      }
+      return originalGetElementById(id);
+    };
+    return () => {
+      document.getElementById = originalGetElementById;
+    };
   };
 
   useEffect(() => {
@@ -410,18 +447,6 @@ const SkulptRunner = ({ active, outputPanels = ["text", "visual"] }) => {
     }
     dispatch(setSenseHatEnabled(false));
 
-    // runCode runs from the current runner's useEffect before VisualOutputPane’s useEffect
-    // so Sk.TurtleGraphics.target / assets are set here so they exist before import
-    const host = document.querySelector("editor-wc");
-    const turtleOutputElement =
-      host?.shadowRoot?.getElementById("turtleOutput") ||
-      document.getElementById("turtleOutput");
-
-    configureTurtleGraphics({
-      targetEl: turtleOutputElement,
-      projectImages: project.image_list || [],
-    });
-
     var prog = mainComponent?.content || "";
 
     if (prog.includes(`# ${t("input.comment.py5")}`)) {
@@ -435,6 +460,16 @@ const SkulptRunner = ({ active, outputPanels = ["text", "visual"] }) => {
       }
     }
 
+    if (Sk.TurtleGraphics?.reset) {
+      Sk.TurtleGraphics.reset();
+    } else if (Sk.TurtleGraphics?.stop) {
+      Sk.TurtleGraphics.stop();
+    }
+
+    // Start from a fresh container to avoid stale turtle module internals
+    // surviving SPA remounts.
+    Sk.TurtleGraphics = {};
+
     Sk.configure({
       inputfun: inf,
       output: outf,
@@ -443,6 +478,10 @@ const SkulptRunner = ({ active, outputPanels = ["text", "visual"] }) => {
       inputTakesPrompt: true,
       uncaughtException: handleError,
     });
+
+    bindTurtleGraphics();
+
+    const uninstallTurtleDomTargetFallback = installTurtleDomTargetFallback();
 
     var myPromise = Sk.misceval
       .asyncToPromise(() => Sk.importMainWithBody("main", false, prog, true), {
@@ -456,6 +495,7 @@ const SkulptRunner = ({ active, outputPanels = ["text", "visual"] }) => {
         handleError(err);
       })
       .finally(() => {
+        uninstallTurtleDomTargetFallback();
         dispatch(codeRunHandled());
       });
     myPromise.then(function (_mod) {});
@@ -535,7 +575,7 @@ const SkulptRunner = ({ active, outputPanels = ["text", "visual"] }) => {
                   {!isEmbedded && isMobile && <RunnerControls skinny />}
                 </div>
                 <TabPanel key={0}>
-                  <VisualOutputPane />
+                  <VisualOutputPane ref={visualOutputPaneRef} />
                 </TabPanel>
               </Tabs>
             </div>
@@ -598,7 +638,7 @@ const SkulptRunner = ({ active, outputPanels = ["text", "visual"] }) => {
           </div>
           {!isOutputOnly && <ErrorMessage />}
           <TabPanel key={0}>
-            <VisualOutputPane />
+            <VisualOutputPane ref={visualOutputPaneRef} />
           </TabPanel>
           <TabPanel key={1}>
             <pre

--- a/src/components/Editor/Runners/PythonRunner/SkulptRunner/SkulptRunner.jsx
+++ b/src/components/Editor/Runners/PythonRunner/SkulptRunner/SkulptRunner.jsx
@@ -87,6 +87,7 @@ const SkulptRunner = ({ active, outputPanels = ["text", "visual"] }) => {
   const senseHatAlwaysEnabled = useSelector(
     (state) => state.editor.senseHatAlwaysEnabled,
   );
+  const projectImages = useSelector((state) => state.editor.project.image_list);
   const reactAppApiEndpoint = useSelector((s) => s.editor.reactAppApiEndpoint);
   const output = useRef();
   const dispatch = useDispatch();
@@ -126,6 +127,38 @@ const SkulptRunner = ({ active, outputPanels = ["text", "visual"] }) => {
       ? document.querySelector("editor-wc").shadowRoot.getElementById("input")
       : null;
     return pageInput || webComponentInput;
+  };
+
+  const getTurtleOutputTarget = () => {
+    const connectedEditors = [...document.querySelectorAll("editor-wc")]
+      .reverse()
+      .filter((element) => element.isConnected);
+
+    for (const editor of connectedEditors) {
+      const target = editor.shadowRoot?.getElementById("turtleOutput");
+      if (target) {
+        return target;
+      }
+    }
+
+    return null;
+  };
+
+  const setTurtleGraphicsTarget = () => {
+    const target = getTurtleOutputTarget();
+    if (!target) {
+      return false;
+    }
+
+    const turtleGraphics = Sk.TurtleGraphics || (Sk.TurtleGraphics = {});
+    turtleGraphics.target = target;
+    turtleGraphics.assets = Object.assign(
+      {},
+      ...projectImages.map((image) => ({
+        [`${image.name}.${image.extension}`]: image.url,
+      })),
+    );
+    return true;
   };
 
   useEffect(() => {
@@ -190,6 +223,10 @@ const SkulptRunner = ({ active, outputPanels = ["text", "visual"] }) => {
   };
 
   const builtinRead = (library) => {
+    if (library.includes("turtle")) {
+      setTurtleGraphicsTarget();
+    }
+
     if (library === "./_internal_sense_hat/__init__.js") {
       dispatch(setSenseHatEnabled(true));
     }
@@ -435,6 +472,27 @@ const SkulptRunner = ({ active, outputPanels = ["text", "visual"] }) => {
       }
     }
 
+    const executeProgram = () => {
+      var myPromise = Sk.misceval
+        .asyncToPromise(
+          () => Sk.importMainWithBody("main", false, prog, true),
+          {
+            "*": () => {
+              if (store.getState().editor.codeRunStopped) {
+                throw new Error(t("output.errors.interrupted"));
+              }
+            },
+          },
+        )
+        .catch((err) => {
+          handleError(err);
+        })
+        .finally(() => {
+          dispatch(codeRunHandled());
+        });
+      myPromise.then(function (_mod) {});
+    };
+
     Sk.configure({
       inputfun: inf,
       output: outf,
@@ -444,21 +502,20 @@ const SkulptRunner = ({ active, outputPanels = ["text", "visual"] }) => {
       uncaughtException: handleError,
     });
 
-    var myPromise = Sk.misceval
-      .asyncToPromise(() => Sk.importMainWithBody("main", false, prog, true), {
-        "*": () => {
-          if (store.getState().editor.codeRunStopped) {
-            throw new Error(t("output.errors.interrupted"));
-          }
-        },
-      })
-      .catch((err) => {
-        handleError(err);
-      })
-      .finally(() => {
-        dispatch(codeRunHandled());
+    const usesTurtle = /\b(?:from\s+turtle\s+import|import\s+turtle\b)/.test(
+      prog,
+    );
+    const targetReady = setTurtleGraphicsTarget();
+
+    if (usesTurtle && !targetReady) {
+      requestAnimationFrame(() => {
+        setTurtleGraphicsTarget();
+        executeProgram();
       });
-    myPromise.then(function (_mod) {});
+      return;
+    }
+
+    executeProgram();
   };
 
   function shiftFocusToInput(e) {

--- a/src/components/Editor/Runners/PythonRunner/SkulptRunner/SkulptRunner.jsx
+++ b/src/components/Editor/Runners/PythonRunner/SkulptRunner/SkulptRunner.jsx
@@ -137,19 +137,17 @@ const SkulptRunner = ({ active, outputPanels = ["text", "visual"] }) => {
   const bindTurtleGraphics = () => {
     const target = getTurtleOutputTarget();
     if (!target) {
-      return false;
+      return;
     }
 
     configureTurtleGraphics({
       targetEl: target,
       projectImages,
     });
-
-    return true;
   };
 
   const installTurtleDomTargetFallback = () => {
-    const originalGetElementById = document.getElementById.bind(document);
+    const originalGetElementById = document.getElementById;
 
     document.getElementById = (id) => {
       if (id === "turtle") {
@@ -158,7 +156,7 @@ const SkulptRunner = ({ active, outputPanels = ["text", "visual"] }) => {
           return turtleTarget;
         }
       }
-      return originalGetElementById(id);
+      return originalGetElementById.call(document, id);
     };
     return () => {
       document.getElementById = originalGetElementById;

--- a/src/components/Editor/Runners/PythonRunner/SkulptRunner/SkulptRunner.jsx
+++ b/src/components/Editor/Runners/PythonRunner/SkulptRunner/SkulptRunner.jsx
@@ -466,8 +466,6 @@ const SkulptRunner = ({ active, outputPanels = ["text", "visual"] }) => {
       Sk.TurtleGraphics.stop();
     }
 
-    // Start from a fresh container to avoid stale turtle module internals
-    // surviving SPA remounts.
     Sk.TurtleGraphics = {};
 
     Sk.configure({

--- a/src/components/Editor/Runners/PythonRunner/SkulptRunner/SkulptRunner.test.js
+++ b/src/components/Editor/Runners/PythonRunner/SkulptRunner/SkulptRunner.test.js
@@ -1330,58 +1330,108 @@ describe("When not active and a code run has been triggered", () => {
   });
 });
 
-describe("Turtle graphics is wired before Skulpt import", () => {
-  const asyncToPromise = Sk.misceval.asyncToPromise;
+describe("When turtle run setup is applied", () => {
+  let originalAsyncToPromise;
+  let originalImportMainWithBody;
+  let originalConfigure;
+  let originalGetElementById;
 
-  afterEach(() => {
-    Sk.misceval.asyncToPromise = asyncToPromise;
+  beforeEach(() => {
+    originalAsyncToPromise = Sk.misceval.asyncToPromise;
+    originalImportMainWithBody = Sk.importMainWithBody;
+    originalConfigure = Sk.configure;
+    originalGetElementById = document.getElementById;
+
+    Sk.configure = jest.fn();
   });
 
-  test("sets Sk.TurtleGraphics.target and assets before asyncToPromise runs", () => {
-    Sk.misceval.asyncToPromise = jest.fn((_computeFn) => {
-      const turtleElement = document.getElementById("turtleOutput");
-      expect(turtleElement).not.toBeNull();
-      expect(Sk.TurtleGraphics.target).toBe(turtleElement);
-      expect(Sk.TurtleGraphics.assets["pic.png"]).toBe(
-        "https://example.com/img.png",
-      );
-      return Promise.resolve();
-    });
+  afterEach(() => {
+    Sk.misceval.asyncToPromise = originalAsyncToPromise;
+    Sk.importMainWithBody = originalImportMainWithBody;
+    Sk.configure = originalConfigure;
+    document.getElementById = originalGetElementById;
+  });
+
+  test("binds turtle target from VisualOutputPane ref before execution", () => {
+    Sk.importMainWithBody = jest.fn();
+    Sk.misceval.asyncToPromise = jest.fn(() => Promise.resolve());
 
     const middlewares = [];
     const mockStore = configureStore(middlewares);
-    const initialState = {
+    const store = mockStore({
       editor: {
         project: {
           components: [
             {
               name: "main",
               extension: "py",
-              content: "print('hello')",
+              content: "from turtle import *",
             },
           ],
-          image_list: [
-            {
-              name: "pic",
-              extension: "png",
-              url: "https://example.com/img.png",
-            },
-          ],
+          image_list: [],
         },
         codeRunTriggered: true,
-        isEmbedded: false,
       },
-      auth: {
-        user,
-      },
-    };
-    const store = mockStore(initialState);
+      auth: { user },
+    });
+
     render(
       <Provider store={store}>
         <SkulptRunner active={true} />
       </Provider>,
     );
 
-    expect(Sk.misceval.asyncToPromise).toHaveBeenCalled();
+    expect(Sk.TurtleGraphics.target).not.toBeNull();
+    expect(Sk.TurtleGraphics.target.id).toBe("turtleOutput");
+  });
+
+  test("temporarily maps getElementById('turtle') during execution", async () => {
+    let turtleLookupTarget;
+    let resolveRun;
+    const runPromise = new Promise((resolve) => {
+      resolveRun = resolve;
+    });
+
+    Sk.importMainWithBody = jest.fn(() => {
+      turtleLookupTarget = document.getElementById("turtle");
+      return {};
+    });
+    Sk.misceval.asyncToPromise = jest.fn((runner) => {
+      runner();
+      return runPromise;
+    });
+
+    const middlewares = [];
+    const mockStore = configureStore(middlewares);
+    const store = mockStore({
+      editor: {
+        project: {
+          components: [
+            {
+              name: "main",
+              extension: "py",
+              content: "from turtle import *",
+            },
+          ],
+          image_list: [],
+        },
+        codeRunTriggered: true,
+      },
+      auth: { user },
+    });
+
+    render(
+      <Provider store={store}>
+        <SkulptRunner active={true} />
+      </Provider>,
+    );
+
+    expect(turtleLookupTarget).not.toBeNull();
+    expect(turtleLookupTarget.id).toBe("turtleOutput");
+
+    resolveRun();
+    await runPromise;
+    await Promise.resolve();
+    expect(document.getElementById("turtle")).toBeNull();
   });
 });

--- a/src/components/Editor/Runners/PythonRunner/VisualOutputPane.jsx
+++ b/src/components/Editor/Runners/PythonRunner/VisualOutputPane.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useLayoutEffect } from "react";
+import React, { useEffect } from "react";
 import { useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
@@ -25,17 +25,11 @@ const VisualOutputPane = () => {
   const dispatch = useDispatch();
   const { t } = useTranslation();
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (codeRunTriggered) {
-      if (turtleOutput.current) {
-        turtleOutput.current.innerHTML = "";
-      }
-      if (pygalOutput.current) {
-        pygalOutput.current.innerHTML = "";
-      }
-      if (p5Output.current) {
-        p5Output.current.innerHTML = "";
-      }
+      turtleOutput.current.innerHTML = "";
+      pygalOutput.current.innerHTML = "";
+      p5Output.current.innerHTML = "";
 
       if (!window.py5) {
         window.py5 = {};

--- a/src/components/Editor/Runners/PythonRunner/VisualOutputPane.jsx
+++ b/src/components/Editor/Runners/PythonRunner/VisualOutputPane.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useLayoutEffect } from "react";
 import { useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
@@ -25,11 +25,17 @@ const VisualOutputPane = () => {
   const dispatch = useDispatch();
   const { t } = useTranslation();
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (codeRunTriggered) {
-      turtleOutput.current.innerHTML = "";
-      pygalOutput.current.innerHTML = "";
-      p5Output.current.innerHTML = "";
+      if (turtleOutput.current) {
+        turtleOutput.current.innerHTML = "";
+      }
+      if (pygalOutput.current) {
+        pygalOutput.current.innerHTML = "";
+      }
+      if (p5Output.current) {
+        p5Output.current.innerHTML = "";
+      }
 
       if (!window.py5) {
         window.py5 = {};

--- a/src/components/Editor/Runners/PythonRunner/VisualOutputPane.jsx
+++ b/src/components/Editor/Runners/PythonRunner/VisualOutputPane.jsx
@@ -27,15 +27,9 @@ const VisualOutputPane = () => {
 
   useEffect(() => {
     if (codeRunTriggered) {
-      if (turtleOutput.current) {
-        turtleOutput.current.innerHTML = "";
-      }
-      if (pygalOutput.current) {
-        pygalOutput.current.innerHTML = "";
-      }
-      if (p5Output.current) {
-        p5Output.current.innerHTML = "";
-      }
+      turtleOutput.current.innerHTML = "";
+      pygalOutput.current.innerHTML = "";
+      p5Output.current.innerHTML = "";
 
       if (!window.py5) {
         window.py5 = {};

--- a/src/components/Editor/Runners/PythonRunner/VisualOutputPane.jsx
+++ b/src/components/Editor/Runners/PythonRunner/VisualOutputPane.jsx
@@ -27,9 +27,15 @@ const VisualOutputPane = () => {
 
   useEffect(() => {
     if (codeRunTriggered) {
-      turtleOutput.current.innerHTML = "";
-      pygalOutput.current.innerHTML = "";
-      p5Output.current.innerHTML = "";
+      if (turtleOutput.current) {
+        turtleOutput.current.innerHTML = "";
+      }
+      if (pygalOutput.current) {
+        pygalOutput.current.innerHTML = "";
+      }
+      if (p5Output.current) {
+        p5Output.current.innerHTML = "";
+      }
 
       if (!window.py5) {
         window.py5 = {};

--- a/src/components/Editor/Runners/PythonRunner/VisualOutputPane.jsx
+++ b/src/components/Editor/Runners/PythonRunner/VisualOutputPane.jsx
@@ -1,13 +1,12 @@
-import React, { useEffect } from "react";
+import React, { forwardRef, useEffect, useImperativeHandle } from "react";
 import { useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import Sk from "skulpt";
 import AstroPiModel from "../../../AstroPiModel/AstroPiModel";
 import { codeRunHandled, setError } from "../../../../redux/EditorSlice";
-import { configureTurtleGraphics } from "../../../../utils/configureTurtleGraphics";
 
-const VisualOutputPane = () => {
+const VisualOutputPane = forwardRef((_props, ref) => {
   const codeRunTriggered = useSelector(
     (state) => state.editor.codeRunTriggered,
   );
@@ -25,11 +24,25 @@ const VisualOutputPane = () => {
   const dispatch = useDispatch();
   const { t } = useTranslation();
 
+  useImperativeHandle(
+    ref,
+    () => ({
+      getTurtleTarget: () => turtleOutput.current || null,
+    }),
+    [],
+  );
+
   useEffect(() => {
     if (codeRunTriggered) {
-      turtleOutput.current.innerHTML = "";
-      pygalOutput.current.innerHTML = "";
-      p5Output.current.innerHTML = "";
+      if (turtleOutput.current) {
+        turtleOutput.current.innerHTML = "";
+      }
+      if (pygalOutput.current) {
+        pygalOutput.current.innerHTML = "";
+      }
+      if (p5Output.current) {
+        p5Output.current.innerHTML = "";
+      }
 
       if (!window.py5) {
         window.py5 = {};
@@ -43,11 +56,6 @@ const VisualOutputPane = () => {
       window.assets = projectImages;
 
       (Sk.pygal || (Sk.pygal = {})).outputCanvas = pygalOutput.current;
-
-      configureTurtleGraphics({
-        targetEl: turtleOutput.current,
-        projectImages,
-      });
     }
   }, [codeRunTriggered, projectImages]);
 
@@ -84,6 +92,6 @@ const VisualOutputPane = () => {
       {senseHatEnabled || senseHatAlwaysEnabled ? <AstroPiModel /> : null}
     </div>
   );
-};
+});
 
 export default VisualOutputPane;

--- a/src/components/Editor/Runners/PythonRunner/VisualOutputPane.test.js
+++ b/src/components/Editor/Runners/PythonRunner/VisualOutputPane.test.js
@@ -77,6 +77,7 @@ describe("When Sense Hat library not used", () => {
 describe("When code run is triggered", () => {
   let store;
   let container;
+  let turtleOutputRef;
 
   beforeEach(() => {
     const middlewares = [];
@@ -91,9 +92,10 @@ describe("When code run is triggered", () => {
       },
     };
     store = mockStore(initialState);
+    turtleOutputRef = React.createRef();
     const renderResult = render(
       <Provider store={store}>
-        <VisualOutputPane />
+        <VisualOutputPane ref={turtleOutputRef} />
       </Provider>,
     );
     container = renderResult.container;
@@ -108,7 +110,7 @@ describe("When code run is triggered", () => {
     expect(Sk.pygal.outputCanvas).not.toBeNull();
   });
 
-  test("Sets up turtle canvas", () => {
-    expect(Sk.TurtleGraphics.target).not.toBeNull();
+  test("Exposes turtle target via ref", () => {
+    expect(turtleOutputRef.current.getTurtleTarget()).not.toBeNull();
   });
 });


### PR DESCRIPTION
issue: [1261](https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1261)

### Context

`editor-ui` is embedded inside `editor-standalone` as a web component.

We hit a weird turtle failure when:
- first loading a project - works fine  
- navigating away (e.g. to a lesson page)  
- then coming back - breaks  

A full page refresh fixes it, so this is clearly something about remounting rather than initial load.

The error we were seeing:

```
Cannot read properties of null (reading 'firstChild')
```

At first I suspected this was something to do with lifecycle + Shadow DOM + how Skulpt tries to resolve the turtle target in the light DOM.

---

### What Skulpt is doing

When Python imports `turtle`, Skulpt runs `getConfiguredTarget()`:

- https://github.com/skulpt/skulpt/blob/master/src/lib/turtle.js#L4

It determines the target using:

- `Sk.TurtleGraphics.target`, or falls back to `"turtle"`  
- https://github.com/skulpt/skulpt/blob/master/src/lib/turtle.js#L7  

If it ends up with a string, it does:

```js
document.getElementById(selector)
```

- https://github.com/skulpt/skulpt/blob/master/src/lib/turtle.js#L9  

It then assumes that worked and immediately does:

```js
while (target.firstChild) { ... }
```

- https://github.com/skulpt/skulpt/blob/master/src/lib/turtle.js#L12  

---

### Why this breaks for us

Our turtle output lives inside a **Shadow DOM**, not the top-level document.

So if Skulpt falls back to `"turtle"`:
- `document.getElementById("turtle")` - returns `null`
- our actual element is `#turtleOutput`, and it’s not even in the light DOM anyway

So we end up with:

```js
target === null
```

and then:

```js
target.firstChild
```

So exactly the error we saw.

This lines up with what I saw while debugging:
- failures consistently happen on remount (after navigating away and back)
- if I redirect `"turtle"` lookup to the actual Shadow DOM element, everything works again

---

### Additional findings

I also tried tightening up our lifecycle handling:

- made sure turtle teardown/reinit happens before rerunning code  
- moved more of this into `SkulptRunner`  

After that:
- I can confirm `Sk.TurtleGraphics.target` **is correctly set** before `Sk.importMainWithBody(...)`

**But** Skulpt still seems to hit its internal fallback path and try `"turtle"` anyway.

So this feels like:
- either the target is getting lost/reset internally  
- or Skulpt is re-resolving it in a way that ignores what we set  

---

### The fix (for now)

Not pretty, and this doens't feel like a nice fix, but its the only thing I’ve found that reliably works:

- during execution, temporarily shim `document.getElementById`
- if it’s called with `"turtle"`, return our actual `#turtleOutput` element
- restore the original function in a `finally()` block

---

### Things we might consider

A couple of directions that *might* be worth exploring (more thinking out loud than firm suggestions):

Some possible changes to Skulpt.. 
- Skulpt probably shouldn’t assume `getElementById` will always succeed  
- It would be good if it consistently respected an explicitly provided `Sk.TurtleGraphics.target`, rather than falling back again  

Another option could be introducing something like a `targetFunc()`:

- instead of passing a static value, allow a function that resolves the element at runtime  
- this would play much more nicely with things like Shadow DOM and remounting, where the element isn’t always stable or in the light DOM  

Something along the lines of:

```js
Sk.TurtleGraphics.targetFunc = () => {
  return resolveTurtleElementSomehow();
};
```

That way Skulpt doesn’t need to guess or fall back — it just asks for the element when it needs it.

Not saying we should go and patch Skulpt right now, but it does feel like the kind of thing that could be improved upstream if we ever wanted to explore it - and it might be the only thing that gives a nice solution
