### PR TITLE
Remove loading brackets

### DIFF
--- a/src/assets/stylesheets/Loader.scss
+++ b/src/assets/stylesheets/Loader.scss
@@ -39,11 +39,11 @@
 }
 
 .loader:before {
-  content: "\7B";
+  content: "";
   animation: loader-pulse var(--loader-speed) alternate infinite ease-in-out;
 }
 .loader:after {
-  content: "\7D";
+  content: "";
   animation: loader-pulse var(--loader-speed) var(--loader-speed) alternate
     infinite ease-in-out;
 }


### PR DESCRIPTION
Related to #1451 

I had previously tried to encode the brackets in a different way, but something in our CSS pipeline is decoding them back to brackets

For now just remove them so we can fix the CSS.