### PR TITLE
Cache fixing by unit path invalidation instead of individual file listing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -172,7 +172,8 @@ jobs:
             exit 0
           fi
 
-          echo -n "${{ needs.setup-environment.outputs.deploy_dir }}" | aws s3 cp - s3://${{ secrets.AWS_S3_BUCKET }}/latest_version --endpoint ${{ secrets.AWS_ENDPOINT }} --content-type "text/plain"
+          # Use no-cache so latest_version is revalidated after tag deploys.
+          echo -n "${{ needs.setup-environment.outputs.deploy_dir }}" | aws s3 cp - s3://${{ secrets.AWS_S3_BUCKET }}/latest_version --endpoint ${{ secrets.AWS_ENDPOINT }} --content-type "text/plain" --cache-control "no-cache"
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -181,11 +182,52 @@ jobs:
       - name: Purge Cloudflare cache
         if: env.HAS_CLOUDFLARE_SECRETS == 'true'
         run: |
+          # Cloudflare expects purge prefixes without the URL scheme.
+          # For example, "https://editor-static.raspberrypi.org/releases/v1.2.3"
+          # becomes "editor-static.raspberrypi.org/releases/v1.2.3".
+          cloudflare_prefix() {
+            local url="$1"
+
+            url="${url#https://}"
+            url="${url#http://}"
+            url="${url%/}"
+
+            printf "%s" "$url"
+          }
+
+          # Purge the deployed web component and HTML renderer directories.
+          # The trailing slash makes these directory prefixes, so Cloudflare
+          # removes cached files under each deployed path.
+          purge_prefixes=(
+            "$(cloudflare_prefix "$PUBLIC_URL")/"
+            "$(cloudflare_prefix "$HTML_RENDERER_URL")/"
+          )
+
+          # Tagged releases update /latest_version, which is cached separately
+          # from the release directory. Branch deploys do not touch this file.
+          if [ "$REF_TYPE" = "tag" ]; then
+            purge_prefixes+=("$(cloudflare_prefix "$BASE_URL")/latest_version")
+          fi
+
+          # Build the API payload and de-duplicate prefixes. PUBLIC_URL and
+          # HTML_RENDERER_URL are often the same, so unique avoids purging the
+          # same prefix twice.
+          purge_payload="$(
+            jq -cn --args '
+              $ARGS.positional
+              | unique
+              | {prefixes: .}
+            ' "${purge_prefixes[@]}"
+          )"
+
+          echo "Purging Cloudflare cache prefixes:"
+          jq -r '.prefixes[] | " - \(.)"' <<<"$purge_payload"
+
           response="$(
             curl -sS --fail-with-body -X POST "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/purge_cache" \
               -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
               -H "Content-Type: application/json" \
-              --data '{"files":["${{ needs.setup-environment.outputs.public_url }}/web-component.html", "${{ needs.setup-environment.outputs.public_url }}/web-component.js", "${{ needs.setup-environment.outputs.public_url }}/scratch.html", "${{ needs.setup-environment.outputs.public_url }}/scratch.js", "${{ inputs.base_url }}/latest_version", "${{ needs.setup-environment.outputs.html_renderer_url}}/html-renderer.html", "${{ needs.setup-environment.outputs.html_renderer_url}}/html-renderer.js"]}'
+              --data "$purge_payload"
           )" || {
             echo "Cloudflare purge request failed:"
             echo "$response"
@@ -198,7 +240,11 @@ jobs:
             exit 1
           }
 
-          echo "Cloudflare purge succeeded for ${{ needs.setup-environment.outputs.public_url }}"
+          echo "Cloudflare purge succeeded for $PUBLIC_URL"
         env:
           CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          PUBLIC_URL: ${{ needs.setup-environment.outputs.public_url }}
+          HTML_RENDERER_URL: ${{ needs.setup-environment.outputs.html_renderer_url }}
+          BASE_URL: ${{ inputs.base_url }}
+          REF_TYPE: ${{ github.ref_type }}


### PR DESCRIPTION
Closes https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1371

#### What changed

  This PR changes the deploy workflow to purge Cloudflare by deployed path prefix instead of by a hard-coded list of individual files.

A staging deploy now purges:
```bash
  {
    "prefixes": [
      "staging-editor-static.raspberrypi.org/branches/main/"
    ]
  }
```

while before:

```bash
  {
    "files": [
      "https://staging-editor-static.raspberrypi.org/branches/main/web-component.html",
      "https://staging-editor-static.raspberrypi.org/branches/main/web-component.js",
      "https://staging-editor-static.raspberrypi.org/branches/main/scratch.html",
      "https://staging-editor-static.raspberrypi.org/branches/main/scratch.js",
      "https://staging-editor-static.raspberrypi.org/latest_version",
      "https://staging-editor-static.raspberrypi.org/branches/main/html-renderer.html",
      "https://staging-editor-static.raspberrypi.org/branches/main/html-renderer.js"
    ]
  }
```

The PR also uploads latest_version with Cache-Control: no-cache, because that file is intentionally updated in place.
For production tags, before it purged individual files inside one release plus latest_version. Now it purges:
```bash


  {
    "prefixes": [
      "editor-static.raspberrypi.org/releases/<tag>/",
      "editor-static.raspberrypi.org/latest_version"
    ]
  }
```

## Why

Staging should serve the latest deployed version of editor-ui after each deploy.

The previous single-file purge targeted paths such as `web-component.js`, `scratch.js`, and `html-renderer.js`. That can be unreliable because Cloudflare may cache separate variants of the same URL when request headers differ, for example with different Origin headers. If the purge request does not match the cached variant, Cloudflare can continue serving an older file. Prefix purging clears the deployed build path as a unit. The next request after deploy fetches the updated files from the bucket, and Cloudflare then caches those files again as normal.
This is a targeted deploy/cache invalidation fix.

References:
- Purge cache by prefix (https://developers.cloudflare.com/cache/how-to/purge-cache/purge_by_prefix/)
  - Cloudflare documents prefix purge for clearing a directory/path, reducing purge calls, and causing the next request to refetch from origin.
- Purge Cached Content API (https://developers.cloudflare.com/api/resources/cache/methods/purge/)
- Cache Keys (https://developers.cloudflare.com/cache/how-to/cache-keys/)
- Purge by single-file (https://developers.cloudflare.com/cache/how-to/purge-cache/purge-by-single-file/)
- Origin Cache Control (https://developers.cloudflare.com/cache/concepts/cache-control/)
- Browser Cache TTL (https://developers.cloudflare.com/cache/how-to/edge-browser-cache-ttl/set-browser-ttl/)

Idea: 
Longer term, we should move to content-hashed asset filenames with immutable caching, leaving only small stable entrypoints or manifests as revalidated files.