### PR TITLE
chore: bump to v0.34.22

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raspberrypifoundation/editor-ui",
-  "version": "0.34.21",
+  "version": "0.34.22",
   "private": true,
   "dependencies": {
     "@RaspberryPiFoundation/scratch-gui": "13.7.3-code-classroom.20260522151700",


### PR DESCRIPTION
issue: [1502](https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1502)

bumping the release to 0.34.22