### PR TITLE
Add improved error messaging to python projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "lint": "eslint 'src/**/*.{js,jsx}' cypress/**/*.js",
     "lint:fix": "eslint --fix 'src/**/*.{js,jsx}' cypress/**/*.js",
     "stylelint": "stylelint src/**/*.scss",
-    "test": "node scripts/test.js --transformIgnorePatterns 'node_modules/(?!three)/'",
+    "test": "node scripts/test.js",
     "watch-css": "sass --load-path=./ -q --watch src:src",
     "heroku-postbuild": "export PUBLIC_URL='' && yarn build"
   },
@@ -228,7 +228,7 @@
       "^(?!.*\\.(js|jsx|mjs|cjs|ts|tsx|css|scss|svg|json)$)": "<rootDir>/node_modules/jest-transform-stub"
     },
     "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx|mjs|cjs|ts|tsx)$",
+      "[/\\\\]node_modules[/\\\\](?!three).+\\.(js|jsx|mjs|cjs|ts|tsx)$",
       "^.+\\.module\\.(css|sass|scss)$"
     ],
     "modulePaths": [],

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@juggle/resize-observer": "^3.3.1",
     "@lezer/highlight": "^1.0.0",
     "@raspberrypifoundation/design-system-react": "^2.7.0",
+    "@raspberrypifoundation/python-friendly-error-messages": "0.1.6",
     "@react-three/drei": "9.114.3",
     "@react-three/fiber": "^8.0.13",
     "@reduxjs/toolkit": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "codemirror": "^6.0.1",
     "container-query-polyfill": "^1.0.2",
     "date-fns": "^4.1.0",
+    "dompurify": "^3.4.6",
     "eslint-config-prettier": "^8.8.0",
     "file-saver": "^2.0.5",
     "fs-extra": "^9.0.1",

--- a/src/assets/stylesheets/ErrorMessage.scss
+++ b/src/assets/stylesheets/ErrorMessage.scss
@@ -21,4 +21,14 @@
   &--large {
     @include font-size-2(regular);
   }
+
+  // Only displaying title and summary of friendlyError
+  &__friendly {
+    .pfem__why,
+    .pfem__steps,
+    .pfem__patch,
+    .pfem__details {
+      display: none;
+    }
+  }
 }

--- a/src/components/Editor/ErrorMessage/ErrorMessage.jsx
+++ b/src/components/Editor/ErrorMessage/ErrorMessage.jsx
@@ -20,16 +20,14 @@ const ErrorMessage = () => {
       {friendlyError && (
         <div className="error-message__friendly">
           {friendlyError.title && (
-            <p
-              className="error-message__friendly-title"
-              dangerouslySetInnerHTML={{ __html: friendlyError.title }}
-            />
+            <p className="error-message__friendly-title">
+              {friendlyError.title}
+            </p>
           )}
           {friendlyError.summary && (
-            <p
-              className="error-message__friendly-summary"
-              dangerouslySetInnerHTML={{ __html: friendlyError.summary }}
-            />
+            <p className="error-message__friendly-summary">
+              {friendlyError.summary}
+            </p>
           )}
         </div>
       )}

--- a/src/components/Editor/ErrorMessage/ErrorMessage.jsx
+++ b/src/components/Editor/ErrorMessage/ErrorMessage.jsx
@@ -1,6 +1,7 @@
 import React, { useContext, useEffect, useRef } from "react";
 import "../../../assets/stylesheets/ErrorMessage.scss";
 import { useSelector } from "react-redux";
+import DOMPurify from "dompurify";
 import { SettingsContext } from "../../../utils/settings";
 
 const ErrorMessage = () => {
@@ -14,22 +15,19 @@ const ErrorMessage = () => {
       message.current.innerHTML = error;
     }
   }, [error]);
