### PR TITLE
fix: download button styles

### DIFF
--- a/src/assets/stylesheets/DesignSystemButton.scss
+++ b/src/assets/stylesheets/DesignSystemButton.scss
@@ -39,8 +39,6 @@
 
 .--dark * {
   .rpf-button--secondary {
-    border-color: $rpf-teal-400;
-
     span {
       color: $rpf-white;
     }
@@ -57,8 +55,6 @@
       &::before {
         background-color: rgba($rpf-white, 0.1);
       }
-
-      border-color: $rpf-teal-400;
     }
 
     &:active {
@@ -113,7 +109,7 @@
 
 .--light * {
   .rpf-button--secondary {
-     &::before {
+    &::before {
       background-color: rgba($rpf-white, 1);
     }
 
@@ -121,8 +117,6 @@
       &::before {
         background-color: rgba(231, 248, 247, 1);
       }
-
-      border-color: $rpf-teal-400;
     }
 
     &:active {

--- a/src/components/DownloadButton/DownloadButton.jsx
+++ b/src/components/DownloadButton/DownloadButton.jsx
@@ -8,7 +8,7 @@ import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 import PropTypes from "prop-types";
 
-import DesignSystemButton from "../DesignSystemButton/DesignSystemButton";
+import { Button } from "@raspberrypifoundation/design-system-react";
 
 const DownloadButton = (props) => {
   const {
@@ -73,11 +73,10 @@ const DownloadButton = (props) => {
   };
 
   return (
-    <DesignSystemButton
+    <Button
       className={className}
       onClick={onClickDownload}
       text={buttonText}
-      textAlways
       icon={Icon ? <Icon /> : null}
       type={type}
       {...otherProps}


### PR DESCRIPTION
Closes https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1414

## Summary

- Changes nested button within `DownloadButton` to use the Design System Button
- Removes soem hardcoded teal colours from the button theme
  - teal theme style remains when `user_editor_styles` is true due to global theming

## Screenshots

The hover style when false is not quite right, but this should be tackled in https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1298 its too big of an issue here.

`use_editor_style` = false
<img width="309" height="72" alt="Screenshot 2026-05-20 at 11 07 21" src="https://github.com/user-attachments/assets/d5fdbb5c-8853-4afa-967e-a80b5ae5eed2" />
<img width="315" height="76" alt="Screenshot 2026-05-20 at 11 07 18" src="https://github.com/user-attachments/assets/79aca308-0404-49dc-91ee-1e3a287f4d80" />
<img width="317" height="77" alt="Screenshot 2026-05-20 at 10 27 10" src="https://github.com/user-attachments/assets/70da1856-287f-4692-9a94-12e202411289" />
<img width="311" height="68" alt="Screenshot 2026-05-20 at 10 27 17" src="https://github.com/user-attachments/assets/a6aa469c-fca5-4bfe-93ea-70089020cf6d" />

`use_editor_style` = true
<img width="308" height="69" alt="Screenshot 2026-05-20 at 11 11 06" src="https://github.com/user-attachments/assets/98f68d8f-38a1-4308-9441-076f01971e49" />
<img width="309" height="84" alt="Screenshot 2026-05-20 at 11 11 14" src="https://github.com/user-attachments/assets/e0436bd2-39dc-49d2-a947-af4d5959bc39" />
<img width="311" height="71" alt="Screenshot 2026-05-20 at 11 11 20" src="https://github.com/user-attachments/assets/cd08c813-14f0-43ee-9486-4b1ba0ee5151" />
<img width="310" height="72" alt="Screenshot 2026-05-20 at 11 11 31" src="https://github.com/user-attachments/assets/e7ad46c5-9ebe-4ca9-b611-30f4e0ce6fe0" />
