### PR TITLE
Replace react-toggle with DS Switch

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "react-tabs": "^3.2.3",
     "react-timer-hook": "^3.0.5",
     "react-toastify": "^11.1.0",
-    "react-toggle": "^4.1.3",
     "redux": "^4.2.1",
     "redux-oidc": "^4.0.0-beta1",
     "scratchReactDomVendor": "npm:react-dom@18.3.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@codemirror/view": "^6.3.0",
     "@hello-pangea/dnd": "^16.2.0",
     "@juggle/resize-observer": "^3.3.1",
-    "@raspberrypifoundation/design-system-react": "^2.9.1",
+    "@raspberrypifoundation/design-system-react": "^2.9.2",
     "@raspberrypifoundation/python-friendly-error-messages": "0.7.0",
     "@react-three/drei": "^10.0.0",
     "@react-three/fiber": "^9.6.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@codemirror/view": "^6.3.0",
     "@hello-pangea/dnd": "^16.2.0",
     "@juggle/resize-observer": "^3.3.1",
-    "@raspberrypifoundation/design-system-react": "^2.7.0",
+    "@raspberrypifoundation/design-system-react": "^2.9.1",
     "@raspberrypifoundation/python-friendly-error-messages": "0.7.0",
     "@react-three/drei": "^10.0.0",
     "@react-three/fiber": "^9.6.1",

--- a/src/assets/stylesheets/AstroPiModel.scss
+++ b/src/assets/stylesheets/AstroPiModel.scss
@@ -127,7 +127,6 @@
           }
 
           .rpf-switch {
-            --rpf-switch-on-color: var(--rpf-green-800);
             gap: 0;
           }
         }
@@ -218,6 +217,14 @@
           &-toggle {
             background-color: $rpf-grey-800;
             border: 1px solid $rpf-grey-500;
+
+            .rpf-switch {
+              --rpf-switch-on-color: var(--rpf-green-400);
+              --rpf-switch-handle-on-color: var(--rpf-grey-600);
+              --rpf-switch-off-color: var(--rpf-grey-150);
+              --rpf-switch-icon-off-color: var(--rpf-text-primary);
+              --rpf-switch-track-color: var(--rpf-grey-500);
+            }
           }
         }
       }
@@ -265,6 +272,10 @@
           &-toggle {
             background-color: $rpf-white;
             border: 2px solid $rpf-grey-300;
+
+            .rpf-switch {
+              --rpf-switch-on-color: var(--rpf-green-800);
+            }
           }
         }
       }

--- a/src/assets/stylesheets/AstroPiModel.scss
+++ b/src/assets/stylesheets/AstroPiModel.scss
@@ -125,7 +125,7 @@
           .rpf-input-field {
             margin-block-end: 0;
           }
-          
+
           .rpf-switch {
             --rpf-switch-on-color: var(--rpf-green-800);
             gap: 0;

--- a/src/assets/stylesheets/AstroPiModel.scss
+++ b/src/assets/stylesheets/AstroPiModel.scss
@@ -102,6 +102,7 @@
           font-family: var(--wc-font-family-monospace);
 
           &-timer {
+            flex: 1;
             margin-block-start: 0;
             padding: $space-0-5 0;
             inline-size: 100%;
@@ -119,6 +120,15 @@
 
           label {
             flex: 1;
+          }
+
+          .rpf-input-field {
+            margin-block-end: 0;
+          }
+          
+          .rpf-switch {
+            --rpf-switch-on-color: var(--rpf-green-800);
+            gap: 0;
           }
         }
 
@@ -208,13 +218,6 @@
           &-toggle {
             background-color: $rpf-grey-800;
             border: 1px solid $rpf-grey-500;
-
-            .react-toggle {
-              &-thumb {
-                border: 1px solid $rpf-white;
-                background-color: $rpf-white;
-              }
-            }
           }
         }
       }
@@ -262,11 +265,6 @@
           &-toggle {
             background-color: $rpf-white;
             border: 2px solid $rpf-grey-300;
-
-            .react-toggle-thumb {
-              border: 1px solid $rpf-grey-100;
-              background-color: $rpf-grey-100;
-            }
           }
         }
       }

--- a/src/assets/stylesheets/ExternalStyles.scss
+++ b/src/assets/stylesheets/ExternalStyles.scss
@@ -1,6 +1,5 @@
 @forward "../../../node_modules/@raspberrypifoundation/design-system-react/dist/scss/design-system-core";
 @use "../../../node_modules/react-tabs/style/react-tabs.css";
-@use "../../../node_modules/react-toggle/style.css";
 @use "../../../node_modules/prismjs/plugins/line-numbers/prism-line-numbers.css";
 @use "../../../node_modules/prismjs/plugins/line-highlight/prism-line-highlight.css";
 @use "../../../node_modules/react-toastify/dist/ReactToastify.css";