+
+  const friendlyErrorHtml = friendlyError?.html
+    ? DOMPurify.sanitize(friendlyError.html)
+    : null;
+
   return error ? (
     <div className={`error-message error-message--${settings.fontSize}`}>
-      <pre ref={message} className="error-message__content"></pre>
-      {friendlyError && (
-        <div className="error-message__friendly">
-          {friendlyError.title && (
-            <p className="error-message__friendly-title">
-              {friendlyError.title}
-            </p>
-          )}
-          {friendlyError.summary && (
-            <p className="error-message__friendly-summary">
-              {friendlyError.summary}
-            </p>
-          )}
-        </div>
+      <pre ref={message} className="error-message__content" />
+      {friendlyErrorHtml && (
+        <div
+          className="error-message__friendly"
+          dangerouslySetInnerHTML={{ __html: friendlyErrorHtml }}
+        />
       )}
     </div>
   ) : null;

--- a/src/components/Editor/ErrorMessage/ErrorMessage.jsx
+++ b/src/components/Editor/ErrorMessage/ErrorMessage.jsx
@@ -1,20 +1,15 @@
-import React, { useContext, useEffect, useRef } from "react";
+import React, { useContext } from "react";
 import "../../../assets/stylesheets/ErrorMessage.scss";
 import { useSelector } from "react-redux";
 import DOMPurify from "dompurify";
 import { SettingsContext } from "../../../utils/settings";
 
 const ErrorMessage = () => {
-  const message = useRef();
   const error = useSelector((state) => state.editor.error);
   const friendlyError = useSelector((state) => state.editor.friendlyError);
   const settings = useContext(SettingsContext);
 
-  useEffect(() => {
-    if (message.current) {
-      message.current.innerHTML = error;
-    }
-  }, [error]);
+  const errorHtml = DOMPurify.sanitize(error);
 
   const friendlyErrorHtml = friendlyError?.html
     ? DOMPurify.sanitize(friendlyError.html)
@@ -22,7 +17,10 @@ const ErrorMessage = () => {
 
   return error ? (
     <div className={`error-message error-message--${settings.fontSize}`}>
-      <pre ref={message} className="error-message__content" />
+      <pre
+        className="error-message__content"
+        dangerouslySetInnerHTML={{ __html: errorHtml }}
+      />
       {friendlyErrorHtml && (
         <div
           className="error-message__friendly"

--- a/src/components/Editor/ErrorMessage/ErrorMessage.jsx
+++ b/src/components/Editor/ErrorMessage/ErrorMessage.jsx
@@ -6,6 +6,7 @@ import { SettingsContext } from "../../../utils/settings";
 const ErrorMessage = () => {
   const message = useRef();
   const error = useSelector((state) => state.editor.error);
+  const friendlyError = useSelector((state) => state.editor.friendlyError);
   const settings = useContext(SettingsContext);
 
   useEffect(() => {
@@ -16,6 +17,22 @@ const ErrorMessage = () => {
   return error ? (
     <div className={`error-message error-message--${settings.fontSize}`}>
       <pre ref={message} className="error-message__content"></pre>
+      {friendlyError && (
+        <div className="error-message__friendly">
+          {friendlyError.title && (
+            <p
+              className="error-message__friendly-title"
+              dangerouslySetInnerHTML={{ __html: friendlyError.title }}
+            />
+          )}
+          {friendlyError.summary && (
+            <p
+              className="error-message__friendly-summary"
+              dangerouslySetInnerHTML={{ __html: friendlyError.summary }}
+            />
+          )}
+        </div>
+      )}
     </div>
   ) : null;
 };

--- a/src/components/Editor/ErrorMessage/ErrorMessage.test.js
+++ b/src/components/Editor/ErrorMessage/ErrorMessage.test.js
@@ -8,7 +8,7 @@ describe("When error is set", () => {
   const middlewares = [];
   const mockStore = configureStore(middlewares);
 
-  describe("When error is set", () => {
+  describe("When error is set and friendlyError is not set", () => {
     beforeEach(() => {
       const initialState = {
         editor: {
@@ -34,6 +34,49 @@ describe("When error is set", () => {
     test("Font size class is set correctly", () => {
       const errorMessage = screen.queryByText("Oops").parentElement;
       expect(errorMessage).toHaveClass("error-message--myFontSize");
+    });
+
+    test("Does not display friendly error elements", () => {
+      expect(
+        document.querySelector(".error-message__friendly"),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("When friendlyError is set", () => {
+    beforeEach(() => {
+      const initialState = {
+        editor: {
+          error: "An error occurred",
+          friendlyError: {
+            title: "Friendly Error Title",
+            summary: "This is a more user-friendly explanation of the error.",
+          },
+        },
+      };
+      const store = mockStore(initialState);
+      render(
+        <Provider store={store}>
+          <SettingsContext.Provider
+            value={{ theme: "dark", fontSize: "myFontSize" }}
+          >
+            <ErrorMessage />
+          </SettingsContext.Provider>
+        </Provider>,
+      );
+    });
+
+    test("Friendly error title and summary display", () => {
+      expect(screen.getByText("Friendly Error Title")).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "This is a more user-friendly explanation of the error.",
+        ),
+      ).toBeInTheDocument();
+    });
+
+    test("original error message also displays", () => {
+      expect(screen.queryByText("An error occurred")).toBeInTheDocument();
     });
   });
 

--- a/src/components/Editor/ErrorMessage/ErrorMessage.test.js
+++ b/src/components/Editor/ErrorMessage/ErrorMessage.test.js
@@ -8,7 +8,7 @@ describe("When error is set", () => {
   const middlewares = [];
   const mockStore = configureStore(middlewares);
 
-  describe("When error is set and friendlyError is not set", () => {
+  describe("When friendlyError is not set", () => {
     beforeEach(() => {
       const initialState = {
         editor: {
@@ -49,8 +49,7 @@ describe("When error is set", () => {
         editor: {
           error: "An error occurred",
           friendlyError: {
-            title: "Friendly Error Title",
-            summary: "This is a more user-friendly explanation of the error.",
+            html: '<div class="pfem__title">Friendly Error Title</div><div class="pfem__summary">This is a more user-friendly explanation of the error.</div><div class="pfem__why">A variable created in another place might not be available here.</div><ul class="pfem__steps"><li>Move the line that makes it to above where you use it.</li><li>Or set it here just before you use it.</li></ul><pre class="pfem__patch">kettle = 0</pre><details class="pfem__details"><summary>Original error</summary><pre>An error occurred</pre></details>',
           },
         },
       };
@@ -75,8 +74,36 @@ describe("When error is set", () => {
       ).toBeInTheDocument();
     });
 
-    test("original error message also displays", () => {
-      expect(screen.queryByText("An error occurred")).toBeInTheDocument();
+    it("strips unsafe scripts", () => {
+      const initialState = {
+        editor: {
+          error: "An error occurred",
+          friendlyError: {
+            html: `
+                <div class="pfem__title">Friendly Error Title</div>
+                <img src="x" onerror="alert('xss')" />
+                <script>alert("xss")</script>
+                <a href="javascript:alert('xss')">Bad link</a>
+              `,
+          },
+        },
+      };
+      const store = mockStore(initialState);
+      const { container } = render(
+        <Provider store={store}>
+          <SettingsContext.Provider
+            value={{ theme: "dark", fontSize: "myFontSize" }}
+          >
+            <ErrorMessage />
+          </SettingsContext.Provider>
+        </Provider>,
+      );
+
+      expect(container.querySelector("script")).not.toBeInTheDocument();
+      expect(container.querySelector("[onerror]")).not.toBeInTheDocument();
+      expect(
+        container.querySelector('a[href^="javascript:"]'),
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/src/components/Editor/Runners/PythonRunner/PyodideRunner/PyodideRunner.jsx
+++ b/src/components/Editor/Runners/PythonRunner/PyodideRunner/PyodideRunner.jsx
@@ -39,14 +39,20 @@ const getWorkerURL = (url) => {
   return URL.createObjectURL(blob);
 };
 
-const PyodideRunner = ({ active, outputPanels = ["text", "visual"] }) => {
+const PyodideRunner = ({
+  active,
+  outputPanels = ["text", "visual"],
+  friendlyErrorsEnabled = false,
+}) => {
   const [pyodideWorker, setPyodideWorker] = useState(null);
 
   useEffect(() => {
-    loadCopydeckFor(navigator.language, {
-      base: `${process.env.PUBLIC_URL}/python-error-copydecks/`,
-    });
-    registerAdapter("pyodide", pyodideAdapter);
+    if (friendlyErrorsEnabled) {
+      loadCopydeckFor(navigator.language, {
+        base: `${process.env.PUBLIC_URL}/python-error-copydecks/`,
+      });
+      registerAdapter("pyodide", pyodideAdapter);
+    }
   }, []);
 
   useEffect(() => {
@@ -221,17 +227,19 @@ const PyodideRunner = ({ active, outputPanels = ["text", "visual"] }) => {
       });
       createError(projectIdentifier, userId, { errorType: type, errorMessage });
 
-      const inputCode =
-        projectCode?.find((c) => c.name === "main" && c.extension === "py")
-          ?.content ?? "";
+      if (friendlyErrorsEnabled) {
+        const inputCode =
+          projectCode?.find((c) => c.name === "main" && c.extension === "py")
+            ?.content ?? "";
 
-      const friendlyError = friendlyExplain({
-        error: errorMessage,
-        code: inputCode,
-        runtime: "pyodide",
-      });
-      if (friendlyError?.html) {
-        errorMessage = friendlyError.html;
+        const friendlyError = friendlyExplain({
+          error: errorMessage,
+          code: inputCode,
+          runtime: "pyodide",
+        });
+        if (friendlyError?.html) {
+          errorMessage = friendlyError.html;
+        }
       }
     }
 

--- a/src/components/Editor/Runners/PythonRunner/PyodideRunner/PyodideRunner.jsx
+++ b/src/components/Editor/Runners/PythonRunner/PyodideRunner/PyodideRunner.jsx
@@ -11,6 +11,12 @@ import {
   updateProjectComponent,
   addProjectComponent,
 } from "../../../../../redux/EditorSlice";
+import {
+  loadCopydeckFor,
+  registerAdapter,
+  pyodideAdapter,
+  friendlyExplain,
+} from "@raspberrypifoundation/python-friendly-error-messages";
 import { Tab, Tabs, TabList, TabPanel } from "react-tabs";
 import { useMediaQuery } from "react-responsive";
 import { MOBILE_MEDIA_QUERY } from "../../../../../utils/mediaQueryBreakpoints";
@@ -35,6 +41,13 @@ const getWorkerURL = (url) => {
 
 const PyodideRunner = ({ active, outputPanels = ["text", "visual"] }) => {
   const [pyodideWorker, setPyodideWorker] = useState(null);
+
+  useEffect(() => {
+    loadCopydeckFor(navigator.language, {
+      base: `${process.env.PUBLIC_URL}/python-error-copydecks/`,
+    });
+    registerAdapter("pyodide", pyodideAdapter);
+  }, []);
 
   useEffect(() => {
     if (active) {
@@ -207,6 +220,19 @@ const PyodideRunner = ({ active, outputPanels = ["text", "visual"] }) => {
         reactAppApiEndpoint,
       });
       createError(projectIdentifier, userId, { errorType: type, errorMessage });
+
+      const inputCode =
+        projectCode?.find((c) => c.name === "main" && c.extension === "py")
+          ?.content ?? "";
+
+      const friendlyError = friendlyExplain({
+        error: errorMessage,
+        code: inputCode,
+        runtime: "pyodide",
+      });
+      if (friendlyError?.html) {
+        errorMessage = friendlyError.html;
+      }
     }
 
     dispatch(setError(errorMessage));

--- a/src/components/Editor/Runners/PythonRunner/PyodideRunner/PyodideRunner.jsx
+++ b/src/components/Editor/Runners/PythonRunner/PyodideRunner/PyodideRunner.jsx
@@ -239,16 +239,9 @@ const PyodideRunner = ({
           runtime: "pyodide",
         });
 
-        dispatch(
-          setFriendlyError(
-            friendlyError?.title || friendlyError?.summary
-              ? {
-                  title: friendlyError?.title ?? null,
-                  summary: friendlyError?.summary ?? null,
-                }
-              : null,
-          ),
-        );
+        if (friendlyError?.html) {
+          dispatch(setFriendlyError({ html: friendlyError.html }));
+        }
       }
     }
 

--- a/src/components/Editor/Runners/PythonRunner/PyodideRunner/PyodideRunner.jsx
+++ b/src/components/Editor/Runners/PythonRunner/PyodideRunner/PyodideRunner.jsx
@@ -6,6 +6,7 @@ import { useTranslation } from "react-i18next";
 import classNames from "classnames";
 import {
   setError,
+  setFriendlyError,
   codeRunHandled,
   setLoadedRunner,
   updateProjectComponent,
@@ -237,9 +238,13 @@ const PyodideRunner = ({
           code: inputCode,
           runtime: "pyodide",
         });
-        if (friendlyError?.html) {
-          errorMessage = friendlyError.html;
-        }
+
+        dispatch(
+          setFriendlyError({
+            title: friendlyError?.title ?? null,
+            summary: friendlyError?.summary ?? null,
+          }),
+        );
       }
     }
 
@@ -290,6 +295,7 @@ const PyodideRunner = ({
   const handleRun = async () => {
     output.current.innerHTML = "";
     dispatch(setError(""));
+    dispatch(setFriendlyError(null));
     setVisuals([]);
     stdinClosed.current = false;
 

--- a/src/components/Editor/Runners/PythonRunner/PyodideRunner/PyodideRunner.jsx
+++ b/src/components/Editor/Runners/PythonRunner/PyodideRunner/PyodideRunner.jsx
@@ -54,7 +54,7 @@ const PyodideRunner = ({
       });
       registerAdapter("pyodide", pyodideAdapter);
     }
-  }, []);
+  }, [friendlyErrorsEnabled]);
 
   useEffect(() => {
     if (active) {
@@ -240,10 +240,14 @@ const PyodideRunner = ({
         });
 
         dispatch(
-          setFriendlyError({
-            title: friendlyError?.title ?? null,
-            summary: friendlyError?.summary ?? null,
-          }),
+          setFriendlyError(
+            friendlyError?.title || friendlyError?.summary
+              ? {
+                  title: friendlyError?.title ?? null,
+                  summary: friendlyError?.summary ?? null,
+                }
+              : null,
+          ),
         );
       }
     }

--- a/src/components/Editor/Runners/PythonRunner/PyodideRunner/PyodideRunner.test.js
+++ b/src/components/Editor/Runners/PythonRunner/PyodideRunner/PyodideRunner.test.js
@@ -41,6 +41,10 @@ const project = {
 window.crossOriginIsolated = true;
 process.env.PUBLIC_URL = ".";
 
+const friendlyErrorHtml =
+  '<div class="pfem__title">Friendly error title</div>' +
+  '<div class="pfem__summary">A friendly summary of the error</div>';
+
 const updateRunner = ({ project = {}, codeRunTriggered = false }) => {
   act(() => {
     if (project) {
@@ -451,7 +455,7 @@ describe("When an error is received", () => {
       } = require("@raspberrypifoundation/python-friendly-error-messages"));
 
       friendlyExplain.mockReturnValue({
-        html: '<div class="pfem__title">Friendly error title</div><div class="pfem__summary">A friendly summary of the error</div>',
+        html: friendlyErrorHtml,
       });
 
       render(
@@ -481,7 +485,7 @@ describe("When an error is received", () => {
     test("dispatches setFriendlyError", () => {
       expect(dispatchSpy).toHaveBeenCalledWith(
         setFriendlyError({
-          html: '<div class="pfem__title">Friendly error title</div><div class="pfem__summary">A friendly summary of the error</div>',
+          html: friendlyErrorHtml,
         }),
       );
     });

--- a/src/components/Editor/Runners/PythonRunner/PyodideRunner/PyodideRunner.test.js
+++ b/src/components/Editor/Runners/PythonRunner/PyodideRunner/PyodideRunner.test.js
@@ -20,6 +20,7 @@ import {
   setSenseHatAlwaysEnabled,
   openFile,
   setFocussedFileIndex,
+  setFriendlyError,
 } from "../../../../../redux/EditorSlice.js";
 import store from "../../../../../app/store";
 
@@ -433,6 +434,58 @@ describe("When an error is received", () => {
     expect(dispatchSpy).toHaveBeenCalledWith({
       type: "editor/setError",
       payload: "SyntaxError: something's wrong on line 2 of main.py",
+    });
+  });
+
+  describe("When friendly errors are enabled", () => {
+    let loadCopydeckFor;
+    let registerAdapter;
+    let friendlyExplain;
+
+    beforeEach(() => {
+      ({
+        // Using the global mock in setupTests.js to track calls to these functions
+        loadCopydeckFor,
+        registerAdapter,
+        friendlyExplain,
+      } = require("@raspberrypifoundation/python-friendly-error-messages"));
+
+      friendlyExplain.mockReturnValue({
+        title: "Friendly error title",
+        summary: "A friendly summaryof the error",
+      });
+
+      render(
+        <Provider store={store}>
+          <PyodideRunner active={true} friendlyErrorsEnabled={true} />
+        </Provider>,
+      );
+
+      const worker = PyodideWorker.getLastInstance();
+      worker.postMessageFromWorker({
+        method: "handleError",
+        line: 2,
+        file: "main.py",
+        type: "SyntaxError",
+        info: "something's wrong",
+      });
+    });
+
+    test("loadCopydeckFor is called", () => {
+      expect(loadCopydeckFor).toHaveBeenCalled();
+    });
+
+    test("registerAdapter is called for pyodide", () => {
+      expect(registerAdapter).toHaveBeenCalledWith("pyodide", {});
+    });
+
+    test("dispatches setFriendlyError with title and summary", () => {
+      expect(dispatchSpy).toHaveBeenCalledWith(
+        setFriendlyError({
+          title: "Friendly error title",
+          summary: "A friendly summaryof the error",
+        }),
+      );
     });
   });
 });

--- a/src/components/Editor/Runners/PythonRunner/PyodideRunner/PyodideRunner.test.js
+++ b/src/components/Editor/Runners/PythonRunner/PyodideRunner/PyodideRunner.test.js
@@ -451,8 +451,7 @@ describe("When an error is received", () => {
       } = require("@raspberrypifoundation/python-friendly-error-messages"));
 
       friendlyExplain.mockReturnValue({
-        title: "Friendly error title",
-        summary: "A friendly summaryof the error",
+        html: '<div class="pfem__title">Friendly error title</div><div class="pfem__summary">A friendly summary of the error</div>',
       });
 
       render(
@@ -479,11 +478,10 @@ describe("When an error is received", () => {
       expect(registerAdapter).toHaveBeenCalledWith("pyodide", {});
     });
 
-    test("dispatches setFriendlyError with title and summary", () => {
+    test("dispatches setFriendlyError", () => {
       expect(dispatchSpy).toHaveBeenCalledWith(
         setFriendlyError({
-          title: "Friendly error title",
-          summary: "A friendly summaryof the error",
+          html: '<div class="pfem__title">Friendly error title</div><div class="pfem__summary">A friendly summary of the error</div>',
         }),
       );
     });

--- a/src/components/Editor/Runners/PythonRunner/PyodideRunner/VisualOutputPane.test.js
+++ b/src/components/Editor/Runners/PythonRunner/PyodideRunner/VisualOutputPane.test.js
@@ -4,8 +4,10 @@ import configureStore from "redux-mock-store";
 import { Provider } from "react-redux";
 import VisualOutputPane from "./VisualOutputPane.jsx";
 import Highcharts from "highcharts";
+import Plotly from "plotly.js";
 
 jest.mock("highcharts");
+jest.mock("plotly.js");
 
 const renderPaneWithVisuals = (visuals) => {
   const middlewares = [];
@@ -140,7 +142,11 @@ describe("when there is plotly output", () => {
   });
 
   test("it renders the plotly chart as an svg", () => {
-    expect(screen.getByText("Test Plot")).toBeInTheDocument();
+    expect(Plotly.newPlot).toHaveBeenCalledWith(
+      expect.any(Object),
+      [{ x: [1, 2, 3], y: [4, 5, 6], type: "scatter" }],
+      { title: { text: "Test Plot" } },
+    );
   });
 });
 

--- a/src/components/Editor/Runners/PythonRunner/PyodideRunner/VisualOutputPane.test.js
+++ b/src/components/Editor/Runners/PythonRunner/PyodideRunner/VisualOutputPane.test.js
@@ -7,6 +7,9 @@ import Highcharts from "highcharts";
 import Plotly from "plotly.js";
 
 jest.mock("highcharts");
+jest.mock("plotly.js", () => ({
+  newPlot: jest.fn(),
+}));
 
 const renderPaneWithVisuals = (visuals) => {
   const middlewares = [];

--- a/src/components/Editor/Runners/PythonRunner/PyodideRunner/VisualOutputPane.test.js
+++ b/src/components/Editor/Runners/PythonRunner/PyodideRunner/VisualOutputPane.test.js
@@ -7,7 +7,6 @@ import Highcharts from "highcharts";
 import Plotly from "plotly.js";
 
 jest.mock("highcharts");
-jest.mock("plotly.js");
 
 const renderPaneWithVisuals = (visuals) => {
   const middlewares = [];

--- a/src/components/Editor/Runners/PythonRunner/PyodideRunner/VisualOutputPane.test.js
+++ b/src/components/Editor/Runners/PythonRunner/PyodideRunner/VisualOutputPane.test.js
@@ -7,9 +7,6 @@ import Highcharts from "highcharts";
 import Plotly from "plotly.js";
 
 jest.mock("highcharts");
-jest.mock("plotly.js", () => ({
-  newPlot: jest.fn(),
-}));
 
 const renderPaneWithVisuals = (visuals) => {
   const middlewares = [];

--- a/src/components/Editor/Runners/PythonRunner/PythonRunner.jsx
+++ b/src/components/Editor/Runners/PythonRunner/PythonRunner.jsx
@@ -27,6 +27,9 @@ const PythonRunner = ({ outputPanels = ["text", "visual"] }) => {
   const senseHatAlwaysEnabled = useSelector(
     (state) => state.editor.senseHatAlwaysEnabled,
   );
+  const friendlyErrorsEnabled = useSelector(
+    (state) => state.editor.friendlyErrorsEnabled,
+  );
   const [usePyodide, setUsePyodide] = useState(null);
   const [skulptFallback, setSkulptFallback] = useState(false);
   const { t } = useTranslation();
@@ -74,10 +77,12 @@ const PythonRunner = ({ outputPanels = ["text", "visual"] }) => {
       <PyodideRunner
         active={activeRunner === "pyodide"}
         outputPanels={outputPanels}
+        friendlyErrorsEnabled={friendlyErrorsEnabled}
       />
       <SkulptRunner
         active={activeRunner === "skulpt"}
         outputPanels={outputPanels}
+        friendlyErrorsEnabled={friendlyErrorsEnabled}
       />
     </>
   );

--- a/src/components/Editor/Runners/PythonRunner/SkulptRunner/SkulptRunner.jsx
+++ b/src/components/Editor/Runners/PythonRunner/SkulptRunner/SkulptRunner.jsx
@@ -181,7 +181,7 @@ const SkulptRunner = ({
       });
       registerAdapter("skulpt", skulptAdapter);
     }
-  }, []);
+  }, [friendlyErrorsEnabled]);
 
   useEffect(() => {
     if (!codeRunTriggered) {
@@ -456,10 +456,14 @@ const SkulptRunner = ({
         });
 
         dispatch(
-          setFriendlyError({
-            title: friendlyError?.title ?? null,
-            summary: friendlyError?.summary ?? null,
-          }),
+          setFriendlyError(
+            friendlyError?.title || friendlyError?.summary
+              ? {
+                  title: friendlyError?.title ?? null,
+                  summary: friendlyError?.summary ?? null,
+                }
+              : null,
+          ),
         );
       }
     }

--- a/src/components/Editor/Runners/PythonRunner/SkulptRunner/SkulptRunner.jsx
+++ b/src/components/Editor/Runners/PythonRunner/SkulptRunner/SkulptRunner.jsx
@@ -455,16 +455,9 @@ const SkulptRunner = ({
           runtime: "skulpt",
         });
 
-        dispatch(
-          setFriendlyError(
-            friendlyError?.title || friendlyError?.summary
-              ? {
-                  title: friendlyError?.title ?? null,
-                  summary: friendlyError?.summary ?? null,
-                }
-              : null,
-          ),
-        );
+        if (friendlyError?.html) {
+          dispatch(setFriendlyError({ html: friendlyError.html }));
+        }
       }
     }
 

--- a/src/components/Editor/Runners/PythonRunner/SkulptRunner/SkulptRunner.jsx
+++ b/src/components/Editor/Runners/PythonRunner/SkulptRunner/SkulptRunner.jsx
@@ -16,6 +16,12 @@ import {
   triggerDraw,
   setLoadedRunner,
 } from "../../../../../redux/EditorSlice";
+import {
+  loadCopydeckFor,
+  registerAdapter,
+  skulptAdapter,
+  friendlyExplain,
+} from "@raspberrypifoundation/python-friendly-error-messages";
 import ErrorMessage from "../../../ErrorMessage/ErrorMessage";
 import ApiCallHandler from "../../../../../utils/apiCallHandler";
 import store from "../../../../../redux/stores/WebComponentStore";
@@ -162,6 +168,13 @@ const SkulptRunner = ({ active, outputPanels = ["text", "visual"] }) => {
       document.getElementById = originalGetElementById;
     };
   };
+
+  useEffect(() => {
+    loadCopydeckFor(navigator.language, {
+      base: `${process.env.PUBLIC_URL}/python-error-copydecks/`,
+    });
+    registerAdapter("skulpt", skulptAdapter);
+  }, []);
 
   useEffect(() => {
     if (!codeRunTriggered) {
@@ -424,6 +437,18 @@ const SkulptRunner = ({ active, outputPanels = ["text", "visual"] }) => {
         description: errorDescription,
         message: errorMessage,
       };
+
+      const inputCode =
+        projectCode?.find((c) => c.name === "main" && c.extension === "py")
+          ?.content ?? "";
+      const friendlyError = friendlyExplain({
+        error: errorMessage,
+        code: inputCode,
+        runtime: "skulpt",
+      });
+      if (friendlyError?.html) {
+        errorMessage = friendlyError.html;
+      }
     }
 
     dispatch(setError(errorMessage));

--- a/src/components/Editor/Runners/PythonRunner/SkulptRunner/SkulptRunner.jsx
+++ b/src/components/Editor/Runners/PythonRunner/SkulptRunner/SkulptRunner.jsx
@@ -10,6 +10,7 @@ import classNames from "classnames";
 import {
   setError,
   setErrorDetails,
+  setFriendlyError,
   codeRunHandled,
   stopDraw,
   setSenseHatEnabled,
@@ -453,9 +454,13 @@ const SkulptRunner = ({
           code: inputCode,
           runtime: "skulpt",
         });
-        if (friendlyError?.html) {
-          errorMessage = friendlyError.html;
-        }
+
+        dispatch(
+          setFriendlyError({
+            title: friendlyError?.title ?? null,
+            summary: friendlyError?.summary ?? null,
+          }),
+        );
       }
     }
 

--- a/src/components/Editor/Runners/PythonRunner/SkulptRunner/SkulptRunner.jsx
+++ b/src/components/Editor/Runners/PythonRunner/SkulptRunner/SkulptRunner.jsx
@@ -72,7 +72,11 @@ const VISUAL_LIBRARIES = [
   "turtle",
 ];
 
-const SkulptRunner = ({ active, outputPanels = ["text", "visual"] }) => {
+const SkulptRunner = ({
+  active,
+  outputPanels = ["text", "visual"],
+  friendlyErrorsEnabled = false,
+}) => {
   const loadedRunner = useSelector((state) => state.editor.loadedRunner);
   const projectCode = useSelector((state) => state.editor.project.components);
   const mainComponent = projectCode?.find(
@@ -170,10 +174,12 @@ const SkulptRunner = ({ active, outputPanels = ["text", "visual"] }) => {
   };
 
   useEffect(() => {
-    loadCopydeckFor(navigator.language, {
-      base: `${process.env.PUBLIC_URL}/python-error-copydecks/`,
-    });
-    registerAdapter("skulpt", skulptAdapter);
+    if (friendlyErrorsEnabled) {
+      loadCopydeckFor(navigator.language, {
+        base: `${process.env.PUBLIC_URL}/python-error-copydecks/`,
+      });
+      registerAdapter("skulpt", skulptAdapter);
+    }
   }, []);
 
   useEffect(() => {
@@ -438,16 +444,18 @@ const SkulptRunner = ({ active, outputPanels = ["text", "visual"] }) => {
         message: errorMessage,
       };
 
-      const inputCode =
-        projectCode?.find((c) => c.name === "main" && c.extension === "py")
-          ?.content ?? "";
-      const friendlyError = friendlyExplain({
-        error: errorMessage,
-        code: inputCode,
-        runtime: "skulpt",
-      });
-      if (friendlyError?.html) {
-        errorMessage = friendlyError.html;
+      if (friendlyErrorsEnabled) {
+        const inputCode =
+          projectCode?.find((c) => c.name === "main" && c.extension === "py")
+            ?.content ?? "";
+        const friendlyError = friendlyExplain({
+          error: errorMessage,
+          code: inputCode,
+          runtime: "skulpt",
+        });
+        if (friendlyError?.html) {
+          errorMessage = friendlyError.html;
+        }
       }
     }
 

--- a/src/components/Editor/Runners/PythonRunner/SkulptRunner/SkulptRunner.test.js
+++ b/src/components/Editor/Runners/PythonRunner/SkulptRunner/SkulptRunner.test.js
@@ -238,8 +238,7 @@ describe("When an error occurs", () => {
       } = require("@raspberrypifoundation/python-friendly-error-messages"));
 
       friendlyExplain.mockReturnValue({
-        title: "Friendly error title",
-        summary: "A friendly summary of the error",
+        html: '<div class="pfem__title">Friendly error title</div><div class="pfem__summary">A friendly summary of the error</div>',
       });
 
       render(
@@ -257,12 +256,11 @@ describe("When an error occurs", () => {
       expect(registerAdapter).toHaveBeenCalledWith("skulpt", {});
     });
 
-    test("dispatches setFriendlyError with title and summary", () => {
+    test("dispatches setFriendlyError", () => {
       expect(store.getActions()).toEqual(
         expect.arrayContaining([
           setFriendlyError({
-            title: "Friendly error title",
-            summary: "A friendly summary of the error",
+            html: '<div class="pfem__title">Friendly error title</div><div class="pfem__summary">A friendly summary of the error</div>',
           }),
         ]),
       );

--- a/src/components/Editor/Runners/PythonRunner/SkulptRunner/SkulptRunner.test.js
+++ b/src/components/Editor/Runners/PythonRunner/SkulptRunner/SkulptRunner.test.js
@@ -32,6 +32,10 @@ const user = {
   },
 };
 
+const friendlyErrorHtml =
+  '<div class="pfem__title">Friendly error title</div>' +
+  '<div class="pfem__summary">A friendly summary of the error</div>';
+
 describe("Testing basic input span functionality", () => {
   let input;
   let store;
@@ -238,7 +242,7 @@ describe("When an error occurs", () => {
       } = require("@raspberrypifoundation/python-friendly-error-messages"));
 
       friendlyExplain.mockReturnValue({
-        html: '<div class="pfem__title">Friendly error title</div><div class="pfem__summary">A friendly summary of the error</div>',
+        html: friendlyErrorHtml,
       });
 
       render(
@@ -260,7 +264,7 @@ describe("When an error occurs", () => {
       expect(store.getActions()).toEqual(
         expect.arrayContaining([
           setFriendlyError({
-            html: '<div class="pfem__title">Friendly error title</div><div class="pfem__summary">A friendly summary of the error</div>',
+            html: friendlyErrorHtml,
           }),
         ]),
       );

--- a/src/components/Editor/Runners/PythonRunner/SkulptRunner/SkulptRunner.test.js
+++ b/src/components/Editor/Runners/PythonRunner/SkulptRunner/SkulptRunner.test.js
@@ -10,6 +10,7 @@ import {
   setError,
   setErrorDetails,
   triggerDraw,
+  setFriendlyError,
 } from "../../../../../redux/EditorSlice";
 import { SettingsContext } from "../../../../../utils/settings";
 import { matchMedia, setMedia } from "mock-match-media";
@@ -221,6 +222,51 @@ describe("When an error occurs", () => {
         }),
       ]),
     );
+  });
+
+  describe("When friendly errors are enabled", () => {
+    let loadCopydeckFor;
+    let registerAdapter;
+    let friendlyExplain;
+
+    beforeEach(() => {
+      ({
+        // Using the global mock in setupTests.js to track calls to these functions
+        loadCopydeckFor,
+        registerAdapter,
+        friendlyExplain,
+      } = require("@raspberrypifoundation/python-friendly-error-messages"));
+
+      friendlyExplain.mockReturnValue({
+        title: "Friendly error title",
+        summary: "A friendly summary of the error",
+      });
+
+      render(
+        <Provider store={store}>
+          <SkulptRunner active={true} friendlyErrorsEnabled={true} />
+        </Provider>,
+      );
+    });
+
+    test("loadCopydeckFor is called", () => {
+      expect(loadCopydeckFor).toHaveBeenCalled();
+    });
+
+    test("registerAdapter is called for skulpt", () => {
+      expect(registerAdapter).toHaveBeenCalledWith("skulpt", {});
+    });
+
+    test("dispatches setFriendlyError with title and summary", () => {
+      expect(store.getActions()).toEqual(
+        expect.arrayContaining([
+          setFriendlyError({
+            title: "Friendly error title",
+            summary: "A friendly summary of the error",
+          }),
+        ]),
+      );
+    });
   });
 });
 

--- a/src/containers/WebComponentLoader.jsx
+++ b/src/containers/WebComponentLoader.jsx
@@ -3,6 +3,7 @@ import { useSelector, useDispatch } from "react-redux";
 import {
   disableTheming,
   setSenseHatAlwaysEnabled,
+  setFriendlyErrorsEnabled,
   setLoadRemixDisabled,
   setReactAppApiEndpoint,
   setScratchApiEndpoint,
@@ -68,6 +69,7 @@ const WebComponentLoader = (props) => {
     scratchApiEndpoint = process.env.REACT_APP_API_ENDPOINT,
     readOnly = false,
     senseHatAlwaysEnabled = false,
+    friendlyErrorsEnabled = false,
     showSavePrompt = false,
     sidebarOptions = [],
     useEditorStyles = false, // If true use the standard editor styling for the web component
@@ -184,6 +186,10 @@ const WebComponentLoader = (props) => {
   useEffect(() => {
     dispatch(setSenseHatAlwaysEnabled(senseHatAlwaysEnabled));
   }, [senseHatAlwaysEnabled, dispatch]);
+
+  useEffect(() => {
+    dispatch(setFriendlyErrorsEnabled(friendlyErrorsEnabled));
+  }, [friendlyErrorsEnabled, dispatch]);
 
   useEffect(() => {
     dispatch(setLoadRemixDisabled(loadRemixDisabled));

--- a/src/redux/EditorSlice.js
+++ b/src/redux/EditorSlice.js
@@ -126,6 +126,7 @@ export const editorInitialState = {
   initialComponents: [],
   scratchIframeProjectIdentifier: null,
   friendlyErrorsEnabled: false,
+  friendlyError: null,
 };
 
 const isScratchProject = (state) =>
@@ -288,6 +289,9 @@ export const EditorSlice = createSlice({
     },
     setFriendlyErrorsEnabled: (state, action) => {
       state.friendlyErrorsEnabled = action.payload;
+    },
+    setFriendlyError: (state, action) => {
+      state.friendlyError = action.payload;
     },
     setLoadRemixDisabled: (state, action) => {
       state.loadRemixDisabled = action.payload;
@@ -545,6 +549,7 @@ export const {
   setSidebarOption,
   disableTheming,
   setErrorDetails,
+  setFriendlyError,
 } = EditorSlice.actions;
 
 export default EditorSlice.reducer;

--- a/src/redux/EditorSlice.js
+++ b/src/redux/EditorSlice.js
@@ -125,6 +125,7 @@ export const editorInitialState = {
   runnerBeingLoaded: null | "pyodide" | "skulpt",
   initialComponents: [],
   scratchIframeProjectIdentifier: null,
+  friendlyErrorsEnabled: false,
 };
 
 const isScratchProject = (state) =>
@@ -284,6 +285,9 @@ export const EditorSlice = createSlice({
     },
     setSenseHatEnabled: (state, action) => {
       state.senseHatEnabled = action.payload;
+    },
+    setFriendlyErrorsEnabled: (state, action) => {
+      state.friendlyErrorsEnabled = action.payload;
     },
     setLoadRemixDisabled: (state, action) => {
       state.loadRemixDisabled = action.payload;
@@ -516,6 +520,7 @@ export const {
   setInstructionsEditable,
   setSenseHatAlwaysEnabled,
   setSenseHatEnabled,
+  setFriendlyErrorsEnabled,
   setLoadRemixDisabled,
   setReactAppApiEndpoint,
   setScratchApiEndpoint,

--- a/src/redux/EditorSlice.js
+++ b/src/redux/EditorSlice.js
@@ -289,6 +289,9 @@ export const EditorSlice = createSlice({
     },
     setFriendlyErrorsEnabled: (state, action) => {
       state.friendlyErrorsEnabled = action.payload;
+      if (!action.payload) {
+        state.friendlyError = null;
+      }
     },
     setFriendlyError: (state, action) => {
       state.friendlyError = action.payload;

--- a/src/redux/EditorSlice.test.js
+++ b/src/redux/EditorSlice.test.js
@@ -20,6 +20,8 @@ import reducer, {
   scratchSaveStarted,
   scratchSaveSucceeded,
   scratchSaveFailed,
+  setFriendlyErrorsEnabled,
+  setFriendlyError,
 } from "./EditorSlice";
 
 const mockCreateRemix = jest.fn();
@@ -236,6 +238,47 @@ test("closing rename modal updates showing status", () => {
     },
   };
   expect(reducer(previousState, closeRenameFileModal())).toEqual(expectedState);
+});
+
+test("Action setFriendlyErrorsEnabled sets friendlyErrorsEnabled to true", () => {
+  const previousState = {
+    friendlyErrorsEnabled: false,
+  };
+  const expectedState = {
+    friendlyErrorsEnabled: true,
+  };
+  expect(reducer(previousState, setFriendlyErrorsEnabled(true))).toEqual(
+    expectedState,
+  );
+});
+
+test("Action setFriendlyErrorsEnabled sets friendlyErrorsEnabled to false and clears friendlyError", () => {
+  const previousState = {
+    friendlyErrorsEnabled: true,
+    friendlyError: { title: "Error title", summary: "Error summary" },
+  };
+  const expectedState = {
+    friendlyErrorsEnabled: false,
+    friendlyError: null,
+  };
+  expect(reducer(previousState, setFriendlyErrorsEnabled(false))).toEqual(
+    expectedState,
+  );
+});
+
+test("Action setFriendlyError sets friendlyError", () => {
+  const previousState = {
+    friendlyError: null,
+  };
+  const expectedState = {
+    friendlyError: { title: "Error title", summary: "Error summary" },
+  };
+  expect(
+    reducer(
+      previousState,
+      setFriendlyError({ title: "Error title", summary: "Error summary" }),
+    ),
+  ).toEqual(expectedState);
 });
 
 describe("When project has no identifier", () => {

--- a/src/redux/EditorSlice.test.js
+++ b/src/redux/EditorSlice.test.js
@@ -255,7 +255,9 @@ test("Action setFriendlyErrorsEnabled sets friendlyErrorsEnabled to true", () =>
 test("Action setFriendlyErrorsEnabled sets friendlyErrorsEnabled to false and clears friendlyError", () => {
   const previousState = {
     friendlyErrorsEnabled: true,
-    friendlyError: { title: "Error title", summary: "Error summary" },
+    friendlyError: {
+      html: '<div class="pfem__title">Friendly error title</div><div class="pfem__summary">A friendly summary of the error</div>',
+    },
   };
   const expectedState = {
     friendlyErrorsEnabled: false,
@@ -271,12 +273,16 @@ test("Action setFriendlyError sets friendlyError", () => {
     friendlyError: null,
   };
   const expectedState = {
-    friendlyError: { title: "Error title", summary: "Error summary" },
+    friendlyError: {
+      html: '<div class="pfem__title">Friendly error title</div><div class="pfem__summary">A friendly summary of the error</div>',
+    },
   };
   expect(
     reducer(
       previousState,
-      setFriendlyError({ title: "Error title", summary: "Error summary" }),
+      setFriendlyError({
+        html: '<div class="pfem__title">Friendly error title</div><div class="pfem__summary">A friendly summary of the error</div>',
+      }),
     ),
   ).toEqual(expectedState);
 });

--- a/src/redux/EditorSlice.test.js
+++ b/src/redux/EditorSlice.test.js
@@ -38,6 +38,10 @@ jest.mock("../utils/apiCallHandler", () => () => ({
   createOrUpdateProject: jest.fn(mockCreateOrUpdateProject),
 }));
 
+const friendlyErrorHtml =
+  '<div class="pfem__title">Friendly error title</div>' +
+  '<div class="pfem__summary">A friendly summary of the error</div>';
+
 test("Action stopCodeRun sets codeRunStopped to true", () => {
   const previousState = {
     codeRunTriggered: true,
@@ -256,7 +260,7 @@ test("Action setFriendlyErrorsEnabled sets friendlyErrorsEnabled to false and cl
   const previousState = {
     friendlyErrorsEnabled: true,
     friendlyError: {
-      html: '<div class="pfem__title">Friendly error title</div><div class="pfem__summary">A friendly summary of the error</div>',
+      html: friendlyErrorHtml,
     },
   };
   const expectedState = {
@@ -274,14 +278,14 @@ test("Action setFriendlyError sets friendlyError", () => {
   };
   const expectedState = {
     friendlyError: {
-      html: '<div class="pfem__title">Friendly error title</div><div class="pfem__summary">A friendly summary of the error</div>',
+      html: friendlyErrorHtml,
     },
   };
   expect(
     reducer(
       previousState,
       setFriendlyError({
-        html: '<div class="pfem__title">Friendly error title</div><div class="pfem__summary">A friendly summary of the error</div>',
+        html: friendlyErrorHtml,
       }),
     ),
   ).toEqual(expectedState);

--- a/src/utils/setupTests.js
+++ b/src/utils/setupTests.js
@@ -52,6 +52,20 @@ jest.mock("../assets/markdown/demoInstructions.md", () => {
   return "demoInstructions.md";
 });
 
+jest.mock("@raspberrypifoundation/python-friendly-error-messages", () => ({
+  loadCopydeckFor: jest.fn(),
+  registerAdapter: jest.fn(),
+  pyodideAdapter: {},
+  skulptAdapter: {},
+  friendlyExplain: jest.fn(),
+}));
+
+jest.mock("plotly.js", () => ({
+  newPlot: jest.fn(),
+  react: jest.fn(),
+  purge: jest.fn(),
+}));
+
 global.Blob = jest.fn();
 window.URL.createObjectURL = jest.fn();
 window.Worker = PyodideWorker;

--- a/src/utils/setupTests.js
+++ b/src/utils/setupTests.js
@@ -60,6 +60,12 @@ jest.mock("@raspberrypifoundation/python-friendly-error-messages", () => ({
   friendlyExplain: jest.fn(),
 }));
 
+jest.mock("plotly.js", () => ({
+  newPlot: jest.fn(),
+  react: jest.fn(),
+  purge: jest.fn(),
+}));
+
 global.Blob = jest.fn();
 window.URL.createObjectURL = jest.fn();
 window.Worker = PyodideWorker;

--- a/src/utils/setupTests.js
+++ b/src/utils/setupTests.js
@@ -60,12 +60,6 @@ jest.mock("@raspberrypifoundation/python-friendly-error-messages", () => ({
   friendlyExplain: jest.fn(),
 }));
 
-jest.mock("plotly.js", () => ({
-  newPlot: jest.fn(),
-  react: jest.fn(),
-  purge: jest.fn(),
-}));
-
 global.Blob = jest.fn();
 window.URL.createObjectURL = jest.fn();
 window.Worker = PyodideWorker;

--- a/src/web-component.js
+++ b/src/web-component.js
@@ -80,6 +80,7 @@ class WebComponent extends HTMLElement {
       "with_projectbar",
       "with_sidebar",
       "load_cache",
+      "friendly_errors_enabled",
     ];
   }
 
@@ -98,6 +99,7 @@ class WebComponent extends HTMLElement {
       "with_projectbar",
       "with_sidebar",
       "load_cache",
+      "friendly_errors_enabled",
     ];
     const jsonAttrs = [
       "instructions",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -68,6 +68,12 @@ const moduleRules = [
     use: ["babel-loader"],
   },
   {
+    test: /\.js$/,
+    include:
+      /node_modules\/@raspberrypifoundation\/python-friendly-error-messages/,
+    resolve: { fullySpecified: false },
+  },
+  {
     test: /\.css$/,
     use: ["css-loader"],
   },
@@ -237,6 +243,10 @@ const mainConfig = {
       patterns: [
         { from: "public", to: "" },
         { from: "src/projects", to: "projects" },
+        {
+          from: "node_modules/@raspberrypifoundation/python-friendly-error-messages/copydecks",
+          to: "python-error-copydecks",
+        },
       ],
     }),
   ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -4460,6 +4460,7 @@ __metadata:
     curl: "npm:^0.1.4"
     cypress: "npm:14.5.4"
     date-fns: "npm:^4.1.0"
+    dompurify: "npm:^3.4.6"
     dotenv: "npm:8.2.0"
     dotenv-expand: "npm:5.1.0"
     dotenv-webpack: "npm:8.1.0"
@@ -10680,6 +10681,18 @@ __metadata:
     "@types/trusted-types":
       optional: true
   checksum: 10/dcaf945376eff2a61841b205501b163b2c8ae9afe7251e68276b561d9fcf943cefc67e2631fdeae080b52a8b37c96e6beb7e6ae80ad8a83692ff67965dd6b4db
+  languageName: node
+  linkType: hard
+
+"dompurify@npm:^3.4.6":
+  version: 3.4.6
+  resolution: "dompurify@npm:3.4.6"
+  dependencies:
+    "@types/trusted-types": "npm:^2.0.7"
+  dependenciesMeta:
+    "@types/trusted-types":
+      optional: true
+  checksum: 10/950bfadc9ad6ee5706ccdfde09313c9c8f6a299206f77ccb621b1355947443753163031770cbb46236f1b6910e57e6710c34970b13c8a9e0fd7c93fac77c4815
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4423,6 +4423,7 @@ __metadata:
     "@lezer/highlight": "npm:^1.0.0"
     "@pmmmwh/react-refresh-webpack-plugin": "npm:0.4.3"
     "@raspberrypifoundation/design-system-react": "npm:^2.7.0"
+    "@raspberrypifoundation/python-friendly-error-messages": "npm:0.1.6"
     "@react-three/drei": "npm:9.114.3"
     "@react-three/fiber": "npm:^8.0.13"
     "@react-three/test-renderer": "npm:8.2.1"
@@ -4576,6 +4577,13 @@ __metadata:
     worker-plugin: "npm:5.0.1"
   languageName: unknown
   linkType: soft
+
+"@raspberrypifoundation/python-friendly-error-messages@npm:0.1.6":
+  version: 0.1.6
+  resolution: "@raspberrypifoundation/python-friendly-error-messages@npm:0.1.6"
+  checksum: 10/d453c0328a38b9f284009892d10f0c12b344fbd676b17cdfe3f832514d88d293600a648ae960fa38bfb6de1b303d177d2c20d704733ad34b02e16a2dac293b25
+  languageName: node
+  linkType: hard
 
 "@react-spring/animated@npm:~9.6.1":
   version: 9.6.1


### PR DESCRIPTION
Part of https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1448

### Changes
- Added pfem package and required changes for it to run properly
- Added dompurify package for sanitising HTML contents that are returned from pfem
- Added `friendly_errors_enabled` attribute set to `false` by default and added to redux
- The new redux state read by PythonRunner and passed as a prop to both PyodideRunner and SkulptRunner
- Added pfem logic to both runners and stored the friendly error html in redux
- Updated ErrorMessage component to display the friendly errors conditionally
  - For now, CSS used to restrict to displaying title and summary parts of friendly error html 
  - pfem will be updated so that we can choose parts before storing in redux
- ⚠️ The error messages will be formatted in another PR: https://github.com/RaspberryPiFoundation/editor-ui/pull/1485

### Behaviour

- When the editor-wc in the host app has `friendly_errors_enabled` attribute not set or set to `false`, it shows the original error.
   <img width="450" alt="Screenshot 2026-05-28 at 14 59 03" src="https://github.com/user-attachments/assets/4bff14ca-40cd-4a3e-b76e-98a69a45301e" />

- When the editor-wc in the host has `friendly_errors_enabled` attribute set to `true`, it shows the original error followed by title and summary of the new friendly error.
  <img width="500" alt="Screenshot 2026-06-01 at 15 16 33" src="https://github.com/user-attachments/assets/68b55121-0051-4169-84db-4abb9df4ca74" />

### Notes on using the pfem ESM in Jest
- Tried adding it to `jest.transformIgnorePatterns` in package.json, but resulted in a cascade of errors from plotly
  - Just moved `three` to  `jest.transformIgnorePatterns` from `scripts.test` 
- Added global jest mocks for pfem and plotly to `setupTests.js`
  - Also imported plotly to `PyodideRunner/VisualOutputPane.test.js` 
- <- with a CJS build of pfem, these changes may be unnecessary  