### PR TITLE
Stop brackets in CSS content breaking styling

### DIFF
--- a/src/assets/stylesheets/Loader.scss
+++ b/src/assets/stylesheets/Loader.scss
@@ -39,11 +39,11 @@
 }
 
 .loader:before {
-  content: "{";
+  content: "\7B";
   animation: loader-pulse var(--loader-speed) alternate infinite ease-in-out;
 }
 .loader:after {
-  content: "}";
+  content: "\7D";
   animation: loader-pulse var(--loader-speed) var(--loader-speed) alternate
     infinite ease-in-out;
 }


### PR DESCRIPTION
On staging, line breaks were incorrectly being inserted within the content string, after the `{` character. This is causing some CSS not to apply. and the editor not to take up the full height.


<img width="1411" height="990" alt="Screenshot 2026-05-05 at 10 18 33" src="https://github.com/user-attachments/assets/9733269b-0409-49b1-9e8a-2be0155305dd" />



I'm not quite sure what part of the stack is breaking it, but we're using style-it which is no longer maintained so could be the cause, and we're on an old version of `style-loader`.

I'd like to try the simpler fix for now and avoid the issue by encoding the `{`/`}` characters. We can always investigate other ways to prevent this later.