### PR TITLE
Use cooldowns to reduce the risk of supply chain attacks

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,5 +2,10 @@ build/
 dist/
 .git/
 node_modules/
-.yarn/
-.yarnrc.yml
+
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: "npm"
+  directory: "/"
+  cooldown:
+    default-days: 10
+  schedule:
+    interval: "daily"

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -7,3 +7,9 @@ enableGlobalCache: false
 nodeLinker: node-modules
 
 yarnPath: .yarn/releases/yarn-4.12.0.cjs
+
+npmMinimalAgeGate: 7d
+
+npmPreapprovedPackages:
+  - "@raspberrypifoundation/design-system-react"
+  - "@raspberrypifoundation/design-system-core"

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,7 @@ WORKDIR /app
 COPY package.json yarn.lock ./
 COPY . /app
 
-RUN corepack enable \
-  && yarn set version 4.12.0 \
-  && echo "nodeLinker: node-modules\n\n$(cat /app/.yarnrc.yml)" > /app/.yarnrc.yml \
-  && cat /app/.yarnrc.yml \
-  && printf "Switched to Yarn version: "; yarn --version
+RUN corepack enable
 
 RUN chsh -s $(which zsh) ${USER}
 


### PR DESCRIPTION
Related to a similar change in editor-standalone: https://github.com/RaspberryPiFoundation/editor-standalone/pull/881

This does three things:

- Set up dependabot so we get non-security updates to, will a cooldown
- Add a cooldown to yarn using the `npmMinimalAgeGate` setting.
- Make docker's use of yarn more consistent with other environments

See commits for more