### PR TITLE
bump to v0.34.25

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raspberrypifoundation/editor-ui",
-  "version": "0.34.24",
+  "version": "0.34.25",
   "private": true,
   "dependencies": {
     "@RaspberryPiFoundation/scratch-gui": "13.7.3-code-classroom.20260522151700",


### PR DESCRIPTION
Will include:
<img width="492" height="185" alt="Screenshot 2026-07-01 at 11 59 54" src="https://github.com/user-attachments/assets/1890009c-87b1-4fd5-9afd-864bab5fcc4f" />
