### PR TITLE
Allow clearing Pyodide text console with os.system("clear")

### DIFF
--- a/cypress/e2e/spec-wc-pyodide.cy.js
+++ b/cypress/e2e/spec-wc-pyodide.cy.js
@@ -13,7 +13,8 @@ import {
   stopProject,
 } from "../helpers/editor.js";
 
-const origin = "http://localhost:3011/web-component.html";
+const origin =
+  Cypress.env("EDITOR_ORIGIN") || "http://localhost:3011/web-component.html";
 
 beforeEach(() => {
   cy.intercept("*", (req) => {
@@ -224,6 +225,20 @@ print(text_out)
       "contain",
       "ModuleNotFoundError: No module named 'i_do_not_exist' on line 1 of main.py",
     );
+  });
+
+  it("clears the console when os.system('clear') is called", () => {
+    runCode('print("before")\nimport os\nos.system("clear")\nprint("after")');
+    getPythonConsoleOutput().should("contain", "after");
+    getPythonConsoleOutput().should("not.contain.text", "before");
+  });
+
+  it("clears buffered output written without a newline before clearing", () => {
+    runCode(
+      'import os\nprint("partial", end="")\nos.system("clear")\nprint("after")',
+    );
+    getPythonConsoleOutput().should("contain", "after");
+    getPythonConsoleOutput().should("not.contain.text", "partial");
   });
 
   it("clears user-defined variables between code runs", () => {

--- a/src/PyodideWorker.js
+++ b/src/PyodideWorker.js
@@ -410,6 +410,7 @@ const PyodideWorker = () => {
         postMessage({ method: "handleFileWrite", filename, content, mode });
       },
       locals: () => pyodide.runPython("globals()"),
+      clear_console: () => postMessage({ method: "handleClear" }),
     },
   };
 
@@ -442,6 +443,21 @@ const PyodideWorker = () => {
     pyodide = await pyodidePromise;
 
     pyodide.registerJsModule("basthon", fakeBasthonPackage);
+
+    await pyodide.runPythonAsync(`
+    import os as _os, sys as _sys, basthon as _basthon
+    _real_system = _os.system
+    def _patched_system(command):
+        if isinstance(command, str) and command.strip().lower() in ("clear", "cls"):
+            _sys.stdout.write("\\n")
+            _sys.stderr.write("\\n")
+            _sys.stdout.flush()
+            _sys.stderr.flush()
+            _basthon.kernel.clear_console()
+            return 0
+        return _real_system(command)
+    _os.system = _patched_system
+    `);
 
     await pyodide.runPythonAsync(`
     __old_input__ = input

--- a/src/components/Editor/Runners/PythonRunner/PyodideRunner/PyodideRunner.jsx
+++ b/src/components/Editor/Runners/PythonRunner/PyodideRunner/PyodideRunner.jsx
@@ -114,6 +114,9 @@ const PyodideRunner = ({
           case "handleOutput":
             handleOutput(data.stream, data.content);
             break;
+          case "handleClear":
+            clearConsole();
+            break;
           case "handleError":
             handleError(
               data.file,
@@ -210,6 +213,10 @@ const PyodideRunner = ({
     node.scrollTop = node.scrollHeight;
   };
 
+  const clearConsole = () => {
+    output.current.innerHTML = "";
+  };
+
   const handleError = (file, line, mistake, type, info) => {
     let errorMessage;
 
@@ -290,7 +297,7 @@ const PyodideRunner = ({
   };
 
   const handleRun = async () => {
-    output.current.innerHTML = "";
+    clearConsole();
     dispatch(setError(""));
     dispatch(setFriendlyError(null));
     setVisuals([]);

--- a/src/components/Editor/Runners/PythonRunner/PyodideRunner/PyodideRunner.test.js
+++ b/src/components/Editor/Runners/PythonRunner/PyodideRunner/PyodideRunner.test.js
@@ -260,6 +260,28 @@ describe("When output is received", () => {
   });
 });
 
+describe("When a clear console message is received", () => {
+  beforeEach(() => {
+    render(
+      <Provider store={store}>
+        <PyodideRunner active={true} />,
+      </Provider>,
+    );
+
+    const worker = PyodideWorker.getLastInstance();
+    worker.postMessageFromWorker({
+      method: "handleOutput",
+      stream: "stdout",
+      content: "hello",
+    });
+    worker.postMessageFromWorker({ method: "handleClear" });
+  });
+
+  test("it clears previously printed output", () => {
+    expect(screen.queryByText("hello")).not.toBeInTheDocument();
+  });
+});
+
 describe("When file write event is received", () => {
   let worker;
   beforeEach(() => {

--- a/src/components/Editor/Runners/PythonRunner/PyodideRunner/PyodideWorker.test.js
+++ b/src/components/Editor/Runners/PythonRunner/PyodideRunner/PyodideWorker.test.js
@@ -96,6 +96,29 @@ describe("PyodideWorker", () => {
     );
   });
 
+  test("it patches os.system to handle clear/cls", async () => {
+    expect(pyodide.runPythonAsync).toHaveBeenCalledWith(
+      expect.stringMatching(/os\.system/),
+    );
+  });
+
+  test("it forces batched output to flush before clearing", async () => {
+    expect(pyodide.runPythonAsync).toHaveBeenCalledWith(
+      expect.stringMatching(/_sys\.stdout\.write\("\\n"\)/),
+    );
+    expect(pyodide.runPythonAsync).toHaveBeenCalledWith(
+      expect.stringMatching(/_sys\.stderr\.write\("\\n"\)/),
+    );
+  });
+
+  test("the basthon clear_console bridge posts handleClear", () => {
+    const basthonCall = pyodide.registerJsModule.mock.calls.find(
+      ([name]) => name === "basthon",
+    );
+    basthonCall[1].kernel.clear_console();
+    expect(global.postMessage).toHaveBeenCalledWith({ method: "handleClear" });
+  });
+
   test("it patches urllib and requests modules", async () => {
     expect(pyodide.runPythonAsync).toHaveBeenCalledWith(
       expect.stringMatching(/pyodide_http.patch_all()/),


### PR DESCRIPTION
## Summary
- Patch Pyodide `os.system("clear")` / `os.system("cls")` to clear the on-screen text console mid-run.
- Add a worker bridge (`handleClear`) and main-thread handler that wipes the `<pre>` output pane only.
- Flush batched stdout/stderr (including forced newline) before clearing so `print(..., end="")` does not reappear after a clear.
- Add Jest wiring tests and Cypress e2e coverage; allow overriding the e2e origin via `EDITOR_ORIGIN`.

## Test plan
- [x] `CI=true yarn run test --runTestsByPath src/components/Editor/Runners/PythonRunner/PyodideRunner/PyodideRunner.test.js src/components/Editor/Runners/PythonRunner/PyodideRunner/PyodideWorker.test.js`
- [x] `yarn exec eslint` on touched files
- [x] Manual browser verification on alternate dev server (`http://localhost:65442/web-component.html`) with real Pyodide
- [ ] `yarn exec cypress run --spec cypress/e2e/spec-wc-pyodide.cy.js` (Cypress binary failed to launch locally in agent environment)


Made with [Cursor](https://cursor.com)