### PR TITLE
Add fallback colour to header overlay

### DIFF
--- a/src/assets/stylesheets/Scratch.scss
+++ b/src/assets/stylesheets/Scratch.scss
@@ -39,7 +39,11 @@ div[class^="gui_body-wrapper_"] {
 }
 
 div[class^="stage-header_stage-header-wrapper-overlay_"] {
-  background-color: var(--rpf-white);
+  /* Fallback value for the CSS variable as background-color
+    can silently fall back to transparent (the initial background-color value)
+    if the custom property isn't resolved at the time the element is painted
+    which allows the underlying panels to bleed through. */
+  background-color: var(--rpf-white, #ffffff);
 }
 
 li[class*="gui_tab_"] {


### PR DESCRIPTION
Work for https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1406

<img width="1212" height="569" alt="image" src="https://github.com/user-attachments/assets/7cefe3ee-1eb4-4222-9b0b-f75ef77ef6db" />

<img width="1212" height="569" alt="image" src="https://github.com/user-attachments/assets/3bc3351c-ec17-4845-b737-425e9af4571b" />
