### PR TITLE
Mimic autosave in Scratch Editor

### DIFF
--- a/cypress/e2e/spec-scratch.cy.js
+++ b/cypress/e2e/spec-scratch.cy.js
@@ -97,7 +97,7 @@ describe("Scratch save integration", () => {
     cy.findByText("cool-scratch").click();
   });
 
-  it("remixes on the first save, keeps the iframe project loaded, and saves after the identifier update", () => {
+  it("remixes on the first save, keeps the iframe project loaded, and auto-saves after the identifier update", () => {
     getEditorShadow()
       .find("iframe[title='Scratch']")
       .its("0.contentDocument.body")
@@ -131,6 +131,14 @@ describe("Scratch save integration", () => {
           },
         }),
       );
+      win.dispatchEvent(
+        new win.MessageEvent("message", {
+          origin: win.location.origin,
+          data: {
+            type: "scratch-gui-remixing-succeeded",
+          },
+        }),
+      );
     });
 
     cy.get("#project-identifier").should("have.text", "student-remix");
@@ -146,11 +154,35 @@ describe("Scratch save integration", () => {
       postMessage.resetHistory();
     });
 
-    getEditorShadow().findByRole("button", { name: "Save" }).click();
+    getEditorShadow()
+      .find("button")
+      .should(($buttons) => {
+        const buttonText = [...$buttons].map((button) =>
+          button.textContent.trim(),
+        );
+        expect(buttonText).not.to.include("Save");
+      });
 
-    cy.get("@scratchPostMessage")
-      .its("firstCall.args.0")
-      .should("deep.include", { type: "scratch-gui-save" });
+    cy.window().then((win) => {
+      win.dispatchEvent(
+        new win.MessageEvent("message", {
+          origin: win.location.origin,
+          data: {
+            type: "scratch-gui-project-changed",
+          },
+        }),
+      );
+    });
+
+    cy.wait(2100);
+
+    cy.get("@scratchPostMessage").should((postMessage) => {
+      const saveMessage = postMessage
+        .getCalls()
+        .some((call) => call.args[0]?.type === "scratch-gui-save");
+
+      expect(saveMessage).to.eq(true);
+    });
   });
 });
 

