### PR TITLE
Fix the HTML preview locally

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -201,7 +201,8 @@ const mainConfig = {
             "/pyodide/shims/pygal.js",
             "/PyodideWorker.js",
           ].includes(req.url) ||
-          req.url.startsWith("/scratch.html")
+          req.url.startsWith("/scratch.html") ||
+          req.url.startsWith("/html-renderer.html")
         ) {
           res.setHeader("Cross-Origin-Resource-Policy", "cross-origin");
         }


### PR DESCRIPTION
Found while working on https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1379

In production we have a cloudflare rule that allows cross-origin requests. Without this the iframe does not render in locally (tested in Chrome).