--- a/src/components/AstroPiModel/AstroPiControls/MotionInput.jsx
+++ b/src/components/AstroPiModel/AstroPiControls/MotionInput.jsx
@@ -1,10 +1,9 @@
 import React from "react";
 import { useEffect, useState, startTransition } from "react";
 import { useSelector } from "react-redux";
-import Toggle from "react-toggle";
+import { Switch } from "@raspberrypifoundation/design-system-react";
 import Sk from "skulpt";
 import "../../../assets/stylesheets/AstroPiModel.scss";
-import "react-toggle/style.css";
 import { useTranslation } from "react-i18next";
 
 const MotionInput = (props) => {
@@ -45,9 +44,9 @@ const MotionInput = (props) => {
         <label htmlFor={`sense_hat_motion`}>
           {t("output.senseHat.controls.motionSensorOptions.no")}
         </label>
-        <Toggle
+        <Switch
           id="sense_hat_motion"
-          icons={false}
+          name="senseHatMotionToggle"
           checked={value}
           onChange={(e) => setValue(e.target.checked)}
         />

--- a/src/components/AstroPiModel/AstroPiControls/MotionInput.jsx
+++ b/src/components/AstroPiModel/AstroPiControls/MotionInput.jsx
@@ -47,6 +47,7 @@ const MotionInput = (props) => {
         <Switch
           id="sense_hat_motion"
           name="senseHatMotionToggle"
+          icon
           checked={value}
           onChange={(e) => setValue(e.target.checked)}
         />

--- a/yarn.lock
+++ b/yarn.lock
@@ -4091,20 +4091,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@raspberrypifoundation/design-system-core@npm:^2.4.5":
-  version: 2.4.5
-  resolution: "@raspberrypifoundation/design-system-core@npm:2.4.5"
+"@raspberrypifoundation/design-system-core@npm:^2.4.7":
+  version: 2.4.7
+  resolution: "@raspberrypifoundation/design-system-core@npm:2.4.7"
   dependencies:
     classnames: "npm:^2.3.2"
-  checksum: 10/fcc9a17221599b1b812b4fa6427b49fc9dd3c1b7a5315608760fdf0e7a0db7ef5ffbbef34f315917d00279d7880fc7a464b8a58e147eaa77451982cf6b6eb4d1
+  checksum: 10/3692700108f69bb41df4d0e5c512e87efbd5b1c5d929f86bfb62bc80b2a24a71f48f9b232be748aea6c937331324677c58e5f90ce54eab32ae4f8752dd614fd5
   languageName: node
   linkType: hard
 
-"@raspberrypifoundation/design-system-react@npm:^2.9.1":
-  version: 2.9.1
-  resolution: "@raspberrypifoundation/design-system-react@npm:2.9.1"
+"@raspberrypifoundation/design-system-react@npm:^2.9.2":
+  version: 2.9.2
+  resolution: "@raspberrypifoundation/design-system-react@npm:2.9.2"
   dependencies:
-    "@raspberrypifoundation/design-system-core": "npm:^2.4.5"
+    "@raspberrypifoundation/design-system-core": "npm:^2.4.7"
     classnames: "npm:^2.5.1"
     lucide-react: "npm:^0.553.0"
   peerDependencies:
@@ -4116,7 +4116,7 @@ __metadata:
       optional: false
     react-dom:
       optional: false
-  checksum: 10/cbe29aedfc6629527e254c682cd733121d2632450073006d8897dc8dc3e44add9156d10f11534dca2ceb5e05ddeb6c418950ee4a443fbc0f0a99028b3d1c9feb
+  checksum: 10/36ec7dc3ade7da08b0b2d7fbec6e7114cc84ab14c7fec566969ad5d30c8dbd694643295fbb97ed51f7a85b643fa9e06146e852860a68f563e81aea9941bb91f9
   languageName: node
   linkType: hard
 
@@ -4135,7 +4135,7 @@ __metadata:
     "@codemirror/view": "npm:^6.3.0"
     "@hello-pangea/dnd": "npm:^16.2.0"
     "@juggle/resize-observer": "npm:^3.3.1"
-    "@raspberrypifoundation/design-system-react": "npm:^2.9.1"
+    "@raspberrypifoundation/design-system-react": "npm:^2.9.2"
     "@raspberrypifoundation/python-friendly-error-messages": "npm:0.7.0"
     "@react-three/drei": "npm:^10.0.0"
     "@react-three/fiber": "npm:^9.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4091,20 +4091,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@raspberrypifoundation/design-system-core@npm:^2.4.0":
-  version: 2.4.0
-  resolution: "@raspberrypifoundation/design-system-core@npm:2.4.0"
+"@raspberrypifoundation/design-system-core@npm:^2.4.5":
+  version: 2.4.5
+  resolution: "@raspberrypifoundation/design-system-core@npm:2.4.5"
   dependencies:
     classnames: "npm:^2.3.2"
-  checksum: 10/4f989c48c9e93f57f65a6979c37c6b0cda69fb8e06c6dffb91dc5c407783775422b527907a081258aa16dab06977af9e74e053456b3d98680fc1f1c86218a417
+  checksum: 10/fcc9a17221599b1b812b4fa6427b49fc9dd3c1b7a5315608760fdf0e7a0db7ef5ffbbef34f315917d00279d7880fc7a464b8a58e147eaa77451982cf6b6eb4d1
   languageName: node
   linkType: hard
 
-"@raspberrypifoundation/design-system-react@npm:^2.7.0":
-  version: 2.7.3
-  resolution: "@raspberrypifoundation/design-system-react@npm:2.7.3"
+"@raspberrypifoundation/design-system-react@npm:^2.9.1":
+  version: 2.9.1
+  resolution: "@raspberrypifoundation/design-system-react@npm:2.9.1"
   dependencies:
-    "@raspberrypifoundation/design-system-core": "npm:^2.4.0"
+    "@raspberrypifoundation/design-system-core": "npm:^2.4.5"
     classnames: "npm:^2.5.1"
     lucide-react: "npm:^0.553.0"
   peerDependencies:
@@ -4116,7 +4116,7 @@ __metadata:
       optional: false
     react-dom:
       optional: false
-  checksum: 10/28db4405bbb59c612308411f12201ec5b6437116078187286e76022822a6e41be54cb78a82b00857218f07f6e6aeb3efdebcfa7e87425ce0e9302f0043d1ed6c
+  checksum: 10/cbe29aedfc6629527e254c682cd733121d2632450073006d8897dc8dc3e44add9156d10f11534dca2ceb5e05ddeb6c418950ee4a443fbc0f0a99028b3d1c9feb
   languageName: node
   linkType: hard
 
@@ -4135,7 +4135,7 @@ __metadata:
     "@codemirror/view": "npm:^6.3.0"
     "@hello-pangea/dnd": "npm:^16.2.0"
     "@juggle/resize-observer": "npm:^3.3.1"
-    "@raspberrypifoundation/design-system-react": "npm:^2.7.0"
+    "@raspberrypifoundation/design-system-react": "npm:^2.9.1"
     "@raspberrypifoundation/python-friendly-error-messages": "npm:0.7.0"
     "@react-three/drei": "npm:^10.0.0"
     "@react-three/fiber": "npm:^9.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4234,7 +4234,6 @@ __metadata:
     react-tabs: "npm:^3.2.3"
     react-timer-hook: "npm:^3.0.5"
     react-toastify: "npm:^11.1.0"
-    react-toggle: "npm:^4.1.3"
     redux: "npm:^4.2.1"
     redux-mock-store: "npm:^1.5.4"
     redux-oidc: "npm:^4.0.0-beta1"
@@ -18355,19 +18354,6 @@ __metadata:
     react: ^18 || ^19
     react-dom: ^18 || ^19
   checksum: 10/56cdc448a189503580f3bdb2b102c2a150323844844558563cb73503438ce787598a61fdc2a2444be10d6fecabb4b4cc9b04a852ea7274388a53d20ed30818f1
-  languageName: node
-  linkType: hard
-
-"react-toggle@npm:^4.1.3":
-  version: 4.1.3
-  resolution: "react-toggle@npm:4.1.3"
-  dependencies:
-    classnames: "npm:^2.2.5"
-  peerDependencies:
-    prop-types: ">= 15.3.0 < 19"
-    react: ">= 15.3.0 < 19"
-    react-dom: ">= 15.3.0 < 19"
-  checksum: 10/b63b7c3bd37431c4dc3cce741143a490239ba4981302a1af0f5aeb83635bf580bc1b142097eb28a4f52fef8dee40913085aa30d52579f355992689002d2602ca
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1499

### Changes
- Bumped Design System React to 2.9.2 to use Switch component and updated colour variable. 
- Replaced react-toggle Toggle with Switch and removed react-toggle dependency
- Increased height of colour and timer controls to match the minimum height applied to `.rpf-switch` for a WCAG AAA touch-target requirement
- Updated colours as per Max's design

### Screen recordings
- Before
https://github.com/user-attachments/assets/4a280a36-b5d9-4a12-b461-30af7b64e854

- After
https://github.com/user-attachments/assets/35745f4e-701e-4eaf-a8a3-2fe2eb7187fa
