### PR TITLE
Add projects site to allowed iframe origins

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -145,7 +145,7 @@ jobs:
       react_app_google_tag_manager_id: GTM-5FWFWFJ
       react_app_sentry_dsn: https://a6d7b79c7a474a6499ace73acf792a83@o17504.ingest.sentry.io/4504055099621376
       react_app_sentry_env: production
-      react_app_allowed_iframe_origins: "https://editor.raspberrypi.org,https://editor-static.raspberrypi.org,https://classroom.raspberrypi.org"
+      react_app_allowed_iframe_origins: "https://editor.raspberrypi.org,https://editor-static.raspberrypi.org,https://classroom.raspberrypi.org,https://projects.raspberrypi.org"
     secrets: inherit
 
   deploy-main:


### PR DESCRIPTION
To fix: 
https://github.com/orgs/RaspberryPiFoundation/projects/60/views/37?pane=issue&itemId=206194277&issue=RaspberryPiFoundation%7Cprojects-ui%7C3772

<img width="740" height="283" alt="Screenshot 2026-06-30 at 14 32 10" src="https://github.com/user-attachments/assets/7dbed339-8b91-478f-88ba-5264a201e951" />