--- a/src/components/ProjectBar/ScratchProjectBar.jsx
+++ b/src/components/ProjectBar/ScratchProjectBar.jsx
@@ -36,10 +36,12 @@ const ScratchProjectBar = ({ nameEditable = true }) => {
 
   const projectIdentifier = project?.identifier;
   const isScratchSaving = saving === "pending";
+  const isScratchSaveFailed = saving === "failed";
   const isNewProject = !projectIdentifier;
   const canAutoSave = Boolean(projectIdentifier && !shouldRemixOnSave);
   const showSaveButton = canSave && (isNewProject || shouldRemixOnSave);
-  const showSaveStatus = canSave && canAutoSave && Boolean(lastSavedTime);
+  const showSaveStatus =
+    canSave && canAutoSave && Boolean(lastSavedTime) && !isScratchSaveFailed;
   const projectLastSavedTime = getProjectLastSavedTime(project?.updated_at);
 
   useEffect(() => {

--- a/src/components/ProjectBar/ScratchProjectBar.jsx
+++ b/src/components/ProjectBar/ScratchProjectBar.jsx
@@ -1,5 +1,5 @@
-import React from "react";
-import { useSelector } from "react-redux";
+import React, { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
 import { useTranslation } from "react-i18next";
 import DownloadIcon from "../../assets/icons/download.svg";
 import UploadIcon from "../../assets/icons/upload.svg";
@@ -8,26 +8,51 @@ import ProjectName from "../ProjectName/ProjectName";
 import DownloadButton from "../DownloadButton/DownloadButton";
 import UploadButton from "../UploadButton/UploadButton";
 import DesignSystemButton from "../DesignSystemButton/DesignSystemButton";
+import SaveStatus from "../SaveStatus/SaveStatus";
 
 import "../../assets/stylesheets/ProjectBar.scss";
+import { setScratchLastSavedTime } from "../../redux/EditorSlice";
 import { useScratchSave } from "../../hooks/useScratchSave";
+
+const getProjectLastSavedTime = (updatedAt) => {
+  const timestamp = Date.parse(updatedAt || "");
+  return Number.isNaN(timestamp) ? null : timestamp;
+};
 
 const ScratchProjectBar = ({ nameEditable = true }) => {
   const { t } = useTranslation();
+  const dispatch = useDispatch();
 
   const user = useSelector((state) => state.auth.user);
   const loading = useSelector((state) => state.editor.loading);
+  const project = useSelector((state) => state.editor.project);
   const readOnly = useSelector((state) => state.editor.readOnly);
-  const showScratchSaveButton = Boolean(user && !readOnly);
-  const {
-    isScratchSaving,
-    saveScratchProject,
-    scratchSaveLabelKey,
-    shouldRemixOnSave,
-  } = useScratchSave({
-    enabled: showScratchSaveButton,
+  const saving = useSelector((state) => state.editor.saving);
+  const lastSavedTime = useSelector((state) => state.editor.lastSavedTime);
+  const canSave = Boolean(user && !readOnly);
+  const { saveScratchProject, shouldRemixOnSave } = useScratchSave({
+    enabled: canSave,
   });
-  const scratchSaveLabel = t(scratchSaveLabelKey);
+
+  const projectIdentifier = project?.identifier;
+  const isScratchSaving = saving === "pending";
+  const isNewProject = !projectIdentifier;
+  const canAutoSave = Boolean(projectIdentifier && !shouldRemixOnSave);
+  const showSaveButton = canSave && (isNewProject || shouldRemixOnSave);
+  const showSaveStatus = canSave && canAutoSave && Boolean(lastSavedTime);
+  const projectLastSavedTime = getProjectLastSavedTime(project?.updated_at);
+
+  useEffect(() => {
+    if (!canSave || !canAutoSave || lastSavedTime || !projectLastSavedTime) {
+      return;
+    }
+
+    dispatch(
+      setScratchLastSavedTime({
+        lastSavedTime: projectLastSavedTime,
+      }),
+    );
+  }, [dispatch, canAutoSave, canSave, lastSavedTime, projectLastSavedTime]);
 
   if (loading !== "success") {
     return null;
@@ -55,12 +80,12 @@ const ScratchProjectBar = ({ nameEditable = true }) => {
             type="tertiary"
           />
         </div>
-        {showScratchSaveButton && (
+        {showSaveButton && (
           <div className="project-bar__btn-wrapper">
             <DesignSystemButton
               className="project-bar__btn btn--save btn--primary"
               onClick={() => saveScratchProject({ shouldRemixOnSave })}
-              text={scratchSaveLabel}
+              text={t("header.save")}
               textAlways
               icon={<SaveIcon />}
               type="primary"
@@ -68,6 +93,7 @@ const ScratchProjectBar = ({ nameEditable = true }) => {
             />
           </div>
         )}
+        {showSaveStatus && <SaveStatus />}
       </div>
     </div>
   );

--- a/src/components/ProjectBar/ScratchProjectBar.test.js
+++ b/src/components/ProjectBar/ScratchProjectBar.test.js
@@ -239,6 +239,19 @@ describe("Additional Scratch manual save states", () => {
     expect(screen.getByText("saveStatus.saved now")).toBeInTheDocument();
   });
 
+  test("does not show a saved status after a Scratch save failure", () => {
+    renderSignedInScratchProjectBar({
+      project: {
+        ...scratchProject,
+        updated_at: new Date(Date.now()).toISOString(),
+      },
+    });
+
+    dispatchScratchMessage("scratch-gui-saving-failed");
+
+    expect(screen.queryByText(/saveStatus.saved/)).not.toBeInTheDocument();
+  });
+
   test("shows the saving state during a Scratch remix", () => {
     renderSignedInScratchProjectBar({
       project: {

--- a/src/components/ProjectBar/ScratchProjectBar.test.js
+++ b/src/components/ProjectBar/ScratchProjectBar.test.js
@@ -1,9 +1,10 @@
 import React from "react";
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
-import configureStore from "redux-mock-store";
+import { configureStore } from "@reduxjs/toolkit";
 import { MemoryRouter } from "react-router-dom";
 import ScratchProjectBar from "./ScratchProjectBar";
+import editorReducer, { editorInitialState } from "../../redux/EditorSlice";
 import { postMessageToScratchIframe } from "../../utils/scratchIframe";
 
 jest.mock("axios");
@@ -16,6 +17,8 @@ jest.mock("react-router-dom", () => ({
   ...jest.requireActual("react-router-dom"),
   useNavigate: () => jest.fn(),
 }));
+
+jest.useFakeTimers();
 
 const scratchProject = {
   name: "Hello world",
@@ -34,19 +37,24 @@ const user = {
 };
 
 const renderScratchProjectBar = (state) => {
-  const middlewares = [];
-  const mockStore = configureStore(middlewares);
   const project = state.editor?.project || {};
-  const store = mockStore({
-    editor: {
-      loading: "success",
-      project,
-      scratchIframeProjectIdentifier: project.identifier || null,
-      ...state.editor,
+  const store = configureStore({
+    reducer: {
+      editor: editorReducer,
+      auth: (authState = {}) => authState,
     },
-    auth: {
-      user: null,
-      ...state.auth,
+    preloadedState: {
+      editor: {
+        ...editorInitialState,
+        loading: "success",
+        project,
+        scratchIframeProjectIdentifier: project.identifier || null,
+        ...state.editor,
+      },
+      auth: {
+        user: null,
+        ...state.auth,
+      },
     },
   });
 
@@ -57,7 +65,25 @@ const renderScratchProjectBar = (state) => {
       </MemoryRouter>
     </Provider>,
   );
+
+  return store;
 };
+
+const renderSignedInScratchProjectBar = ({
+  project = scratchProject,
+  editor = {},
+  auth = {},
+} = {}) =>
+  renderScratchProjectBar({
+    editor: {
+      project,
+      ...editor,
+    },
+    auth: {
+      user,
+      ...auth,
+    },
+  });
 
 const getScratchOrigin = () => process.env.ASSETS_URL || window.location.origin;
 
@@ -76,28 +102,31 @@ beforeEach(() => {
   jest.clearAllMocks();
 });
 
-describe("When project is Scratch", () => {
-  beforeEach(() => {
-    postMessageToScratchIframe.mockClear();
-    renderScratchProjectBar({
-      editor: {
-        project: scratchProject,
-      },
-      auth: {
-        user,
-      },
-    });
-  });
+afterEach(() => {
+  jest.clearAllTimers();
+});
 
+describe("When project is Scratch", () => {
   test("Upload button shown", () => {
+    renderSignedInScratchProjectBar();
+
     expect(screen.queryByText("header.upload")).toBeInTheDocument();
   });
 
   test("Download button shown", () => {
+    renderSignedInScratchProjectBar();
+
     expect(screen.queryByText("header.download")).toBeInTheDocument();
   });
 
-  test("clicking Save sends scratch-gui-save message", () => {
+  test("clicking Save sends scratch-gui-save for a new Scratch project", () => {
+    renderSignedInScratchProjectBar({
+      project: {
+        ...scratchProject,
+        identifier: null,
+      },
+    });
+
     fireEvent.click(screen.getByRole("button", { name: "header.save" }));
 
     expect(postMessageToScratchIframe).toHaveBeenCalledTimes(1);
@@ -107,79 +136,140 @@ describe("When project is Scratch", () => {
   });
 
   test("clicking Save remixes a non-owner Scratch project on the first save", () => {
-    renderScratchProjectBar({
-      editor: {
-        project: {
-          ...scratchProject,
-          user_id: "teacher-id",
-        },
-      },
-      auth: {
-        user,
+    renderSignedInScratchProjectBar({
+      project: {
+        ...scratchProject,
+        user_id: "teacher-id",
       },
     });
 
-    fireEvent.click(screen.getAllByRole("button", { name: "header.save" })[1]);
+    fireEvent.click(screen.getByRole("button", { name: "header.save" }));
 
     expect(postMessageToScratchIframe).toHaveBeenCalledWith({
       type: "scratch-gui-remix",
+    });
+  });
+
+  test("does not show the manual Save button for an already saved Scratch project", () => {
+    renderSignedInScratchProjectBar();
+
+    expect(
+      screen.queryByRole("button", { name: "header.save" }),
+    ).not.toBeInTheDocument();
+  });
+
+  test("shows the autosave status for an already saved Scratch project", () => {
+    renderSignedInScratchProjectBar({
+      project: {
+        ...scratchProject,
+        updated_at: new Date(Date.now()).toISOString(),
+      },
+    });
+
+    expect(screen.getByText("saveStatus.saved now")).toBeInTheDocument();
+  });
+
+  test("auto-saves after a Scratch project change", () => {
+    renderSignedInScratchProjectBar();
+
+    dispatchScratchMessage("scratch-gui-project-changed");
+
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    expect(postMessageToScratchIframe).toHaveBeenCalledWith({
+      type: "scratch-gui-save",
+    });
+  });
+
+  test("hides the manual Save button and auto-saves after a Scratch remix", () => {
+    renderSignedInScratchProjectBar({
+      project: {
+        ...scratchProject,
+        identifier: "remixed-project",
+        user_id: "teacher-id",
+      },
+      editor: {
+        scratchIframeProjectIdentifier: scratchProject.identifier,
+      },
+    });
+
+    expect(
+      screen.queryByRole("button", { name: "header.save" }),
+    ).not.toBeInTheDocument();
+
+    dispatchScratchMessage("scratch-gui-project-changed");
+
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    expect(postMessageToScratchIframe).toHaveBeenCalledWith({
+      type: "scratch-gui-save",
     });
   });
 });
 
 describe("Additional Scratch manual save states", () => {
   test("shows the saving state from the scratch save hook", () => {
-    renderScratchProjectBar({
-      editor: {
-        project: scratchProject,
-      },
-      auth: {
-        user,
+    renderSignedInScratchProjectBar({
+      project: {
+        ...scratchProject,
+        updated_at: new Date(Date.now()).toISOString(),
       },
     });
 
     dispatchScratchMessage("scratch-gui-saving-started");
 
     expect(
-      screen.getByRole("button", { name: "saveStatus.saving" }),
-    ).toBeDisabled();
+      screen.queryByRole("button", { name: "header.save" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText(/saveStatus.saving/)).toBeInTheDocument();
   });
 
   test("shows the saved state from the scratch save hook", () => {
-    renderScratchProjectBar({
-      editor: {
-        project: scratchProject,
-      },
-      auth: {
-        user,
-      },
-    });
+    renderSignedInScratchProjectBar();
 
     dispatchScratchMessage("scratch-gui-saving-succeeded");
 
     expect(
-      screen.getByRole("button", { name: "saveStatus.saved" }),
-    ).toBeInTheDocument();
+      screen.queryByRole("button", { name: "header.save" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("saveStatus.saved now")).toBeInTheDocument();
   });
 
   test("shows the saving state during a Scratch remix", () => {
-    renderScratchProjectBar({
-      editor: {
-        project: {
-          ...scratchProject,
-          user_id: "teacher-id",
-        },
-      },
-      auth: {
-        user,
+    renderSignedInScratchProjectBar({
+      project: {
+        ...scratchProject,
+        user_id: "teacher-id",
       },
     });
 
     dispatchScratchMessage("scratch-gui-remixing-started");
 
-    expect(
-      screen.getByRole("button", { name: "saveStatus.saving" }),
-    ).toBeDisabled();
+    expect(screen.getByRole("button", { name: "header.save" })).toBeDisabled();
+  });
+
+  test("does not auto-save a non-owner Scratch project before the first remix save", () => {
+    renderSignedInScratchProjectBar({
+      project: {
+        ...scratchProject,
+        updated_at: new Date(Date.now()).toISOString(),
+        user_id: "teacher-id",
+      },
+    });
+
+    expect(screen.queryByText(/saveStatus.saved/)).not.toBeInTheDocument();
+
+    dispatchScratchMessage("scratch-gui-project-changed");
+
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    expect(postMessageToScratchIframe).not.toHaveBeenCalled();
   });
 
   test("does not show save for logged-out Scratch users", () => {

--- a/src/components/ScratchEditor/ScratchIntegrationHOC.jsx
+++ b/src/components/ScratchEditor/ScratchIntegrationHOC.jsx
@@ -8,6 +8,10 @@ import {
   setStageSize,
 } from "@scratch/scratch-gui";
 import { allowedIframeHost } from "../../utils/iframeUtils";
+import { postScratchGuiEvent } from "./events.js";
+
+const targetIdsFor = (targets = []) =>
+  targets.map((target) => target.id).join("|");
 
 const ScratchIntegrationHOC = function (WrappedComponent) {
   class ScratchIntegrationComponent extends React.Component {
@@ -19,13 +23,26 @@ const ScratchIntegrationHOC = function (WrappedComponent) {
       this.handleUpload = this.handleUpload.bind(this);
       this.handleRemix = this.handleRemix.bind(this);
       this.handleSave = this.handleSave.bind(this);
+      this.handleProjectChanged = this.handleProjectChanged.bind(this);
+      this.handleTargetsUpdate = this.handleTargetsUpdate.bind(this);
     }
     componentDidMount() {
       window.addEventListener("message", this.handleMessage);
+      this.props.vm?.on?.("PROJECT_CHANGED", this.handleProjectChanged);
+      this.props.vm?.on?.("targetsUpdate", this.handleTargetsUpdate);
+      this.previousTargetIds = targetIdsFor(this.props.vm?.runtime?.targets);
       this.props.setStageSize();
     }
     componentWillUnmount() {
       window.removeEventListener("message", this.handleMessage);
+      this.props.vm?.removeListener?.(
+        "PROJECT_CHANGED",
+        this.handleProjectChanged,
+      );
+      this.props.vm?.removeListener?.(
+        "targetsUpdate",
+        this.handleTargetsUpdate,
+      );
     }
 
     handleMessage(event) {
@@ -40,7 +57,7 @@ const ScratchIntegrationHOC = function (WrappedComponent) {
         return;
       }
 
-      switch (event.data.type) {
+      switch (event.data?.type) {
         case "scratch-gui-download":
           this.handleDownload(event);
           break;
@@ -69,15 +86,30 @@ const ScratchIntegrationHOC = function (WrappedComponent) {
     }
     handleUpload(event) {
       const file = event.data.file;
-      file?.arrayBuffer()?.then((arrayBuffer) => {
-        this.props.loadProject(arrayBuffer);
-      });
+      file
+        ?.arrayBuffer()
+        ?.then((arrayBuffer) => this.props.loadProject(arrayBuffer))
+        ?.then(this.handleProjectChanged);
     }
     handleRemix() {
       this.props.onClickRemix();
     }
     handleSave() {
       this.props.onClickSave();
+    }
+    handleProjectChanged() {
+      postScratchGuiEvent("scratch-gui-project-changed");
+    }
+    handleTargetsUpdate({ targetList } = {}) {
+      const targetIds = targetIdsFor(targetList);
+      if (!targetIds) {
+        return;
+      }
+
+      if (this.previousTargetIds && this.previousTargetIds !== targetIds) {
+        this.handleProjectChanged();
+      }
+      this.previousTargetIds = targetIds;
     }
     render() {
       const {
@@ -99,6 +131,7 @@ const ScratchIntegrationHOC = function (WrappedComponent) {
       state.scratchGui.vm,
     ),
     loadProject: state.scratchGui.vm.loadProject.bind(state.scratchGui.vm),
+    vm: state.scratchGui.vm,
   });
 
   const mapDispatchToProps = (dispatch) => ({
@@ -113,6 +146,7 @@ const ScratchIntegrationHOC = function (WrappedComponent) {
     onClickRemix: PropTypes.func,
     onClickSave: PropTypes.func,
     setStageSize: PropTypes.func,
+    vm: PropTypes.object,
   };
   return connect(
     mapStateToProps,

--- a/src/components/ScratchEditor/ScratchIntegrationHOC.jsx
+++ b/src/components/ScratchEditor/ScratchIntegrationHOC.jsx
@@ -10,9 +10,6 @@ import {
 import { allowedIframeHost } from "../../utils/iframeUtils";
 import { postScratchGuiEvent } from "./events.js";
 
-const targetIdsFor = (targets = []) =>
-  targets.map((target) => target.id).join("|");
-
 const ScratchIntegrationHOC = function (WrappedComponent) {
   class ScratchIntegrationComponent extends React.Component {
     constructor(props) {
@@ -24,24 +21,17 @@ const ScratchIntegrationHOC = function (WrappedComponent) {
       this.handleRemix = this.handleRemix.bind(this);
       this.handleSave = this.handleSave.bind(this);
       this.handleProjectChanged = this.handleProjectChanged.bind(this);
-      this.handleTargetsUpdate = this.handleTargetsUpdate.bind(this);
     }
     componentDidMount() {
       window.addEventListener("message", this.handleMessage);
-      this.props.vm?.on?.("PROJECT_CHANGED", this.handleProjectChanged);
-      this.props.vm?.on?.("targetsUpdate", this.handleTargetsUpdate);
-      this.previousTargetIds = targetIdsFor(this.props.vm?.runtime?.targets);
+      this.props.vm.on("PROJECT_CHANGED", this.handleProjectChanged);
       this.props.setStageSize();
     }
     componentWillUnmount() {
       window.removeEventListener("message", this.handleMessage);
-      this.props.vm?.removeListener?.(
+      this.props.vm.removeListener(
         "PROJECT_CHANGED",
         this.handleProjectChanged,
-      );
-      this.props.vm?.removeListener?.(
-        "targetsUpdate",
-        this.handleTargetsUpdate,
       );
     }
 
@@ -99,17 +89,6 @@ const ScratchIntegrationHOC = function (WrappedComponent) {
     }
     handleProjectChanged() {
       postScratchGuiEvent("scratch-gui-project-changed");
-    }
-    handleTargetsUpdate({ targetList } = {}) {
-      const targetIds = targetIdsFor(targetList);
-      if (!targetIds) {
-        return;
-      }
-
-      if (this.previousTargetIds && this.previousTargetIds !== targetIds) {
-        this.handleProjectChanged();
-      }
-      this.previousTargetIds = targetIds;
     }
     render() {
       const {

--- a/src/components/ScratchEditor/ScratchIntegrationHOC.test.jsx
+++ b/src/components/ScratchEditor/ScratchIntegrationHOC.test.jsx
@@ -38,9 +38,6 @@ describe("ScratchIntegrationHOC", () => {
     mockLoadProject.mockClear();
     mockVm.on.mockClear();
     mockVm.removeListener.mockClear();
-    mockVm.runtime = {
-      targets: [{ id: "stage" }, { id: "sprite-1" }],
-    };
     postScratchGuiEvent.mockClear();
     process.env.REACT_APP_ALLOWED_IFRAME_ORIGINS = allowedOrigin;
     const mockStore = configureStore([]);
@@ -137,32 +134,6 @@ describe("ScratchIntegrationHOC", () => {
         expect(postScratchGuiEvent).toHaveBeenCalledWith(
           "scratch-gui-project-changed",
         );
-      });
-
-      it("posts a project-changed event when the target list changes", () => {
-        render(
-          React.createElement(
-            Provider,
-            { store },
-            React.createElement(Wrapped),
-          ),
-        );
-
-        const targetsUpdateHandler = getVmHandler("targetsUpdate");
-        const targetList = [
-          { id: "stage" },
-          { id: "sprite-1" },
-          { id: "sprite-2" },
-        ];
-
-        targetsUpdateHandler({ targetList });
-        expect(postScratchGuiEvent).toHaveBeenCalledWith(
-          "scratch-gui-project-changed",
-        );
-
-        postScratchGuiEvent.mockClear();
-        targetsUpdateHandler({ targetList });
-        expect(postScratchGuiEvent).not.toHaveBeenCalled();
       });
     });
   });

--- a/src/components/ScratchEditor/ScratchIntegrationHOC.test.jsx
+++ b/src/components/ScratchEditor/ScratchIntegrationHOC.test.jsx
@@ -2,18 +2,27 @@ const React = require("react");
 const { render, waitFor } = require("@testing-library/react");
 const { Provider } = require("react-redux");
 const configureStore = require("redux-mock-store").default;
-const ScratchIntegrationHOC = require("./ScratchIntegrationHOC").default;
 
 jest.mock("file-saver", () => ({ saveAs: jest.fn() }));
+jest.mock("./events.js", () => ({ postScratchGuiEvent: jest.fn() }));
 jest.mock("@scratch/scratch-gui", () => ({
   remixProject: () => ({ type: "remix" }),
   manualUpdateProject: () => ({ type: "manualUpdate" }),
   setStageSize: () => ({ type: "setStageSize" }),
 }));
 
+const ScratchIntegrationHOC = require("./ScratchIntegrationHOC").default;
+const { postScratchGuiEvent } = require("./events.js");
+
 describe("ScratchIntegrationHOC", () => {
   const mockSaveProjectSb3 = jest.fn();
   const mockLoadProject = jest.fn();
+  const mockVm = {
+    saveProjectSb3: mockSaveProjectSb3,
+    loadProject: mockLoadProject,
+    on: jest.fn(),
+    removeListener: jest.fn(),
+  };
   const allowedOrigin = "https://editor.example.com";
   let store;
   let Wrapped;
@@ -27,14 +36,17 @@ describe("ScratchIntegrationHOC", () => {
     }
     mockSaveProjectSb3.mockClear();
     mockLoadProject.mockClear();
+    mockVm.on.mockClear();
+    mockVm.removeListener.mockClear();
+    mockVm.runtime = {
+      targets: [{ id: "stage" }, { id: "sprite-1" }],
+    };
+    postScratchGuiEvent.mockClear();
     process.env.REACT_APP_ALLOWED_IFRAME_ORIGINS = allowedOrigin;
     const mockStore = configureStore([]);
     store = mockStore({
       scratchGui: {
-        vm: {
-          saveProjectSb3: mockSaveProjectSb3,
-          loadProject: mockLoadProject,
-        },
+        vm: mockVm,
       },
     });
     const Dummy = () =>
@@ -45,6 +57,11 @@ describe("ScratchIntegrationHOC", () => {
   afterEach(() => {
     delete process.env.REACT_APP_ALLOWED_IFRAME_ORIGINS;
   });
+
+  const getVmHandler = (eventName) =>
+    mockVm.on.mock.calls.find(
+      ([registeredEventName]) => registeredEventName === eventName,
+    )?.[1];
 
   describe("scratch-gui-download message", () => {
     it("calls saveProjectSb3 and saveAs with blob and filename", async () => {
@@ -80,6 +97,7 @@ describe("ScratchIntegrationHOC", () => {
       const file = {
         arrayBuffer: jest.fn().mockResolvedValue(arrayBuffer),
       };
+      mockLoadProject.mockResolvedValue();
 
       render(
         React.createElement(Provider, { store }, React.createElement(Wrapped)),
@@ -98,6 +116,53 @@ describe("ScratchIntegrationHOC", () => {
       await waitFor(() => {
         expect(file.arrayBuffer).toHaveBeenCalledTimes(1);
         expect(mockLoadProject).toHaveBeenCalledWith(arrayBuffer);
+        expect(postScratchGuiEvent).toHaveBeenCalledWith(
+          "scratch-gui-project-changed",
+        );
+      });
+    });
+
+    describe("Scratch VM project changes", () => {
+      it("posts a project-changed event to the parent window", () => {
+        render(
+          React.createElement(
+            Provider,
+            { store },
+            React.createElement(Wrapped),
+          ),
+        );
+
+        getVmHandler("PROJECT_CHANGED")();
+
+        expect(postScratchGuiEvent).toHaveBeenCalledWith(
+          "scratch-gui-project-changed",
+        );
+      });
+
+      it("posts a project-changed event when the target list changes", () => {
+        render(
+          React.createElement(
+            Provider,
+            { store },
+            React.createElement(Wrapped),
+          ),
+        );
+
+        const targetsUpdateHandler = getVmHandler("targetsUpdate");
+        const targetList = [
+          { id: "stage" },
+          { id: "sprite-1" },
+          { id: "sprite-2" },
+        ];
+
+        targetsUpdateHandler({ targetList });
+        expect(postScratchGuiEvent).toHaveBeenCalledWith(
+          "scratch-gui-project-changed",
+        );
+
+        postScratchGuiEvent.mockClear();
+        targetsUpdateHandler({ targetList });
+        expect(postScratchGuiEvent).not.toHaveBeenCalled();
       });
     });
   });

--- a/src/hooks/useScratchSave.js
+++ b/src/hooks/useScratchSave.js
@@ -22,18 +22,17 @@ export const useScratchSave = ({ enabled = true } = {}) => {
     projectOwner,
     scratchIframeProjectIdentifier,
   });
-  const { isScratchSaving, saveScratchProject, scratchSaveLabelKey } =
-    useScratchSaveState({
-      enabled: enableScratchSaveState,
-    });
+  const autoSaveEnabled = Boolean(project?.identifier && !shouldRemixOnSave);
+  const { saveScratchProject } = useScratchSaveState({
+    enabled: enableScratchSaveState,
+    autoSaveEnabled,
+  });
 
   return {
     enableScratchSaveState,
-    isScratchSaving,
     loading,
     projectOwner,
     saveScratchProject,
-    scratchSaveLabelKey,
     shouldRemixOnSave,
     user,
   };

--- a/src/hooks/useScratchSaveState.js
+++ b/src/hooks/useScratchSaveState.js
@@ -40,7 +40,9 @@ export const useScratchSaveState = ({
 
   const scheduleAutoSave = useCallback(
     (delay = SCRATCH_AUTOSAVE_DELAY_MS) => {
-      clearAutoSaveTimeout();
+      if (autoSaveTimeoutRef.current) {
+        return;
+      }
 
       autoSaveTimeoutRef.current = setTimeout(() => {
         autoSaveTimeoutRef.current = null;
@@ -58,7 +60,7 @@ export const useScratchSaveState = ({
         postSaveRequest({ autosave: true });
       }, delay);
     },
-    [clearAutoSaveTimeout, postSaveRequest],
+    [postSaveRequest],
   );
 
   const scheduleQueuedAutoSave = useCallback(() => {

--- a/src/hooks/useScratchSaveState.js
+++ b/src/hooks/useScratchSaveState.js
@@ -1,72 +1,101 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef } from "react";
+import { useDispatch } from "react-redux";
 import {
   getScratchAllowedOrigin,
   postMessageToScratchIframe,
 } from "../utils/scratchIframe";
+import {
+  scratchSaveFailed,
+  scratchSaveStarted,
+  scratchSaveSucceeded,
+} from "../redux/EditorSlice";
 
-const SCRATCH_SAVE_LABEL_KEYS = {
-  idle: "header.save",
-  saving: "saveStatus.saving",
-  saved: "saveStatus.saved",
-};
-const SCRATCH_SAVE_MINIMUM_SAVING_DURATION_MS = 1000;
-const SCRATCH_SAVE_RESET_DELAY_MS = 5000;
+const SCRATCH_AUTOSAVE_DELAY_MS = 2000;
 
-export const useScratchSaveState = ({ enabled = false } = {}) => {
-  const scratchSaveTimeoutRef = useRef(null);
-  const scratchSavingStartedAtRef = useRef(null);
-  const [scratchSaveState, setScratchSaveState] = useState("idle");
+export const useScratchSaveState = ({
+  enabled = false,
+  autoSaveEnabled = false,
+} = {}) => {
+  const dispatch = useDispatch();
+  const autoSaveTimeoutRef = useRef(null);
+  const saveInFlightRef = useRef(false);
+  const autoSaveEnabledRef = useRef(false);
+  const autoSaveQueuedAfterSaveRef = useRef(false);
+  const projectChangedAtRef = useRef(null);
+
+  const clearAutoSaveTimeout = useCallback(() => {
+    if (autoSaveTimeoutRef.current) {
+      clearTimeout(autoSaveTimeoutRef.current);
+      autoSaveTimeoutRef.current = null;
+    }
+  }, []);
+
+  const postSaveRequest = useCallback(() => {
+    postMessageToScratchIframe({
+      type: "scratch-gui-save",
+    });
+  }, []);
+
+  const scheduleAutoSave = useCallback(
+    (delay = SCRATCH_AUTOSAVE_DELAY_MS) => {
+      clearAutoSaveTimeout();
+
+      autoSaveTimeoutRef.current = setTimeout(() => {
+        autoSaveTimeoutRef.current = null;
+
+        if (!autoSaveEnabledRef.current) {
+          return;
+        }
+
+        if (saveInFlightRef.current) {
+          autoSaveQueuedAfterSaveRef.current = true;
+          return;
+        }
+
+        autoSaveQueuedAfterSaveRef.current = false;
+        postSaveRequest();
+      }, delay);
+    },
+    [clearAutoSaveTimeout, postSaveRequest],
+  );
+
+  const scheduleQueuedAutoSave = useCallback(() => {
+    if (!autoSaveQueuedAfterSaveRef.current) {
+      return;
+    }
+
+    autoSaveQueuedAfterSaveRef.current = false;
+
+    if (!autoSaveEnabledRef.current) {
+      return;
+    }
+
+    const lastChangedAt = projectChangedAtRef.current;
+    const remainingDebounceTime =
+      lastChangedAt == null
+        ? 0
+        : Math.max(0, lastChangedAt + SCRATCH_AUTOSAVE_DELAY_MS - Date.now());
+
+    scheduleAutoSave(remainingDebounceTime);
+  }, [scheduleAutoSave]);
 
   useEffect(() => {
-    const clearScratchSaveTimeout = () => {
-      if (scratchSaveTimeoutRef.current) {
-        clearTimeout(scratchSaveTimeoutRef.current);
-        scratchSaveTimeoutRef.current = null;
-      }
-    };
+    autoSaveEnabledRef.current = Boolean(enabled && autoSaveEnabled);
 
-    const resetScratchSaveState = () => {
-      clearScratchSaveTimeout();
-      scratchSavingStartedAtRef.current = null;
-      setScratchSaveState("idle");
-    };
+    if (!autoSaveEnabledRef.current) {
+      clearAutoSaveTimeout();
+      autoSaveQueuedAfterSaveRef.current = false;
+    }
+  }, [autoSaveEnabled, clearAutoSaveTimeout, enabled]);
 
-    const transitionScratchSaveStateToSaved = () => {
-      scratchSaveTimeoutRef.current = null;
-      scratchSavingStartedAtRef.current = null;
-      setScratchSaveState("saved");
-      scratchSaveTimeoutRef.current = setTimeout(() => {
-        scratchSaveTimeoutRef.current = null;
-        setScratchSaveState("idle");
-      }, SCRATCH_SAVE_RESET_DELAY_MS);
-    };
-
-    const scheduleScratchSaveStateToSaved = () => {
-      clearScratchSaveTimeout();
-
-      const savingStartedAt = scratchSavingStartedAtRef.current;
-      if (savingStartedAt == null) {
-        transitionScratchSaveStateToSaved();
-        return;
-      }
-
-      const savingCanFinishAt =
-        savingStartedAt + SCRATCH_SAVE_MINIMUM_SAVING_DURATION_MS;
-      const remainingSavingTime = savingCanFinishAt - Date.now();
-
-      if (remainingSavingTime <= 0) {
-        transitionScratchSaveStateToSaved();
-        return;
-      }
-
-      scratchSaveTimeoutRef.current = setTimeout(
-        transitionScratchSaveStateToSaved,
-        remainingSavingTime,
-      );
+  useEffect(() => {
+    const resetScratchSaveTracking = () => {
+      saveInFlightRef.current = false;
     };
 
     if (!enabled) {
-      resetScratchSaveState();
+      resetScratchSaveTracking();
+      clearAutoSaveTimeout();
       return undefined;
     }
 
@@ -77,19 +106,38 @@ export const useScratchSaveState = ({ enabled = false } = {}) => {
       }
 
       switch (event.data?.type) {
+        case "scratch-gui-project-changed":
+          if (!autoSaveEnabledRef.current) {
+            break;
+          }
+          projectChangedAtRef.current = Date.now();
+          if (saveInFlightRef.current) {
+            autoSaveQueuedAfterSaveRef.current = true;
+            break;
+          }
+          scheduleAutoSave();
+          break;
         case "scratch-gui-saving-started":
         case "scratch-gui-remixing-started":
-          clearScratchSaveTimeout();
-          scratchSavingStartedAtRef.current = Date.now();
-          setScratchSaveState("saving");
+          saveInFlightRef.current = true;
+          dispatch(scratchSaveStarted());
           break;
         case "scratch-gui-saving-succeeded":
+          saveInFlightRef.current = false;
+          dispatch(scratchSaveSucceeded({ autosave: true }));
+          scheduleQueuedAutoSave();
+          break;
         case "scratch-gui-remixing-succeeded":
-          scheduleScratchSaveStateToSaved();
+          saveInFlightRef.current = false;
+          dispatch(scratchSaveSucceeded({ autosave: false }));
+          scheduleQueuedAutoSave();
           break;
         case "scratch-gui-saving-failed":
         case "scratch-gui-remixing-failed":
-          resetScratchSaveState();
+          autoSaveQueuedAfterSaveRef.current = false;
+          clearAutoSaveTimeout();
+          resetScratchSaveTracking();
+          dispatch(scratchSaveFailed());
           break;
         default:
           break;
@@ -100,21 +148,28 @@ export const useScratchSaveState = ({ enabled = false } = {}) => {
 
     return () => {
       window.removeEventListener("message", handleScratchMessage);
-      clearScratchSaveTimeout();
+      clearAutoSaveTimeout();
     };
-  }, [enabled]);
+  }, [
+    clearAutoSaveTimeout,
+    dispatch,
+    enabled,
+    scheduleAutoSave,
+    scheduleQueuedAutoSave,
+  ]);
 
-  const saveScratchProject = ({ shouldRemixOnSave = false } = {}) => {
-    postMessageToScratchIframe({
-      type: shouldRemixOnSave ? "scratch-gui-remix" : "scratch-gui-save",
-    });
-  };
+  const saveScratchProject = useCallback(
+    ({ shouldRemixOnSave = false } = {}) => {
+      clearAutoSaveTimeout();
+      autoSaveQueuedAfterSaveRef.current = false;
+      postMessageToScratchIframe({
+        type: shouldRemixOnSave ? "scratch-gui-remix" : "scratch-gui-save",
+      });
+    },
+    [clearAutoSaveTimeout],
+  );
 
   return {
-    scratchSaveState,
-    scratchSaveLabelKey:
-      SCRATCH_SAVE_LABEL_KEYS[scratchSaveState] || SCRATCH_SAVE_LABEL_KEYS.idle,
-    isScratchSaving: scratchSaveState === "saving",
     saveScratchProject,
   };
 };

--- a/src/hooks/useScratchSaveState.js
+++ b/src/hooks/useScratchSaveState.js
@@ -19,6 +19,7 @@ export const useScratchSaveState = ({
   const dispatch = useDispatch();
   const autoSaveTimeoutRef = useRef(null);
   const saveInFlightRef = useRef(false);
+  const currentSaveIsAutosaveRef = useRef(false);
   const autoSaveEnabledRef = useRef(false);
   const autoSaveQueuedAfterSaveRef = useRef(false);
   const projectChangedAtRef = useRef(null);
@@ -30,7 +31,8 @@ export const useScratchSaveState = ({
     }
   }, []);
 
-  const postSaveRequest = useCallback(() => {
+  const postSaveRequest = useCallback(({ autosave }) => {
+    currentSaveIsAutosaveRef.current = autosave;
     postMessageToScratchIframe({
       type: "scratch-gui-save",
     });
@@ -53,7 +55,7 @@ export const useScratchSaveState = ({
         }
 
         autoSaveQueuedAfterSaveRef.current = false;
-        postSaveRequest();
+        postSaveRequest({ autosave: true });
       }, delay);
     },
     [clearAutoSaveTimeout, postSaveRequest],
@@ -91,6 +93,7 @@ export const useScratchSaveState = ({
   useEffect(() => {
     const resetScratchSaveTracking = () => {
       saveInFlightRef.current = false;
+      currentSaveIsAutosaveRef.current = false;
     };
 
     if (!enabled) {
@@ -124,20 +127,26 @@ export const useScratchSaveState = ({
           break;
         case "scratch-gui-saving-succeeded":
           saveInFlightRef.current = false;
-          dispatch(scratchSaveSucceeded({ autosave: true }));
+          dispatch(
+            scratchSaveSucceeded({
+              autosave: currentSaveIsAutosaveRef.current,
+            }),
+          );
+          currentSaveIsAutosaveRef.current = false;
           scheduleQueuedAutoSave();
           break;
         case "scratch-gui-remixing-succeeded":
           saveInFlightRef.current = false;
           dispatch(scratchSaveSucceeded({ autosave: false }));
+          currentSaveIsAutosaveRef.current = false;
           scheduleQueuedAutoSave();
           break;
         case "scratch-gui-saving-failed":
         case "scratch-gui-remixing-failed":
-          autoSaveQueuedAfterSaveRef.current = false;
           clearAutoSaveTimeout();
           resetScratchSaveTracking();
           dispatch(scratchSaveFailed());
+          scheduleQueuedAutoSave();
           break;
         default:
           break;
@@ -162,11 +171,17 @@ export const useScratchSaveState = ({
     ({ shouldRemixOnSave = false } = {}) => {
       clearAutoSaveTimeout();
       autoSaveQueuedAfterSaveRef.current = false;
-      postMessageToScratchIframe({
-        type: shouldRemixOnSave ? "scratch-gui-remix" : "scratch-gui-save",
-      });
+      currentSaveIsAutosaveRef.current = false;
+      if (shouldRemixOnSave) {
+        postMessageToScratchIframe({
+          type: "scratch-gui-remix",
+        });
+        return;
+      }
+
+      postSaveRequest({ autosave: false });
     },
-    [clearAutoSaveTimeout],
+    [clearAutoSaveTimeout, postSaveRequest],
   );
 
   return {

--- a/src/hooks/useScratchSaveState.test.js
+++ b/src/hooks/useScratchSaveState.test.js
@@ -1,6 +1,10 @@
+import React from "react";
 import { act, renderHook } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { configureStore } from "@reduxjs/toolkit";
 
 import { useScratchSaveState } from "./useScratchSaveState";
+import editorReducer, { editorInitialState } from "../redux/EditorSlice";
 import {
   getScratchAllowedOrigin,
   postMessageToScratchIframe,
@@ -14,11 +18,34 @@ jest.mock("../utils/scratchIframe", () => ({
 jest.useFakeTimers();
 
 const scratchOrigin = "https://assets.example.com";
+const scratchProject = {
+  identifier: "scratch-project",
+  project_type: "code_editor_scratch",
+  components: [],
+};
 
-const assertScratchSaveState = (result, state, labelKey, isSaving) => {
-  expect(result.current.scratchSaveState).toBe(state);
-  expect(result.current.scratchSaveLabelKey).toBe(labelKey);
-  expect(result.current.isScratchSaving).toBe(isSaving);
+const createScratchStore = () =>
+  configureStore({
+    reducer: {
+      editor: editorReducer,
+    },
+    preloadedState: {
+      editor: {
+        ...editorInitialState,
+        loading: "success",
+        project: scratchProject,
+      },
+    },
+  });
+
+const renderScratchSaveState = (options) => {
+  const store = createScratchStore();
+  const wrapper = ({ children }) => (
+    <Provider store={store}>{children}</Provider>
+  );
+  const hook = renderHook(() => useScratchSaveState(options), { wrapper });
+
+  return { ...hook, store };
 };
 
 const dispatchScratchMessage = (type, origin = scratchOrigin) => {
@@ -47,7 +74,7 @@ describe("useScratchSaveState", () => {
   });
 
   test("posts the scratch save command", () => {
-    const { result } = renderHook(() => useScratchSaveState());
+    const { result } = renderScratchSaveState();
 
     act(() => {
       result.current.saveScratchProject();
@@ -59,7 +86,7 @@ describe("useScratchSaveState", () => {
   });
 
   test("posts the scratch remix command on the first save", () => {
-    const { result } = renderHook(() => useScratchSaveState());
+    const { result } = renderScratchSaveState();
 
     act(() => {
       result.current.saveScratchProject({ shouldRemixOnSave: true });
@@ -70,11 +97,74 @@ describe("useScratchSaveState", () => {
     });
   });
 
-  test("keeps saving visible for at least 1 second before resetting 5 seconds after saved", () => {
-    const { result } = renderHook(() => useScratchSaveState({ enabled: true }));
+  test("does not auto-save project changes until auto-save is enabled", () => {
+    renderScratchSaveState({ enabled: true, autoSaveEnabled: false });
+
+    dispatchScratchMessage("scratch-gui-project-changed");
+
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    expect(postMessageToScratchIframe).not.toHaveBeenCalled();
+  });
+
+  test("auto-saves 2 seconds after a Scratch project change", () => {
+    renderScratchSaveState({ enabled: true, autoSaveEnabled: true });
+
+    dispatchScratchMessage("scratch-gui-project-changed");
+
+    act(() => {
+      jest.advanceTimersByTime(1999);
+    });
+
+    expect(postMessageToScratchIframe).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+
+    expect(postMessageToScratchIframe).toHaveBeenCalledWith({
+      type: "scratch-gui-save",
+    });
+  });
+
+  test("debounces repeated Scratch project changes", () => {
+    renderScratchSaveState({ enabled: true, autoSaveEnabled: true });
+
+    dispatchScratchMessage("scratch-gui-project-changed");
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    dispatchScratchMessage("scratch-gui-project-changed");
+
+    act(() => {
+      jest.advanceTimersByTime(1999);
+    });
+
+    expect(postMessageToScratchIframe).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+
+    expect(postMessageToScratchIframe).toHaveBeenCalledTimes(1);
+    expect(postMessageToScratchIframe).toHaveBeenCalledWith({
+      type: "scratch-gui-save",
+    });
+  });
+
+  test("queues auto-save when a Scratch project change happens during an in-flight save", () => {
+    renderScratchSaveState({ enabled: true, autoSaveEnabled: true });
 
     dispatchScratchMessage("scratch-gui-saving-started");
-    assertScratchSaveState(result, "saving", "saveStatus.saving", true);
+    dispatchScratchMessage("scratch-gui-project-changed");
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
 
     dispatchScratchMessage("scratch-gui-saving-succeeded");
 
@@ -82,70 +172,71 @@ describe("useScratchSaveState", () => {
       jest.advanceTimersByTime(999);
     });
 
-    assertScratchSaveState(result, "saving", "saveStatus.saving", true);
+    expect(postMessageToScratchIframe).not.toHaveBeenCalled();
 
     act(() => {
       jest.advanceTimersByTime(1);
     });
 
-    assertScratchSaveState(result, "saved", "saveStatus.saved", false);
-
-    act(() => {
-      jest.advanceTimersByTime(4999);
+    expect(postMessageToScratchIframe).toHaveBeenCalledWith({
+      type: "scratch-gui-save",
     });
-
-    assertScratchSaveState(result, "saved", "saveStatus.saved", false);
-
-    act(() => {
-      jest.advanceTimersByTime(1);
-    });
-
-    assertScratchSaveState(result, "idle", "header.save", false);
   });
 
-  test("tracks remixing messages with the same save state lifecycle", () => {
-    const { result } = renderHook(() => useScratchSaveState({ enabled: true }));
+  test("tracks saving messages in editor save state", () => {
+    const { store } = renderScratchSaveState({ enabled: true });
+
+    dispatchScratchMessage("scratch-gui-saving-started");
+    expect(store.getState().editor.saving).toBe("pending");
+
+    dispatchScratchMessage("scratch-gui-saving-succeeded");
+
+    expect(store.getState().editor.saving).toBe("success");
+    expect(store.getState().editor.lastSaveAutosave).toBe(true);
+    expect(store.getState().editor.lastSavedTime).toEqual(expect.any(Number));
+  });
+
+  test("tracks remixing messages in editor save state", () => {
+    const { store } = renderScratchSaveState({ enabled: true });
 
     dispatchScratchMessage("scratch-gui-remixing-started");
-    assertScratchSaveState(result, "saving", "saveStatus.saving", true);
+    expect(store.getState().editor.saving).toBe("pending");
 
     dispatchScratchMessage("scratch-gui-remixing-succeeded");
 
-    act(() => {
-      jest.advanceTimersByTime(1000);
-    });
-
-    assertScratchSaveState(result, "saved", "saveStatus.saved", false);
+    expect(store.getState().editor.saving).toBe("success");
+    expect(store.getState().editor.lastSaveAutosave).toBe(false);
+    expect(store.getState().editor.lastSavedTime).toEqual(expect.any(Number));
   });
 
-  test("resets to idle after a remix failure", () => {
-    const { result } = renderHook(() => useScratchSaveState({ enabled: true }));
+  test("sets failed save state after a remix failure", () => {
+    const { store } = renderScratchSaveState({ enabled: true });
 
     dispatchScratchMessage("scratch-gui-remixing-started");
     dispatchScratchMessage("scratch-gui-remixing-failed");
 
-    assertScratchSaveState(result, "idle", "header.save", false);
+    expect(store.getState().editor.saving).toBe("failed");
   });
 
   test("ignores messages from the wrong origin", () => {
-    const { result } = renderHook(() => useScratchSaveState({ enabled: true }));
+    const { store } = renderScratchSaveState({ enabled: true });
 
     dispatchScratchMessage(
       "scratch-gui-saving-started",
       "https://other.example.com",
     );
 
-    assertScratchSaveState(result, "idle", "header.save", false);
+    expect(store.getState().editor.saving).toBe("idle");
   });
 
   test("accepts messages when ASSETS_URL contains a path", () => {
     process.env.ASSETS_URL = `${scratchOrigin}/branches/main`;
     getScratchAllowedOrigin.mockReturnValue(scratchOrigin);
 
-    const { result } = renderHook(() => useScratchSaveState({ enabled: true }));
+    const { store } = renderScratchSaveState({ enabled: true });
 
     dispatchScratchMessage("scratch-gui-saving-started");
 
-    assertScratchSaveState(result, "saving", "saveStatus.saving", true);
+    expect(store.getState().editor.saving).toBe("pending");
   });
 });

--- a/src/hooks/useScratchSaveState.test.js
+++ b/src/hooks/useScratchSaveState.test.js
@@ -129,7 +129,7 @@ describe("useScratchSaveState", () => {
     });
   });
 
-  test("debounces repeated Scratch project changes", () => {
+  test("does not reset a scheduled auto-save after repeated Scratch project changes", () => {
     renderScratchSaveState({ enabled: true, autoSaveEnabled: true });
 
     dispatchScratchMessage("scratch-gui-project-changed");
@@ -141,7 +141,7 @@ describe("useScratchSaveState", () => {
     dispatchScratchMessage("scratch-gui-project-changed");
 
     act(() => {
-      jest.advanceTimersByTime(1999);
+      jest.advanceTimersByTime(999);
     });
 
     expect(postMessageToScratchIframe).not.toHaveBeenCalled();

--- a/src/hooks/useScratchSaveState.test.js
+++ b/src/hooks/useScratchSaveState.test.js
@@ -183,8 +183,17 @@ describe("useScratchSaveState", () => {
     });
   });
 
-  test("tracks saving messages in editor save state", () => {
-    const { store } = renderScratchSaveState({ enabled: true });
+  test("tracks auto-saving messages in editor save state", () => {
+    const { store } = renderScratchSaveState({
+      enabled: true,
+      autoSaveEnabled: true,
+    });
+
+    dispatchScratchMessage("scratch-gui-project-changed");
+
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
 
     dispatchScratchMessage("scratch-gui-saving-started");
     expect(store.getState().editor.saving).toBe("pending");
@@ -193,6 +202,23 @@ describe("useScratchSaveState", () => {
 
     expect(store.getState().editor.saving).toBe("success");
     expect(store.getState().editor.lastSaveAutosave).toBe(true);
+    expect(store.getState().editor.lastSavedTime).toEqual(expect.any(Number));
+  });
+
+  test("tracks manual saving messages in editor save state", () => {
+    const { result, store } = renderScratchSaveState({ enabled: true });
+
+    act(() => {
+      result.current.saveScratchProject();
+    });
+
+    dispatchScratchMessage("scratch-gui-saving-started");
+    expect(store.getState().editor.saving).toBe("pending");
+
+    dispatchScratchMessage("scratch-gui-saving-succeeded");
+
+    expect(store.getState().editor.saving).toBe("success");
+    expect(store.getState().editor.lastSaveAutosave).toBe(false);
     expect(store.getState().editor.lastSavedTime).toEqual(expect.any(Number));
   });
 
@@ -216,6 +242,33 @@ describe("useScratchSaveState", () => {
     dispatchScratchMessage("scratch-gui-remixing-failed");
 
     expect(store.getState().editor.saving).toBe("failed");
+  });
+
+  test("retries a queued auto-save after an in-flight save fails", () => {
+    renderScratchSaveState({ enabled: true, autoSaveEnabled: true });
+
+    dispatchScratchMessage("scratch-gui-saving-started");
+    dispatchScratchMessage("scratch-gui-project-changed");
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    dispatchScratchMessage("scratch-gui-saving-failed");
+
+    act(() => {
+      jest.advanceTimersByTime(999);
+    });
+
+    expect(postMessageToScratchIframe).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+
+    expect(postMessageToScratchIframe).toHaveBeenCalledWith({
+      type: "scratch-gui-save",
+    });
   });
 
   test("ignores messages from the wrong origin", () => {

--- a/src/redux/EditorSlice.js
+++ b/src/redux/EditorSlice.js
@@ -127,6 +127,9 @@ export const editorInitialState = {
   scratchIframeProjectIdentifier: null,
 };
 
+const isScratchProject = (state) =>
+  state.project?.project_type === "code_editor_scratch";
+
 export const EditorSlice = createSlice({
   name: "editor",
   initialState: editorInitialState,
@@ -227,11 +230,42 @@ export const EditorSlice = createSlice({
       state.justLoaded = true;
     },
     applyScratchProjectIdentifierUpdate: (state, action) => {
-      if (state.project?.project_type !== "code_editor_scratch") {
+      if (!isScratchProject(state)) {
         return;
       }
 
       state.project.identifier = action.payload.projectIdentifier;
+    },
+    setScratchLastSavedTime: (state, action) => {
+      if (!isScratchProject(state)) {
+        return;
+      }
+
+      state.lastSavedTime = action.payload.lastSavedTime;
+    },
+    scratchSaveStarted: (state) => {
+      if (!isScratchProject(state)) {
+        return;
+      }
+
+      state.saving = "pending";
+      state.saveTriggered = false;
+    },
+    scratchSaveSucceeded: (state, action) => {
+      if (!isScratchProject(state)) {
+        return;
+      }
+
+      state.lastSaveAutosave = action.payload?.autosave ?? true;
+      state.saving = "success";
+      state.lastSavedTime = Date.now();
+    },
+    scratchSaveFailed: (state) => {
+      if (!isScratchProject(state)) {
+        return;
+      }
+
+      state.saving = "failed";
     },
     setProjectInstructions: (state, action) => {
       state.project.instructions = action.payload;
@@ -410,7 +444,7 @@ export const EditorSlice = createSlice({
     builder.addCase("editor/saveProject/rejected", (state) => {
       state.saving = "failed";
     });
-    builder.addCase("editor/remixProject/pending", (state, action) => {
+    builder.addCase("editor/remixProject/pending", (state) => {
       state.saving = "pending";
       state.saveTriggered = false;
     });
@@ -473,6 +507,10 @@ export const {
   setWebComponent,
   setProject,
   applyScratchProjectIdentifierUpdate,
+  setScratchLastSavedTime,
+  scratchSaveStarted,
+  scratchSaveSucceeded,
+  scratchSaveFailed,
   setProjectInstructions,
   setReadOnly,
   setInstructionsEditable,

--- a/src/redux/EditorSlice.test.js
+++ b/src/redux/EditorSlice.test.js
@@ -16,6 +16,10 @@ import reducer, {
   setCascadeUpdate,
   setProject,
   applyScratchProjectIdentifierUpdate,
+  setScratchLastSavedTime,
+  scratchSaveStarted,
+  scratchSaveSucceeded,
+  scratchSaveFailed,
 } from "./EditorSlice";
 
 const mockCreateRemix = jest.fn();
@@ -896,5 +900,49 @@ describe("initialComponents snapshot", () => {
 
     expect(updatedState.project.identifier).toBe("student-remix");
     expect(updatedState.scratchIframeProjectIdentifier).toBe("scratch-project");
+  });
+
+  test("setScratchLastSavedTime updates the saved timestamp for Scratch projects", () => {
+    const initialState = reducer(
+      undefined,
+      setProject({
+        identifier: "scratch-project",
+        project_type: "code_editor_scratch",
+        components: [],
+      }),
+    );
+
+    const updatedState = reducer(
+      initialState,
+      setScratchLastSavedTime({ lastSavedTime: 1669808953 }),
+    );
+
+    expect(updatedState.lastSavedTime).toBe(1669808953);
+  });
+
+  test("Scratch save lifecycle actions update editor save state", () => {
+    Date.now = jest.fn(() => 1669808953);
+    const initialState = reducer(
+      undefined,
+      setProject({
+        identifier: "scratch-project",
+        project_type: "code_editor_scratch",
+        components: [],
+      }),
+    );
+
+    const savingState = reducer(initialState, scratchSaveStarted());
+    expect(savingState.saving).toBe("pending");
+
+    const savedState = reducer(
+      savingState,
+      scratchSaveSucceeded({ autosave: true }),
+    );
+    expect(savedState.saving).toBe("success");
+    expect(savedState.lastSavedTime).toBe(1669808953);
+    expect(savedState.lastSaveAutosave).toBe(true);
+
+    const failedState = reducer(savedState, scratchSaveFailed());
+    expect(failedState.saving).toBe("failed");
   });
 });


### PR DESCRIPTION
Closes: https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1212

This change adds autosave for Scratch projects and keeps the behaviour close to the existing Python and HTML editors.

Python and HTML already autosave after a short delay when the user owns a saved project. Scratch is different because project changes happen inside the Scratch iframe, so we listen to Scratch VM change events and pass those changes back to the main app.

Autosave only starts once the Scratch project has been saved or remixed and has an identifier. New Scratch projects, and projects that need to be remixed first, still show the manual Save button. After that first save/remix, the manual Save button is hidden and the header shows the autosave status instead.

The autosave delay is 2 seconds. If a save is already running, we do not start another one immediately; we queue the next autosave until the current save finishes.

Scratch save events now update the shared Redux editor save state: saving, lastSavedTime, and lastSaveAutosave. This is the same state used by the existing save status UI, so Scratch can reuse SaveStatus instead of keeping a separate local save-status flow in the Scratch hook.

The Scratch save/remix tests have also been updated to cover the new flow: first save/remix, identifier update, hiding the manual Save button, and triggering autosave once the project is eligible.

As Teacher:

https://github.com/user-attachments/assets/ee9010bc-0ae8-4cb7-953e-eeaea70253ec

As Student (first time):

https://github.com/user-attachments/assets/60bb464b-6bb6-4fc9-9131-d9c84994496d

