### PR TITLE
Reduce Noise in Run Analytics Events

### DIFF
--- a/src/components/Editor/Project/ScratchContainer.jsx
+++ b/src/components/Editor/Project/ScratchContainer.jsx
@@ -49,6 +49,8 @@ export default function ScratchContainer() {
     nonce: null,
     hadAccessToken: false,
   });
+  const projectIdentifierRef = useRef(projectIdentifier);
+  projectIdentifierRef.current = projectIdentifier;
 
   useEffect(() => {
     return subscribeToScratchProjectIdentifierUpdates(
@@ -79,7 +81,7 @@ export default function ScratchContainer() {
       if (event.data?.type !== "scratch-gui-project-run-started") return;
 
       scheduleRunEventCycle(
-        projectIdentifier,
+        projectIdentifierRef.current,
         null,
         { bypassSnapshot: true },
         {
@@ -95,7 +97,7 @@ export default function ScratchContainer() {
       window.removeEventListener("message", handleScratchRunStarted);
       cancelPendingRunEventDebounce();
     };
-  }, [projectIdentifier]);
+  }, []);
 
   useEffect(() => {
     const allowedOrigin = getScratchAllowedOrigin();

--- a/src/components/Editor/Project/ScratchContainer.jsx
+++ b/src/components/Editor/Project/ScratchContainer.jsx
@@ -4,7 +4,10 @@ import { ClickScrollPlugin, OverlayScrollbars } from "overlayscrollbars";
 import { OverlayScrollbarsComponent } from "overlayscrollbars-react";
 import { applyScratchProjectIdentifierUpdate } from "../../../redux/EditorSlice";
 import { runStartedEvent } from "../../../events/WebComponentCustomEvents";
-import { scheduleRunEventCycle } from "../../WebComponentProject/runEventCodeSnapshot";
+import {
+  cancelPendingRunEventDebounce,
+  scheduleRunEventCycle,
+} from "../../WebComponentProject/runEventCodeSnapshot";
 import {
   subscribeToScratchProjectIdentifierUpdates,
   postMessageToScratchIframe,
@@ -90,6 +93,7 @@ export default function ScratchContainer() {
     window.addEventListener("message", handleScratchRunStarted);
     return () => {
       window.removeEventListener("message", handleScratchRunStarted);
+      cancelPendingRunEventDebounce();
     };
   }, [projectIdentifier]);
 

--- a/src/components/Editor/Project/ScratchContainer.jsx
+++ b/src/components/Editor/Project/ScratchContainer.jsx
@@ -4,6 +4,7 @@ import { ClickScrollPlugin, OverlayScrollbars } from "overlayscrollbars";
 import { OverlayScrollbarsComponent } from "overlayscrollbars-react";
 import { applyScratchProjectIdentifierUpdate } from "../../../redux/EditorSlice";
 import { runStartedEvent } from "../../../events/WebComponentCustomEvents";
+import { scheduleRunEventCycle } from "../../WebComponentProject/runEventCodeSnapshot";
 import {
   subscribeToScratchProjectIdentifierUpdates,
   postMessageToScratchIframe,
@@ -74,14 +75,23 @@ export default function ScratchContainer() {
       if (event.origin !== allowedOrigin) return;
       if (event.data?.type !== "scratch-gui-project-run-started") return;
 
-      document.dispatchEvent(runStartedEvent({}));
+      scheduleRunEventCycle(
+        projectIdentifier,
+        null,
+        { bypassSnapshot: true },
+        {
+          onRunStarted: () => {
+            document.dispatchEvent(runStartedEvent({}));
+          },
+        },
+      );
     };
 
     window.addEventListener("message", handleScratchRunStarted);
     return () => {
       window.removeEventListener("message", handleScratchRunStarted);
     };
-  }, []);
+  }, [projectIdentifier]);
 
   useEffect(() => {
     const allowedOrigin = getScratchAllowedOrigin();

--- a/src/components/Editor/Project/ScratchContainer.test.js
+++ b/src/components/Editor/Project/ScratchContainer.test.js
@@ -7,6 +7,7 @@ import * as scratchIframeUtils from "../../../utils/scratchIframe";
 import webComponentStore from "../../../redux/stores/WebComponentStore";
 import { setUser } from "../../../redux/WebComponentAuthSlice";
 import { resetStore } from "../../../redux/RootSlice";
+import { resetRunEventCodeSnapshot } from "../../WebComponentProject/runEventCodeSnapshot";
 
 jest.mock("../../../utils/scratchIframe", () => ({
   ...jest.requireActual("../../../utils/scratchIframe"),
@@ -51,14 +52,17 @@ describe("ScratchContainer", () => {
     scratchApiEndpoint: "https://api.example.com/v1",
   };
 
-  const buildStore = ({ authReducer } = {}) =>
+  const buildStore = ({ authReducer, editorOverrides } = {}) =>
     configureStore({
       reducer: {
         editor: EditorReducer,
         ...(authReducer ? { auth: authReducer } : {}),
       },
       preloadedState: {
-        editor: defaultEditorState,
+        editor: {
+          ...defaultEditorState,
+          ...editorOverrides,
+        },
       },
     });
 
@@ -174,13 +178,22 @@ describe("ScratchContainer", () => {
     let runStartedHandler;
 
     beforeEach(() => {
+      jest.useFakeTimers();
+      resetRunEventCodeSnapshot();
       runStartedHandler = jest.fn();
       document.addEventListener("editor-runStarted", runStartedHandler);
     });
 
     afterEach(() => {
+      jest.useRealTimers();
       document.removeEventListener("editor-runStarted", runStartedHandler);
     });
+
+    const flushScratchRunDebounce = () => {
+      act(() => {
+        jest.advanceTimersByTime(250);
+      });
+    };
 
     test("dispatches editor-runStarted when scratch-gui-project-run-started is received", () => {
       renderScratchContainer();
@@ -190,6 +203,8 @@ describe("ScratchContainer", () => {
           type: "scratch-gui-project-run-started",
         });
       });
+
+      flushScratchRunDebounce();
 
       expect(runStartedHandler).toHaveBeenCalledTimes(1);
       expect(runStartedHandler.mock.calls[0][0].detail).toEqual({});
@@ -210,6 +225,106 @@ describe("ScratchContainer", () => {
       });
 
       expect(runStartedHandler).not.toHaveBeenCalled();
+    });
+
+    test("collapses rapid scratch runs into one debounced dispatch", () => {
+      renderScratchContainer();
+
+      act(() => {
+        dispatchMessage({
+          type: "scratch-gui-project-run-started",
+        });
+      });
+
+      act(() => {
+        dispatchMessage({
+          type: "scratch-gui-project-run-started",
+        });
+      });
+
+      expect(runStartedHandler).toHaveBeenCalledTimes(0);
+
+      flushScratchRunDebounce();
+
+      expect(runStartedHandler).toHaveBeenCalledTimes(1);
+    });
+
+    test("allows separate scratch bursts after debounce quiet period", () => {
+      renderScratchContainer();
+
+      act(() => {
+        dispatchMessage({
+          type: "scratch-gui-project-run-started",
+        });
+      });
+
+      flushScratchRunDebounce();
+
+      act(() => {
+        jest.advanceTimersByTime(250);
+      });
+
+      act(() => {
+        dispatchMessage({
+          type: "scratch-gui-project-run-started",
+        });
+      });
+
+      flushScratchRunDebounce();
+
+      expect(runStartedHandler).toHaveBeenCalledTimes(2);
+    });
+
+    test("collapses rapid read-only scratch runs into one debounced dispatch", () => {
+      renderScratchContainer(
+        buildStore({ editorOverrides: { readOnly: true } }),
+      );
+
+      act(() => {
+        dispatchMessage({
+          type: "scratch-gui-project-run-started",
+        });
+      });
+
+      act(() => {
+        dispatchMessage({
+          type: "scratch-gui-project-run-started",
+        });
+      });
+
+      expect(runStartedHandler).toHaveBeenCalledTimes(0);
+
+      flushScratchRunDebounce();
+
+      expect(runStartedHandler).toHaveBeenCalledTimes(1);
+    });
+
+    test("allows read-only scratch runs after the debounce window", () => {
+      renderScratchContainer(
+        buildStore({ editorOverrides: { readOnly: true } }),
+      );
+
+      act(() => {
+        dispatchMessage({
+          type: "scratch-gui-project-run-started",
+        });
+      });
+
+      flushScratchRunDebounce();
+
+      act(() => {
+        jest.advanceTimersByTime(250);
+      });
+
+      act(() => {
+        dispatchMessage({
+          type: "scratch-gui-project-run-started",
+        });
+      });
+
+      flushScratchRunDebounce();
+
+      expect(runStartedHandler).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/src/components/Editor/Project/ScratchContainer.test.js
+++ b/src/components/Editor/Project/ScratchContainer.test.js
@@ -227,6 +227,24 @@ describe("ScratchContainer", () => {
       expect(runStartedHandler).not.toHaveBeenCalled();
     });
 
+    test("does not dispatch editor-runStarted when unmounted before debounce fires", () => {
+      const store = buildStore();
+      const { unmount } = render(
+        <Provider store={store}>
+          <ScratchContainer />
+        </Provider>,
+      );
+
+      act(() => {
+        dispatchMessage({ type: "scratch-gui-project-run-started" });
+      });
+
+      unmount();
+      flushScratchRunDebounce();
+
+      expect(runStartedHandler).not.toHaveBeenCalled();
+    });
+
     test("collapses rapid scratch runs into one debounced dispatch", () => {
       renderScratchContainer();
 

--- a/src/components/Editor/Project/ScratchContainer.test.js
+++ b/src/components/Editor/Project/ScratchContainer.test.js
@@ -245,6 +245,39 @@ describe("ScratchContainer", () => {
       expect(runStartedHandler).not.toHaveBeenCalled();
     });
 
+    test("dispatches editor-runStarted when project identifier changes during debounce", () => {
+      const store = buildStore();
+      const view = render(
+        <Provider store={store}>
+          <ScratchContainer />
+        </Provider>,
+      );
+
+      act(() => {
+        dispatchMessage({ type: "scratch-gui-project-run-started" });
+      });
+
+      const updatedStore = buildStore({
+        editorOverrides: {
+          project: {
+            identifier: "project-456",
+            project_type: "code_editor_scratch",
+          },
+          scratchIframeProjectIdentifier: "project-456",
+        },
+      });
+
+      view.rerender(
+        <Provider store={updatedStore}>
+          <ScratchContainer />
+        </Provider>,
+      );
+
+      flushScratchRunDebounce();
+
+      expect(runStartedHandler).toHaveBeenCalledTimes(1);
+    });
+
     test("collapses rapid scratch runs into one debounced dispatch", () => {
       renderScratchContainer();
 

--- a/src/components/Editor/Runners/HtmlRunner/HtmlRunner.jsx
+++ b/src/components/Editor/Runners/HtmlRunner/HtmlRunner.jsx
@@ -88,10 +88,9 @@ function HtmlRunner() {
   const [runningFile, setRunningFile] = useState(previewFile);
   const previewFileRef = useRef(previewFile);
 
-  const showModal = () => {
+  const showModal = useCallback(() => {
     dispatch(showErrorModal());
-    eventListener();
-  };
+  }, [dispatch]);
 
   const {
     externalLink,
@@ -100,34 +99,48 @@ function HtmlRunner() {
     handleExternalLinkError,
   } = useExternalLinkState(showModal);
 
-  const eventListener = () => {
-    window.addEventListener("message", (event) => {
-      if (event.data?.type === MSG_HTML_PREVIEW_EVENT) {
-        if (event.data?.msg === "ERROR: External link") {
-          handleExternalLinkError(showModal);
-        } else if (event.data?.msg === "Allowed external link") {
-          handleAllowedExternalLink(event.data.payload.linkTo);
-        } else if (event.data?.msg === "RELOAD") {
-          const nextPreviewFile = `${event.data.payload.linkTo}.html`;
-          setExternalLink(null);
-
-          if (nextPreviewFile === previewFileRef.current) {
-            reloadAfterPreviewChange.current = false;
-            dispatch(triggerCodeRun());
-          } else {
-            reloadAfterPreviewChange.current = true;
-            setPreviewFile(nextPreviewFile);
-          }
-        }
-      }
-    });
-  };
+  const handleAllowedExternalLinkRef = useRef(handleAllowedExternalLink);
+  const handleExternalLinkErrorRef = useRef(handleExternalLinkError);
+  handleAllowedExternalLinkRef.current = handleAllowedExternalLink;
+  handleExternalLinkErrorRef.current = handleExternalLinkError;
 
   useEffect(() => {
-    eventListener();
+    const handleIframeMessage = (event) => {
+      const { data } = event;
+
+      if (data?.type === MSG_HTML_PREVIEW_READY) {
+        setRendererReady(true);
+        return;
+      }
+
+      if (data?.type !== MSG_HTML_PREVIEW_EVENT) {
+        return;
+      }
+
+      if (data.msg === "ERROR: External link") {
+        handleExternalLinkErrorRef.current();
+      } else if (data.msg === "Allowed external link") {
+        handleAllowedExternalLinkRef.current(data.payload.linkTo);
+      } else if (data.msg === "RELOAD") {
+        const nextPreviewFile = `${data.payload.linkTo}.html`;
+        setExternalLink(null);
+
+        if (nextPreviewFile === previewFileRef.current) {
+          reloadAfterPreviewChange.current = false;
+          dispatch(triggerCodeRun());
+        } else {
+          reloadAfterPreviewChange.current = true;
+          setPreviewFile(nextPreviewFile);
+        }
+      }
+    };
+
+    window.addEventListener("message", handleIframeMessage);
     dispatch(loadingRunner("html"));
     dispatch(setLoadedRunner("html"));
-  }, []);
+
+    return () => window.removeEventListener("message", handleIframeMessage);
+  }, [dispatch, setExternalLink]);
 
   let timeout;
 
@@ -171,21 +184,6 @@ function HtmlRunner() {
       dispatch(setPage(runningFile));
     }
   }, [runningFile]);
-
-  useEffect(() => {
-    window.addEventListener("message", listener);
-    return () => window.removeEventListener("message", listener);
-  });
-
-  const listener = useCallback(
-    (event) => {
-      const message = event.data;
-      if (message?.type === MSG_HTML_PREVIEW_READY) {
-        setRendererReady(true);
-      }
-    },
-    [setRendererReady],
-  );
 
   const runCode = () => {
     setRunningFile(previewFile);

--- a/src/components/Editor/Runners/HtmlRunner/HtmlRunner.test.js
+++ b/src/components/Editor/Runners/HtmlRunner/HtmlRunner.test.js
@@ -16,6 +16,7 @@ import { MemoryRouter } from "react-router-dom";
 import { matchMedia, setMedia } from "mock-match-media";
 import { MOBILE_BREAKPOINT } from "../../../../utils/mediaQueryBreakpoints";
 import {
+  MSG_HTML_PREVIEW_EVENT,
   MSG_HTML_PREVIEW_READY,
   MSG_HTML_PROJECT_UPDATE,
 } from "../../../../utils/iframeUtils";
@@ -442,5 +443,77 @@ describe("When run is triggered", () => {
       const runButtonContainer = runButton.parentElement.parentElement;
       expect(runButtonContainer).toHaveClass("react-tabs__tab-container");
     });
+  });
+});
+
+describe("iframe message listener", () => {
+  const htmlRunnerState = {
+    project: {
+      components: [indexPage],
+    },
+    focussedFileIndices: [0],
+    openFiles: [["index.html"]],
+    codeHasBeenRun: true,
+    errorModalShowing: false,
+  };
+
+  const renderHtmlRunner = (store) =>
+    render(
+      <Provider store={store}>
+        <MemoryRouter>
+          <div id="app">
+            <HtmlRunner />
+          </div>
+        </MemoryRouter>
+      </Provider>,
+    );
+
+  test("does not handle preview messages after unmount", () => {
+    const mockStore = configureStore([]);
+    const store = mockStore({ editor: htmlRunnerState });
+    const { unmount } = renderHtmlRunner(store);
+    const actionsAfterMount = store.getActions().length;
+
+    unmount();
+
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          data: {
+            type: MSG_HTML_PREVIEW_EVENT,
+            msg: "RELOAD",
+            payload: { linkTo: "index" },
+          },
+        }),
+      );
+    });
+
+    expect(store.getActions().length).toBe(actionsAfterMount);
+  });
+
+  test("dispatches triggerCodeRun once per RELOAD message after remount", () => {
+    const mockStore = configureStore([]);
+    const store = mockStore({ editor: htmlRunnerState });
+    const first = renderHtmlRunner(store);
+    first.unmount();
+
+    renderHtmlRunner(store);
+
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          data: {
+            type: MSG_HTML_PREVIEW_EVENT,
+            msg: "RELOAD",
+            payload: { linkTo: "index" },
+          },
+        }),
+      );
+    });
+
+    const runActions = store
+      .getActions()
+      .filter((action) => action.type === triggerCodeRun().type);
+    expect(runActions).toHaveLength(1);
   });
 });

--- a/src/components/WebComponentProject/WebComponentProject.jsx
+++ b/src/components/WebComponentProject/WebComponentProject.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useMediaQuery } from "react-responsive";
 import { marked } from "marked";
@@ -25,6 +25,13 @@ import {
   runStartedEvent,
   stepChangedEvent,
 } from "../../events/WebComponentCustomEvents";
+import {
+  getPrevCodeRunTriggered,
+  setPrevCodeRunTriggered,
+  syncRunEventTrackingProject,
+} from "./runEventTrackingState";
+
+export { resetCodeRunEventTracking } from "./runEventTrackingState";
 
 const WebComponentProject = ({
   withProjectbar = false,
@@ -65,7 +72,6 @@ const WebComponentProject = ({
   );
   const isMobile = useMediaQuery({ query: MOBILE_MEDIA_QUERY });
   const [codeHasRun, setCodeHasRun] = useState(codeHasBeenRun);
-  const prevCodeRunTriggeredRef = useRef(false);
   const dispatch = useDispatch();
   const renderer = new marked.Renderer();
 
@@ -122,7 +128,11 @@ const WebComponentProject = ({
   }, [dispatch, projectInstructions, permitInstructionsOverride]);
 
   useEffect(() => {
-    const wasTriggered = prevCodeRunTriggeredRef.current;
+    syncRunEventTrackingProject(projectIdentifier, codeRunTriggered);
+  }, [projectIdentifier, codeRunTriggered]);
+
+  useEffect(() => {
+    const wasTriggered = getPrevCodeRunTriggered();
 
     if (codeRunTriggered && !wasTriggered) {
       document.dispatchEvent(
@@ -160,7 +170,7 @@ const WebComponentProject = ({
       document.dispatchEvent(runCompletedEvent(payload));
     }
 
-    prevCodeRunTriggeredRef.current = codeRunTriggered;
+    setPrevCodeRunTriggered(codeRunTriggered);
   }, [
     codeRunTriggered,
     codeHasRun,

--- a/src/components/WebComponentProject/WebComponentProject.jsx
+++ b/src/components/WebComponentProject/WebComponentProject.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useMediaQuery } from "react-responsive";
 import { marked } from "marked";
@@ -25,6 +25,11 @@ import {
   runStartedEvent,
   stepChangedEvent,
 } from "../../events/WebComponentCustomEvents";
+import {
+  beginRunEventCycle,
+  endRunEventCycle,
+  shouldEmitRunCompletedEvent,
+} from "./runEventCodeSnapshot";
 import {
   getPrevCodeRunTriggered,
   setPrevCodeRunTriggered,
@@ -60,7 +65,10 @@ const WebComponentProject = ({
   const error = useSelector((state) => state.editor.error);
   const errorDetails = useSelector((state) => state.editor.errorDetails);
   const friendlyError = useSelector((state) => state.editor.friendlyError);
-  const codeHasBeenRun = useSelector((state) => state.editor.codeHasBeenRun);
+  const projectComponents = useSelector(
+    (state) => state.editor.project.components,
+  );
+  const readOnly = useSelector((state) => state.editor.readOnly);
   const projectInstructions = useSelector(
     (state) => state.editor.project.instructions,
   );
@@ -71,7 +79,6 @@ const WebComponentProject = ({
     (state) => state.instructions.permitOverride,
   );
   const isMobile = useMediaQuery({ query: MOBILE_MEDIA_QUERY });
-  const [codeHasRun, setCodeHasRun] = useState(codeHasBeenRun);
   const dispatch = useDispatch();
   const renderer = new marked.Renderer();
 
@@ -83,7 +90,6 @@ const WebComponentProject = ({
   }, [editableInstructions, outputSplitView, outputOnly, dispatch]);
 
   useEffect(() => {
-    setCodeHasRun(false);
     const timeout = setTimeout(() => {
       document.dispatchEvent(codeChangedEvent({ step: currentStepPosition }));
     }, 2000);
@@ -135,45 +141,53 @@ const WebComponentProject = ({
     const wasTriggered = getPrevCodeRunTriggered();
 
     if (codeRunTriggered && !wasTriggered) {
-      document.dispatchEvent(
-        runStartedEvent({
-          step: currentStepPosition,
-          projectIdentifier,
-          projectType,
-        }),
-      );
-      setCodeHasRun(true);
+      if (
+        beginRunEventCycle(projectIdentifier, projectComponents, {
+          bypassSnapshot: readOnly,
+        })
+      ) {
+        document.dispatchEvent(
+          runStartedEvent({
+            step: currentStepPosition,
+            projectIdentifier,
+            projectType,
+          }),
+        );
+      }
     }
 
-    if (!codeRunTriggered && wasTriggered && codeHasRun) {
-      const mz_criteria = Sk.sense_hat
-        ? Sk.sense_hat.mz_criteria
-        : { ...defaultMZCriteria };
+    if (!codeRunTriggered && wasTriggered) {
+      if (shouldEmitRunCompletedEvent()) {
+        const mz_criteria = Sk.sense_hat
+          ? Sk.sense_hat.mz_criteria
+          : { ...defaultMZCriteria };
 
-      const payload = outputOnly
-        ? {
-            errorDetails,
-            step: currentStepPosition,
-            projectIdentifier,
-            projectType,
-          }
-        : {
-            isErrorFree: error === "",
-            step: currentStepPosition,
-            errorDetails,
-            friendlyErrorShown: Boolean(friendlyError?.html),
-            projectIdentifier,
-            projectType,
-            ...mz_criteria,
-          };
+        const payload = outputOnly
+          ? {
+              errorDetails,
+              step: currentStepPosition,
+              projectIdentifier,
+              projectType,
+            }
+          : {
+              isErrorFree: error === "",
+              step: currentStepPosition,
+              errorDetails,
+              friendlyErrorShown: Boolean(friendlyError?.html),
+              projectIdentifier,
+              projectType,
+              ...mz_criteria,
+            };
 
-      document.dispatchEvent(runCompletedEvent(payload));
+        document.dispatchEvent(runCompletedEvent(payload));
+      }
+
+      endRunEventCycle();
     }
 
     setPrevCodeRunTriggered(codeRunTriggered);
   }, [
     codeRunTriggered,
-    codeHasRun,
     outputOnly,
     error,
     errorDetails,
@@ -181,6 +195,8 @@ const WebComponentProject = ({
     currentStepPosition,
     projectIdentifier,
     projectType,
+    readOnly,
+    projectComponents,
   ]);
 
   useEffect(() => {

--- a/src/components/WebComponentProject/WebComponentProject.jsx
+++ b/src/components/WebComponentProject/WebComponentProject.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useRef } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useMediaQuery } from "react-responsive";
 import { marked } from "marked";
@@ -82,6 +82,30 @@ const WebComponentProject = ({
   const dispatch = useDispatch();
   const renderer = new marked.Renderer();
 
+  const buildRunCompletedPayloadRef = useRef(() => ({}));
+  buildRunCompletedPayloadRef.current = () => {
+    const mz_criteria = Sk.sense_hat
+      ? Sk.sense_hat.mz_criteria
+      : { ...defaultMZCriteria };
+
+    return outputOnly
+      ? {
+          errorDetails,
+          step: currentStepPosition,
+          projectIdentifier,
+          projectType,
+        }
+      : {
+          isErrorFree: error === "",
+          step: currentStepPosition,
+          errorDetails,
+          friendlyErrorShown: Boolean(friendlyError?.html),
+          projectIdentifier,
+          projectType,
+          ...mz_criteria,
+        };
+  };
+
   useEffect(() => {
     dispatch(setIsSplitView(outputSplitView));
     dispatch(setWebComponent(true));
@@ -140,29 +164,6 @@ const WebComponentProject = ({
   useEffect(() => {
     const wasTriggered = getPrevCodeRunTriggered();
 
-    const buildRunCompletedPayload = () => {
-      const mz_criteria = Sk.sense_hat
-        ? Sk.sense_hat.mz_criteria
-        : { ...defaultMZCriteria };
-
-      return outputOnly
-        ? {
-            errorDetails,
-            step: currentStepPosition,
-            projectIdentifier,
-            projectType,
-          }
-        : {
-            isErrorFree: error === "",
-            step: currentStepPosition,
-            errorDetails,
-            friendlyErrorShown: Boolean(friendlyError?.html),
-            projectIdentifier,
-            projectType,
-            ...mz_criteria,
-          };
-    };
-
     if (codeRunTriggered && !wasTriggered) {
       scheduleRunEventCycle(
         projectIdentifier,
@@ -180,7 +181,7 @@ const WebComponentProject = ({
           },
           onRunCompletedIfRunAlreadyEnded: () => {
             document.dispatchEvent(
-              runCompletedEvent(buildRunCompletedPayload()),
+              runCompletedEvent(buildRunCompletedPayloadRef.current()),
             );
           },
         },
@@ -190,7 +191,9 @@ const WebComponentProject = ({
     if (!codeRunTriggered && wasTriggered) {
       handleRunEndedForEventCycle({
         onRunCompleted: () => {
-          document.dispatchEvent(runCompletedEvent(buildRunCompletedPayload()));
+          document.dispatchEvent(
+            runCompletedEvent(buildRunCompletedPayloadRef.current()),
+          );
         },
       });
 

--- a/src/components/WebComponentProject/WebComponentProject.jsx
+++ b/src/components/WebComponentProject/WebComponentProject.jsx
@@ -26,9 +26,9 @@ import {
   stepChangedEvent,
 } from "../../events/WebComponentCustomEvents";
 import {
-  beginRunEventCycle,
   endRunEventCycle,
-  shouldEmitRunCompletedEvent,
+  handleRunEndedForEventCycle,
+  scheduleRunEventCycle,
 } from "./runEventCodeSnapshot";
 import {
   getPrevCodeRunTriggered,
@@ -140,47 +140,59 @@ const WebComponentProject = ({
   useEffect(() => {
     const wasTriggered = getPrevCodeRunTriggered();
 
-    if (codeRunTriggered && !wasTriggered) {
-      if (
-        beginRunEventCycle(projectIdentifier, projectComponents, {
-          bypassSnapshot: readOnly,
-        })
-      ) {
-        document.dispatchEvent(
-          runStartedEvent({
+    const buildRunCompletedPayload = () => {
+      const mz_criteria = Sk.sense_hat
+        ? Sk.sense_hat.mz_criteria
+        : { ...defaultMZCriteria };
+
+      return outputOnly
+        ? {
+            errorDetails,
             step: currentStepPosition,
             projectIdentifier,
             projectType,
-          }),
-        );
-      }
+          }
+        : {
+            isErrorFree: error === "",
+            step: currentStepPosition,
+            errorDetails,
+            friendlyErrorShown: Boolean(friendlyError?.html),
+            projectIdentifier,
+            projectType,
+            ...mz_criteria,
+          };
+    };
+
+    if (codeRunTriggered && !wasTriggered) {
+      scheduleRunEventCycle(
+        projectIdentifier,
+        projectComponents,
+        { bypassSnapshot: readOnly },
+        {
+          onRunStarted: () => {
+            document.dispatchEvent(
+              runStartedEvent({
+                step: currentStepPosition,
+                projectIdentifier,
+                projectType,
+              }),
+            );
+          },
+          onRunCompletedIfRunAlreadyEnded: () => {
+            document.dispatchEvent(
+              runCompletedEvent(buildRunCompletedPayload()),
+            );
+          },
+        },
+      );
     }
 
     if (!codeRunTriggered && wasTriggered) {
-      if (shouldEmitRunCompletedEvent()) {
-        const mz_criteria = Sk.sense_hat
-          ? Sk.sense_hat.mz_criteria
-          : { ...defaultMZCriteria };
-
-        const payload = outputOnly
-          ? {
-              errorDetails,
-              step: currentStepPosition,
-              projectIdentifier,
-              projectType,
-            }
-          : {
-              isErrorFree: error === "",
-              step: currentStepPosition,
-              errorDetails,
-              friendlyErrorShown: Boolean(friendlyError?.html),
-              projectIdentifier,
-              projectType,
-              ...mz_criteria,
-            };
-
-        document.dispatchEvent(runCompletedEvent(payload));
-      }
+      handleRunEndedForEventCycle({
+        onRunCompleted: () => {
+          document.dispatchEvent(runCompletedEvent(buildRunCompletedPayload()));
+        },
+      });
 
       endRunEventCycle();
     }

--- a/src/components/WebComponentProject/WebComponentProject.jsx
+++ b/src/components/WebComponentProject/WebComponentProject.jsx
@@ -122,7 +122,9 @@ const WebComponentProject = ({
   }, [dispatch, projectInstructions, permitInstructionsOverride]);
 
   useEffect(() => {
-    if (codeRunTriggered && !prevCodeRunTriggeredRef.current) {
+    const wasTriggered = prevCodeRunTriggeredRef.current;
+
+    if (codeRunTriggered && !wasTriggered) {
       document.dispatchEvent(
         runStartedEvent({
           step: currentStepPosition,
@@ -132,11 +134,8 @@ const WebComponentProject = ({
       );
       setCodeHasRun(true);
     }
-    prevCodeRunTriggeredRef.current = codeRunTriggered;
-  }, [codeRunTriggered, currentStepPosition, projectIdentifier, projectType]);
 
-  useEffect(() => {
-    if (!codeRunTriggered && codeHasRun) {
+    if (!codeRunTriggered && wasTriggered && codeHasRun) {
       const mz_criteria = Sk.sense_hat
         ? Sk.sense_hat.mz_criteria
         : { ...defaultMZCriteria };
@@ -160,6 +159,8 @@ const WebComponentProject = ({
 
       document.dispatchEvent(runCompletedEvent(payload));
     }
+
+    prevCodeRunTriggeredRef.current = codeRunTriggered;
   }, [
     codeRunTriggered,
     codeHasRun,

--- a/src/components/WebComponentProject/WebComponentProject.jsx
+++ b/src/components/WebComponentProject/WebComponentProject.jsx
@@ -62,7 +62,7 @@ const WebComponentProject = ({
     (state) => state.editor.codeRunTriggered,
   );
 
-  const error = useSelector((state) => state.editor.error);
+  const error = useSelector((state) => state.editor.error) ?? "";
   const errorDetails = useSelector((state) => state.editor.errorDetails);
   const friendlyError = useSelector((state) => state.editor.friendlyError);
   const projectComponents = useSelector(

--- a/src/components/WebComponentProject/WebComponentProject.test.js
+++ b/src/components/WebComponentProject/WebComponentProject.test.js
@@ -451,6 +451,88 @@ describe("When code run finishes", () => {
 
     expect(runCompletedHandler).toHaveBeenCalledTimes(1);
   });
+
+  test("emits runCompleted with latest error state when run ends during debounce", () => {
+    const middlewares = [];
+    const mockStore = configureStore(middlewares);
+    const editor = {
+      project: {
+        identifier: "test-project",
+        project_type: "python",
+        components: [
+          { name: "main", extension: "py", content: "print('hello')" },
+        ],
+        image_list: [],
+      },
+      loading: "success",
+      openFiles: [],
+      focussedFileIndices: [],
+      codeRunTriggered: true,
+      codeHasBeenRun: true,
+      error: "",
+      errorDetails: undefined,
+      friendlyError: undefined,
+    };
+    const instructions = {
+      currentStepPosition: 3,
+      permitOverride: true,
+    };
+
+    store = mockStore({ editor, instructions, auth: {} });
+
+    const view = render(
+      <Provider store={store}>
+        <WebComponentProject />
+      </Provider>,
+    );
+
+    store = mockStore({
+      editor: { ...editor, codeRunTriggered: false },
+      instructions,
+      auth: {},
+    });
+    view.rerender(
+      <Provider store={store}>
+        <WebComponentProject />
+      </Provider>,
+    );
+
+    store = mockStore({
+      editor: {
+        ...editor,
+        codeRunTriggered: false,
+        error: "NameError: name 'kettle' is not defined on line 5 of main.py",
+        errorDetails: {
+          type: "NameError",
+          file: "main.py",
+          line: 5,
+          description: "name 'kettle' is not defined",
+        },
+      },
+      instructions,
+      auth: {},
+    });
+    view.rerender(
+      <Provider store={store}>
+        <WebComponentProject />
+      </Provider>,
+    );
+
+    flushRunEventDebounce();
+
+    expect(runCompletedHandler).toHaveBeenCalledTimes(1);
+    expect(runCompletedHandler.mock.lastCall[0].detail).toEqual(
+      expect.objectContaining({
+        isErrorFree: false,
+        errorDetails: {
+          type: "NameError",
+          file: "main.py",
+          line: 5,
+          description: "name 'kettle' is not defined",
+        },
+      }),
+    );
+  });
 });
 
 describe("When code is unchanged between runs", () => {

--- a/src/components/WebComponentProject/WebComponentProject.test.js
+++ b/src/components/WebComponentProject/WebComponentProject.test.js
@@ -20,6 +20,12 @@ beforeAll(() => {
 
 jest.useFakeTimers();
 
+const flushRunEventDebounce = () => {
+  act(() => {
+    jest.advanceTimersByTime(250);
+  });
+};
+
 beforeEach(() => {
   resetCodeRunEventTracking();
 });
@@ -84,6 +90,7 @@ describe("When state set", () => {
       instructions: "My amazing instructions",
       codeRunTriggered: true,
     });
+    flushRunEventDebounce();
   });
 
   test("Renders", () => {
@@ -301,6 +308,8 @@ describe("When code run finishes", () => {
       </Provider>,
     );
 
+    flushRunEventDebounce();
+
     return view;
   };
 
@@ -412,6 +421,8 @@ describe("When code run finishes", () => {
       </Provider>,
     );
 
+    flushRunEventDebounce();
+
     expect(runCompletedHandler).toHaveBeenCalledTimes(1);
 
     store = mockStore({
@@ -490,6 +501,7 @@ describe("When code is unchanged between runs", () => {
     const { view, editor, instructions } = renderRunCycle({
       codeRunTriggered: true,
     });
+    flushRunEventDebounce();
 
     expect(runStartedHandler).toHaveBeenCalledTimes(1);
 
@@ -516,6 +528,7 @@ describe("When code is unchanged between runs", () => {
         <WebComponentProject />
       </Provider>,
     );
+    flushRunEventDebounce();
 
     expect(runStartedHandler).toHaveBeenCalledTimes(1);
 
@@ -537,6 +550,7 @@ describe("When code is unchanged between runs", () => {
     const { view, editor, instructions } = renderRunCycle({
       codeRunTriggered: true,
     });
+    flushRunEventDebounce();
 
     store = mockStoreFactory({
       editor: { ...editor, codeRunTriggered: false, codeHasBeenRun: true },
@@ -548,6 +562,8 @@ describe("When code is unchanged between runs", () => {
         <WebComponentProject />
       </Provider>,
     );
+
+    flushRunEventDebounce();
 
     const updatedEditor = {
       ...editor,
@@ -571,6 +587,7 @@ describe("When code is unchanged between runs", () => {
         <WebComponentProject />
       </Provider>,
     );
+    flushRunEventDebounce();
 
     expect(runStartedHandler).toHaveBeenCalledTimes(2);
 
@@ -593,6 +610,7 @@ describe("When code is unchanged between runs", () => {
       codeRunTriggered: true,
       readOnly: true,
     });
+    flushRunEventDebounce();
 
     expect(runStartedHandler).toHaveBeenCalledTimes(1);
 
@@ -608,6 +626,61 @@ describe("When code is unchanged between runs", () => {
     );
 
     expect(runCompletedHandler).toHaveBeenCalledTimes(1);
+
+    flushRunEventDebounce();
+
+    store = mockStoreFactory({
+      editor: {
+        ...editor,
+        codeRunTriggered: true,
+        codeHasBeenRun: true,
+        readOnly: true,
+      },
+      instructions,
+      auth: {},
+    });
+    view.rerender(
+      <Provider store={store}>
+        <WebComponentProject />
+      </Provider>,
+    );
+    flushRunEventDebounce();
+
+    expect(runStartedHandler).toHaveBeenCalledTimes(2);
+
+    store = mockStoreFactory({
+      editor: { ...editor, codeRunTriggered: false, readOnly: true },
+      instructions,
+      auth: {},
+    });
+    view.rerender(
+      <Provider store={store}>
+        <WebComponentProject />
+      </Provider>,
+    );
+
+    expect(runCompletedHandler).toHaveBeenCalledTimes(2);
+  });
+
+  test("collapses rapid read-only reruns into one debounced dispatch", () => {
+    const { view, editor, instructions } = renderRunCycle({
+      codeRunTriggered: true,
+      readOnly: true,
+    });
+    flushRunEventDebounce();
+
+    expect(runStartedHandler).toHaveBeenCalledTimes(1);
+
+    store = mockStoreFactory({
+      editor: { ...editor, codeRunTriggered: false, codeHasBeenRun: true },
+      instructions,
+      auth: {},
+    });
+    view.rerender(
+      <Provider store={store}>
+        <WebComponentProject />
+      </Provider>,
+    );
 
     store = mockStoreFactory({
       editor: {
@@ -625,20 +698,11 @@ describe("When code is unchanged between runs", () => {
       </Provider>,
     );
 
+    expect(runStartedHandler).toHaveBeenCalledTimes(1);
+
+    flushRunEventDebounce();
+
     expect(runStartedHandler).toHaveBeenCalledTimes(2);
-
-    store = mockStoreFactory({
-      editor: { ...editor, codeRunTriggered: false, readOnly: true },
-      instructions,
-      auth: {},
-    });
-    view.rerender(
-      <Provider store={store}>
-        <WebComponentProject />
-      </Provider>,
-    );
-
-    expect(runCompletedHandler).toHaveBeenCalledTimes(2);
   });
 });
 
@@ -679,6 +743,8 @@ describe("When remounted during a run", () => {
         <WebComponentProject />
       </Provider>,
     );
+
+    flushRunEventDebounce();
 
     expect(runStartedHandler).toHaveBeenCalledTimes(1);
 

--- a/src/components/WebComponentProject/WebComponentProject.test.js
+++ b/src/components/WebComponentProject/WebComponentProject.test.js
@@ -2,7 +2,9 @@ import React from "react";
 import { act, render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
-import WebComponentProject from "./WebComponentProject";
+import WebComponentProject, {
+  resetCodeRunEventTracking,
+} from "./WebComponentProject";
 
 const codeChangedHandler = jest.fn();
 const runStartedHandler = jest.fn();
@@ -17,6 +19,10 @@ beforeAll(() => {
 });
 
 jest.useFakeTimers();
+
+beforeEach(() => {
+  resetCodeRunEventTracking();
+});
 
 let store;
 
@@ -433,6 +439,58 @@ describe("When code run finishes", () => {
     );
 
     expect(runCompletedHandler).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("When remounted during a run", () => {
+  beforeEach(() => {
+    runStartedHandler.mockClear();
+  });
+
+  test("does not trigger runStarted again", () => {
+    const middlewares = [];
+    const mockStore = configureStore(middlewares);
+    const initialState = {
+      editor: {
+        project: {
+          identifier: "test-project",
+          project_type: "python",
+          components: [
+            { name: "main", extension: "py", content: "print('hello')" },
+          ],
+          image_list: [],
+        },
+        loading: "success",
+        openFiles: [],
+        focussedFileIndices: [],
+        codeRunTriggered: true,
+        codeHasBeenRun: true,
+      },
+      instructions: {
+        currentStepPosition: 3,
+        permitOverride: true,
+      },
+      auth: {},
+    };
+    const store = mockStore(initialState);
+
+    const view = render(
+      <Provider store={store}>
+        <WebComponentProject />
+      </Provider>,
+    );
+
+    expect(runStartedHandler).toHaveBeenCalledTimes(1);
+
+    view.unmount();
+
+    render(
+      <Provider store={store}>
+        <WebComponentProject />
+      </Provider>,
+    );
+
+    expect(runStartedHandler).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/components/WebComponentProject/WebComponentProject.test.js
+++ b/src/components/WebComponentProject/WebComponentProject.test.js
@@ -442,6 +442,206 @@ describe("When code run finishes", () => {
   });
 });
 
+describe("When code is unchanged between runs", () => {
+  const middlewares = [];
+  const mockStoreFactory = configureStore(middlewares);
+
+  const baseEditor = {
+    project: {
+      identifier: "test-project",
+      project_type: "python",
+      components: [
+        { name: "main", extension: "py", content: "print('hello')" },
+      ],
+      image_list: [],
+    },
+    loading: "success",
+    openFiles: [],
+    focussedFileIndices: [],
+    error: "",
+    errorDetails: undefined,
+    friendlyError: undefined,
+  };
+
+  const renderRunCycle = (editorOverrides = {}) => {
+    const editor = { ...baseEditor, ...editorOverrides };
+    const instructions = {
+      currentStepPosition: 3,
+      permitOverride: true,
+    };
+
+    store = mockStoreFactory({ editor, instructions, auth: {} });
+
+    const view = render(
+      <Provider store={store}>
+        <WebComponentProject />
+      </Provider>,
+    );
+
+    return { view, editor, instructions };
+  };
+
+  beforeEach(() => {
+    runStartedHandler.mockClear();
+    runCompletedHandler.mockClear();
+  });
+
+  test("does not emit run events on repeated runs with the same code", () => {
+    const { view, editor, instructions } = renderRunCycle({
+      codeRunTriggered: true,
+    });
+
+    expect(runStartedHandler).toHaveBeenCalledTimes(1);
+
+    store = mockStoreFactory({
+      editor: { ...editor, codeRunTriggered: false, codeHasBeenRun: true },
+      instructions,
+      auth: {},
+    });
+    view.rerender(
+      <Provider store={store}>
+        <WebComponentProject />
+      </Provider>,
+    );
+
+    expect(runCompletedHandler).toHaveBeenCalledTimes(1);
+
+    store = mockStoreFactory({
+      editor: { ...editor, codeRunTriggered: true, codeHasBeenRun: true },
+      instructions,
+      auth: {},
+    });
+    view.rerender(
+      <Provider store={store}>
+        <WebComponentProject />
+      </Provider>,
+    );
+
+    expect(runStartedHandler).toHaveBeenCalledTimes(1);
+
+    store = mockStoreFactory({
+      editor: { ...editor, codeRunTriggered: false },
+      instructions,
+      auth: {},
+    });
+    view.rerender(
+      <Provider store={store}>
+        <WebComponentProject />
+      </Provider>,
+    );
+
+    expect(runCompletedHandler).toHaveBeenCalledTimes(1);
+  });
+
+  test("emits run events again after code changes", () => {
+    const { view, editor, instructions } = renderRunCycle({
+      codeRunTriggered: true,
+    });
+
+    store = mockStoreFactory({
+      editor: { ...editor, codeRunTriggered: false, codeHasBeenRun: true },
+      instructions,
+      auth: {},
+    });
+    view.rerender(
+      <Provider store={store}>
+        <WebComponentProject />
+      </Provider>,
+    );
+
+    const updatedEditor = {
+      ...editor,
+      project: {
+        ...editor.project,
+        components: [
+          { name: "main", extension: "py", content: "print('world')" },
+        ],
+      },
+      codeRunTriggered: true,
+      codeHasBeenRun: true,
+    };
+
+    store = mockStoreFactory({
+      editor: updatedEditor,
+      instructions,
+      auth: {},
+    });
+    view.rerender(
+      <Provider store={store}>
+        <WebComponentProject />
+      </Provider>,
+    );
+
+    expect(runStartedHandler).toHaveBeenCalledTimes(2);
+
+    store = mockStoreFactory({
+      editor: { ...updatedEditor, codeRunTriggered: false },
+      instructions,
+      auth: {},
+    });
+    view.rerender(
+      <Provider store={store}>
+        <WebComponentProject />
+      </Provider>,
+    );
+
+    expect(runCompletedHandler).toHaveBeenCalledTimes(2);
+  });
+
+  test("emits run events on repeated runs when read only", () => {
+    const { view, editor, instructions } = renderRunCycle({
+      codeRunTriggered: true,
+      readOnly: true,
+    });
+
+    expect(runStartedHandler).toHaveBeenCalledTimes(1);
+
+    store = mockStoreFactory({
+      editor: { ...editor, codeRunTriggered: false, codeHasBeenRun: true },
+      instructions,
+      auth: {},
+    });
+    view.rerender(
+      <Provider store={store}>
+        <WebComponentProject />
+      </Provider>,
+    );
+
+    expect(runCompletedHandler).toHaveBeenCalledTimes(1);
+
+    store = mockStoreFactory({
+      editor: {
+        ...editor,
+        codeRunTriggered: true,
+        codeHasBeenRun: true,
+        readOnly: true,
+      },
+      instructions,
+      auth: {},
+    });
+    view.rerender(
+      <Provider store={store}>
+        <WebComponentProject />
+      </Provider>,
+    );
+
+    expect(runStartedHandler).toHaveBeenCalledTimes(2);
+
+    store = mockStoreFactory({
+      editor: { ...editor, codeRunTriggered: false, readOnly: true },
+      instructions,
+      auth: {},
+    });
+    view.rerender(
+      <Provider store={store}>
+        <WebComponentProject />
+      </Provider>,
+    );
+
+    expect(runCompletedHandler).toHaveBeenCalledTimes(2);
+  });
+});
+
 describe("When remounted during a run", () => {
   beforeEach(() => {
     runStartedHandler.mockClear();

--- a/src/components/WebComponentProject/WebComponentProject.test.js
+++ b/src/components/WebComponentProject/WebComponentProject.test.js
@@ -246,12 +246,65 @@ describe("When overriding instructions is not permitted", () => {
 });
 
 describe("When code run finishes", () => {
-  test("Triggers runCompletedEvent", () => {
-    renderWebComponentProject({
-      projectType: "python",
+  const renderRunCompletion = (editorOverrides = {}, props = {}) => {
+    const middlewares = [];
+    const mockStore = configureStore(middlewares);
+    const baseEditor = {
+      project: {
+        identifier: "test-project",
+        project_type: "python",
+        components: [
+          { name: "main", extension: "py", content: "print('hello')" },
+        ],
+        image_list: [],
+      },
+      loading: "success",
+      openFiles: [],
+      focussedFileIndices: [],
+      codeRunTriggered: true,
       codeHasBeenRun: true,
+      error: "",
+      errorDetails: undefined,
+      friendlyError: undefined,
+      ...editorOverrides,
+    };
+    const initialState = {
+      editor: baseEditor,
+      instructions: {
+        currentStepPosition: 3,
+        permitOverride: true,
+      },
+      auth: {},
+    };
+    store = mockStore(initialState);
+
+    const view = render(
+      <Provider store={store}>
+        <WebComponentProject {...props} />
+      </Provider>,
+    );
+
+    store = mockStore({
+      ...initialState,
+      editor: { ...baseEditor, codeRunTriggered: false },
     });
-    expect(runCompletedHandler).toHaveBeenCalled();
+
+    view.rerender(
+      <Provider store={store}>
+        <WebComponentProject {...props} />
+      </Provider>,
+    );
+
+    return view;
+  };
+
+  beforeEach(() => {
+    runCompletedHandler.mockClear();
+  });
+
+  test("Triggers runCompletedEvent", () => {
+    renderRunCompletion();
+    expect(runCompletedHandler).toHaveBeenCalledTimes(1);
     expect(runCompletedHandler.mock.lastCall[0].detail).toEqual(
       expect.objectContaining({
         isErrorFree: true,
@@ -265,49 +318,20 @@ describe("When code run finishes", () => {
   });
 
   test("includes error details and friendly error state when a run failed", () => {
-    const middlewares = [];
-    const mockStore = configureStore(middlewares);
-    const initialState = {
-      editor: {
-        project: {
-          identifier: "test-project",
-          project_type: "python",
-          components: [
-            { name: "main", extension: "py", content: "print('hello')" },
-          ],
-          image_list: [],
-        },
-        loading: "success",
-        openFiles: [],
-        focussedFileIndices: [],
-        codeRunTriggered: false,
-        codeHasBeenRun: true,
-        error: "NameError: name 'kettle' is not defined on line 5 of main.py",
-        errorDetails: {
-          type: "NameError",
-          file: "main.py",
-          line: 5,
-          description: "name 'kettle' is not defined",
-        },
-        friendlyError: {
-          html: "<p>Friendly error</p>",
-        },
+    renderRunCompletion({
+      error: "NameError: name 'kettle' is not defined on line 5 of main.py",
+      errorDetails: {
+        type: "NameError",
+        file: "main.py",
+        line: 5,
+        description: "name 'kettle' is not defined",
       },
-      instructions: {
-        currentStepPosition: 3,
-        permitOverride: true,
+      friendlyError: {
+        html: "<p>Friendly error</p>",
       },
-      auth: {},
-    };
-    store = mockStore(initialState);
+    });
 
-    render(
-      <Provider store={store}>
-        <WebComponentProject />
-      </Provider>,
-    );
-
-    expect(runCompletedHandler).toHaveBeenCalled();
+    expect(runCompletedHandler).toHaveBeenCalledTimes(1);
     expect(runCompletedHandler.mock.lastCall[0].detail).toEqual(
       expect.objectContaining({
         isErrorFree: false,
@@ -325,12 +349,8 @@ describe("When code run finishes", () => {
   });
 
   test("Triggers runCompletedEvent with error details when outputOnly is true", () => {
-    renderWebComponentProject({
-      projectType: "python",
-      codeHasBeenRun: true,
-      props: { outputOnly: true },
-    });
-    expect(runCompletedHandler).toHaveBeenCalled();
+    renderRunCompletion({}, { outputOnly: true });
+    expect(runCompletedHandler).toHaveBeenCalledTimes(1);
     expect(runCompletedHandler.mock.lastCall[0].detail).toEqual(
       expect.objectContaining({
         errorDetails: undefined,
@@ -339,6 +359,80 @@ describe("When code run finishes", () => {
         projectType: "python",
       }),
     );
+  });
+
+  test("does not trigger runCompletedEvent again when error state updates after the run ends", () => {
+    const middlewares = [];
+    const mockStore = configureStore(middlewares);
+    const editor = {
+      project: {
+        identifier: "test-project",
+        project_type: "python",
+        components: [
+          { name: "main", extension: "py", content: "print('hello')" },
+        ],
+        image_list: [],
+      },
+      loading: "success",
+      openFiles: [],
+      focussedFileIndices: [],
+      codeRunTriggered: true,
+      codeHasBeenRun: true,
+      error: "",
+      errorDetails: undefined,
+      friendlyError: undefined,
+    };
+    const instructions = {
+      currentStepPosition: 3,
+      permitOverride: true,
+    };
+
+    store = mockStore({ editor, instructions, auth: {} });
+
+    const view = render(
+      <Provider store={store}>
+        <WebComponentProject />
+      </Provider>,
+    );
+
+    store = mockStore({
+      editor: { ...editor, codeRunTriggered: false },
+      instructions,
+      auth: {},
+    });
+    view.rerender(
+      <Provider store={store}>
+        <WebComponentProject />
+      </Provider>,
+    );
+
+    expect(runCompletedHandler).toHaveBeenCalledTimes(1);
+
+    store = mockStore({
+      editor: {
+        ...editor,
+        codeRunTriggered: false,
+        error: "NameError: name 'kettle' is not defined on line 5 of main.py",
+        errorDetails: {
+          type: "NameError",
+          file: "main.py",
+          line: 5,
+          description: "name 'kettle' is not defined",
+        },
+        friendlyError: {
+          html: "<p>Friendly error</p>",
+        },
+      },
+      instructions,
+      auth: {},
+    });
+    view.rerender(
+      <Provider store={store}>
+        <WebComponentProject />
+      </Provider>,
+    );
+
+    expect(runCompletedHandler).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/components/WebComponentProject/WebComponentProject.test.js
+++ b/src/components/WebComponentProject/WebComponentProject.test.js
@@ -5,6 +5,7 @@ import configureStore from "redux-mock-store";
 import WebComponentProject, {
   resetCodeRunEventTracking,
 } from "./WebComponentProject";
+import { RUN_EVENT_DEBOUNCE_MS } from "./runEventCodeSnapshot";
 
 const codeChangedHandler = jest.fn();
 const runStartedHandler = jest.fn();
@@ -22,7 +23,7 @@ jest.useFakeTimers();
 
 const flushRunEventDebounce = () => {
   act(() => {
-    jest.advanceTimersByTime(250);
+    jest.advanceTimersByTime(RUN_EVENT_DEBOUNCE_MS);
   });
 };
 
@@ -328,6 +329,17 @@ describe("When code run finishes", () => {
         projectType: "python",
         errorDetails: undefined,
         friendlyErrorShown: false,
+      }),
+    );
+  });
+
+  test("reports isErrorFree when error state is undefined", () => {
+    renderRunCompletion({ error: undefined });
+
+    expect(runCompletedHandler).toHaveBeenCalledTimes(1);
+    expect(runCompletedHandler.mock.lastCall[0].detail).toEqual(
+      expect.objectContaining({
+        isErrorFree: true,
       }),
     );
   });

--- a/src/components/WebComponentProject/buildProjectCodeSnapshot.js
+++ b/src/components/WebComponentProject/buildProjectCodeSnapshot.js
@@ -1,0 +1,13 @@
+export const buildProjectCodeSnapshot = (components = []) => {
+  if (!Array.isArray(components)) {
+    return "";
+  }
+
+  return components
+    .map(
+      ({ name, extension, content }) =>
+        `${name}.${extension}\0${content ?? ""}`,
+    )
+    .sort()
+    .join("\n");
+};

--- a/src/components/WebComponentProject/buildProjectCodeSnapshot.test.js
+++ b/src/components/WebComponentProject/buildProjectCodeSnapshot.test.js
@@ -1,0 +1,29 @@
+import { buildProjectCodeSnapshot } from "./buildProjectCodeSnapshot";
+
+describe("buildProjectCodeSnapshot", () => {
+  test("builds a stable snapshot from project components", () => {
+    const components = [
+      { name: "main", extension: "py", content: "print('hello')" },
+      { name: "utils", extension: "py", content: "def foo(): pass" },
+    ];
+
+    expect(buildProjectCodeSnapshot(components)).toBe(
+      buildProjectCodeSnapshot([...components].reverse()),
+    );
+  });
+
+  test("returns an empty string for non-array input", () => {
+    expect(buildProjectCodeSnapshot(null)).toBe("");
+  });
+
+  test("changes when component content changes", () => {
+    const before = buildProjectCodeSnapshot([
+      { name: "main", extension: "py", content: "print(1)" },
+    ]);
+    const after = buildProjectCodeSnapshot([
+      { name: "main", extension: "py", content: "print(2)" },
+    ]);
+
+    expect(before).not.toBe(after);
+  });
+});

--- a/src/components/WebComponentProject/runEventCodeSnapshot.js
+++ b/src/components/WebComponentProject/runEventCodeSnapshot.js
@@ -115,11 +115,15 @@ export const endRunEventCycle = () => {
   runEndedWhileDebouncing = false;
 };
 
-export const resetRunEventCodeSnapshot = () => {
+export const cancelPendingRunEventDebounce = () => {
   clearDebounceTimer();
   pendingCallbacks = null;
+  runEndedWhileDebouncing = false;
+};
+
+export const resetRunEventCodeSnapshot = () => {
+  cancelPendingRunEventDebounce();
   lastEmittedCodeSnapshot = null;
   trackedProjectIdentifier = null;
   emitRunEventsForCurrentCycle = false;
-  runEndedWhileDebouncing = false;
 };

--- a/src/components/WebComponentProject/runEventCodeSnapshot.js
+++ b/src/components/WebComponentProject/runEventCodeSnapshot.js
@@ -1,44 +1,125 @@
 import { buildProjectCodeSnapshot } from "./buildProjectCodeSnapshot";
 
+export const RUN_EVENT_DEBOUNCE_MS = 250;
+
 let lastEmittedCodeSnapshot = null;
 let trackedProjectIdentifier = null;
 let emitRunEventsForCurrentCycle = false;
+let debounceTimer = null;
+let runEndedWhileDebouncing = false;
+let pendingCallbacks = null;
 
-export const beginRunEventCycle = (
-  projectIdentifier,
-  components,
-  { bypassSnapshot = false } = {},
-) => {
+const syncTrackedProject = (projectIdentifier) => {
+  if (trackedProjectIdentifier !== projectIdentifier) {
+    lastEmittedCodeSnapshot = null;
+    trackedProjectIdentifier = projectIdentifier ?? null;
+  }
+};
+
+const clearDebounceTimer = () => {
+  if (debounceTimer) {
+    clearTimeout(debounceTimer);
+    debounceTimer = null;
+  }
+};
+
+const shouldAllowRunEvent = (components, bypassSnapshot) => {
   if (bypassSnapshot) {
-    emitRunEventsForCurrentCycle = true;
     return true;
   }
 
   const snapshot = buildProjectCodeSnapshot(components);
 
-  if (trackedProjectIdentifier !== projectIdentifier) {
-    lastEmittedCodeSnapshot = null;
-    trackedProjectIdentifier = projectIdentifier ?? null;
-  }
-
   if (snapshot === lastEmittedCodeSnapshot) {
-    emitRunEventsForCurrentCycle = false;
     return false;
   }
 
   lastEmittedCodeSnapshot = snapshot;
-  emitRunEventsForCurrentCycle = true;
   return true;
+};
+
+const flushDebouncedRunEvent = () => {
+  debounceTimer = null;
+  const callbacks = pendingCallbacks;
+  pendingCallbacks = null;
+
+  if (!callbacks) {
+    return;
+  }
+
+  const {
+    projectIdentifier,
+    components,
+    bypassSnapshot,
+    onRunStarted,
+    onRunCompletedIfRunAlreadyEnded,
+  } = callbacks;
+
+  syncTrackedProject(projectIdentifier);
+
+  if (!shouldAllowRunEvent(components, bypassSnapshot)) {
+    emitRunEventsForCurrentCycle = false;
+    runEndedWhileDebouncing = false;
+    return;
+  }
+
+  emitRunEventsForCurrentCycle = true;
+  onRunStarted?.();
+
+  if (runEndedWhileDebouncing) {
+    onRunCompletedIfRunAlreadyEnded?.();
+    emitRunEventsForCurrentCycle = false;
+    runEndedWhileDebouncing = false;
+  }
+};
+
+export const scheduleRunEventCycle = (
+  projectIdentifier,
+  components,
+  { bypassSnapshot = false } = {},
+  { onRunStarted, onRunCompletedIfRunAlreadyEnded } = {},
+) => {
+  syncTrackedProject(projectIdentifier);
+  runEndedWhileDebouncing = false;
+  pendingCallbacks = {
+    projectIdentifier,
+    components,
+    bypassSnapshot,
+    onRunStarted,
+    onRunCompletedIfRunAlreadyEnded,
+  };
+
+  clearDebounceTimer();
+  debounceTimer = setTimeout(flushDebouncedRunEvent, RUN_EVENT_DEBOUNCE_MS);
+};
+
+export const handleRunEndedForEventCycle = ({ onRunCompleted }) => {
+  if (debounceTimer) {
+    runEndedWhileDebouncing = true;
+    return;
+  }
+
+  if (emitRunEventsForCurrentCycle) {
+    onRunCompleted?.();
+  }
 };
 
 export const shouldEmitRunCompletedEvent = () => emitRunEventsForCurrentCycle;
 
 export const endRunEventCycle = () => {
+  if (debounceTimer) {
+    return;
+  }
+
   emitRunEventsForCurrentCycle = false;
+  runEndedWhileDebouncing = false;
 };
 
 export const resetRunEventCodeSnapshot = () => {
+  clearDebounceTimer();
+  pendingCallbacks = null;
   lastEmittedCodeSnapshot = null;
   trackedProjectIdentifier = null;
   emitRunEventsForCurrentCycle = false;
+  runEndedWhileDebouncing = false;
 };

--- a/src/components/WebComponentProject/runEventCodeSnapshot.js
+++ b/src/components/WebComponentProject/runEventCodeSnapshot.js
@@ -1,0 +1,44 @@
+import { buildProjectCodeSnapshot } from "./buildProjectCodeSnapshot";
+
+let lastEmittedCodeSnapshot = null;
+let trackedProjectIdentifier = null;
+let emitRunEventsForCurrentCycle = false;
+
+export const beginRunEventCycle = (
+  projectIdentifier,
+  components,
+  { bypassSnapshot = false } = {},
+) => {
+  if (bypassSnapshot) {
+    emitRunEventsForCurrentCycle = true;
+    return true;
+  }
+
+  const snapshot = buildProjectCodeSnapshot(components);
+
+  if (trackedProjectIdentifier !== projectIdentifier) {
+    lastEmittedCodeSnapshot = null;
+    trackedProjectIdentifier = projectIdentifier ?? null;
+  }
+
+  if (snapshot === lastEmittedCodeSnapshot) {
+    emitRunEventsForCurrentCycle = false;
+    return false;
+  }
+
+  lastEmittedCodeSnapshot = snapshot;
+  emitRunEventsForCurrentCycle = true;
+  return true;
+};
+
+export const shouldEmitRunCompletedEvent = () => emitRunEventsForCurrentCycle;
+
+export const endRunEventCycle = () => {
+  emitRunEventsForCurrentCycle = false;
+};
+
+export const resetRunEventCodeSnapshot = () => {
+  lastEmittedCodeSnapshot = null;
+  trackedProjectIdentifier = null;
+  emitRunEventsForCurrentCycle = false;
+};

--- a/src/components/WebComponentProject/runEventCodeSnapshot.test.js
+++ b/src/components/WebComponentProject/runEventCodeSnapshot.test.js
@@ -1,4 +1,5 @@
 import {
+  cancelPendingRunEventDebounce,
   endRunEventCycle,
   handleRunEndedForEventCycle,
   resetRunEventCodeSnapshot,
@@ -144,5 +145,21 @@ describe("runEventCodeSnapshot", () => {
 
     expect(onRunStarted).toHaveBeenCalledTimes(2);
     expect(shouldEmitRunCompletedEvent()).toBe(true);
+  });
+
+  test("does not fire pending callbacks after debounce is cancelled", () => {
+    const onRunStarted = jest.fn();
+
+    scheduleRunEventCycle(
+      "project-a",
+      components,
+      { bypassSnapshot: true },
+      { onRunStarted },
+    );
+    cancelPendingRunEventDebounce();
+    flushDebounce();
+
+    expect(onRunStarted).not.toHaveBeenCalled();
+    expect(shouldEmitRunCompletedEvent()).toBe(false);
   });
 });

--- a/src/components/WebComponentProject/runEventCodeSnapshot.test.js
+++ b/src/components/WebComponentProject/runEventCodeSnapshot.test.js
@@ -1,7 +1,9 @@
 import {
-  beginRunEventCycle,
   endRunEventCycle,
+  handleRunEndedForEventCycle,
   resetRunEventCodeSnapshot,
+  RUN_EVENT_DEBOUNCE_MS,
+  scheduleRunEventCycle,
   shouldEmitRunCompletedEvent,
 } from "./runEventCodeSnapshot";
 
@@ -9,51 +11,138 @@ const components = [
   { name: "main", extension: "py", content: "print('hello')" },
 ];
 
+const flushDebounce = () => {
+  jest.advanceTimersByTime(RUN_EVENT_DEBOUNCE_MS);
+};
+
 describe("runEventCodeSnapshot", () => {
   beforeEach(() => {
+    jest.useFakeTimers();
     resetRunEventCodeSnapshot();
   });
 
-  test("allows the first run for a project", () => {
-    expect(beginRunEventCycle("project-a", components)).toBe(true);
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test("allows the first run for a project after debounce", () => {
+    const onRunStarted = jest.fn();
+
+    scheduleRunEventCycle("project-a", components, {}, { onRunStarted });
+    flushDebounce();
+
+    expect(onRunStarted).toHaveBeenCalledTimes(1);
     expect(shouldEmitRunCompletedEvent()).toBe(true);
   });
 
   test("suppresses repeated runs with unchanged code", () => {
-    beginRunEventCycle("project-a", components);
+    const onRunStarted = jest.fn();
+
+    scheduleRunEventCycle("project-a", components, {}, { onRunStarted });
+    flushDebounce();
     endRunEventCycle();
 
-    expect(beginRunEventCycle("project-a", components)).toBe(false);
+    scheduleRunEventCycle("project-a", components, {}, { onRunStarted });
+    flushDebounce();
+
+    expect(onRunStarted).toHaveBeenCalledTimes(1);
     expect(shouldEmitRunCompletedEvent()).toBe(false);
   });
 
   test("allows a run after code changes", () => {
-    beginRunEventCycle("project-a", components);
+    const onRunStarted = jest.fn();
+
+    scheduleRunEventCycle("project-a", components, {}, { onRunStarted });
+    flushDebounce();
     endRunEventCycle();
 
     const updatedComponents = [
       { name: "main", extension: "py", content: "print('world')" },
     ];
 
-    expect(beginRunEventCycle("project-a", updatedComponents)).toBe(true);
+    scheduleRunEventCycle("project-a", updatedComponents, {}, { onRunStarted });
+    flushDebounce();
+
+    expect(onRunStarted).toHaveBeenCalledTimes(2);
     expect(shouldEmitRunCompletedEvent()).toBe(true);
+  });
+
+  test("collapses a rapid burst into one run event", () => {
+    const onRunStarted = jest.fn();
+    const onRunCompletedIfRunAlreadyEnded = jest.fn();
+
+    scheduleRunEventCycle(
+      "project-a",
+      components,
+      { bypassSnapshot: true },
+      { onRunStarted, onRunCompletedIfRunAlreadyEnded },
+    );
+    scheduleRunEventCycle(
+      "project-a",
+      components,
+      { bypassSnapshot: true },
+      { onRunStarted, onRunCompletedIfRunAlreadyEnded },
+    );
+    handleRunEndedForEventCycle({
+      onRunCompleted: onRunCompletedIfRunAlreadyEnded,
+    });
+    flushDebounce();
+
+    expect(onRunStarted).toHaveBeenCalledTimes(1);
+    expect(onRunCompletedIfRunAlreadyEnded).toHaveBeenCalledTimes(1);
+    expect(shouldEmitRunCompletedEvent()).toBe(false);
+  });
+
+  test("emits run completed on run end after debounced start", () => {
+    const onRunStarted = jest.fn();
+    const onRunCompleted = jest.fn();
+
+    scheduleRunEventCycle("project-a", components, {}, { onRunStarted });
+    flushDebounce();
+
+    handleRunEndedForEventCycle({ onRunCompleted: onRunCompleted });
+
+    expect(onRunStarted).toHaveBeenCalledTimes(1);
+    expect(onRunCompleted).toHaveBeenCalledTimes(1);
   });
 
   test("resets snapshot when the project identifier changes", () => {
-    beginRunEventCycle("project-a", components);
+    const onRunStarted = jest.fn();
+
+    scheduleRunEventCycle("project-a", components, {}, { onRunStarted });
+    flushDebounce();
     endRunEventCycle();
 
-    expect(beginRunEventCycle("project-b", components)).toBe(true);
+    scheduleRunEventCycle("project-b", components, {}, { onRunStarted });
+    flushDebounce();
+
+    expect(onRunStarted).toHaveBeenCalledTimes(2);
     expect(shouldEmitRunCompletedEvent()).toBe(true);
   });
 
-  test("allows repeated runs when snapshot bypass is enabled", () => {
-    beginRunEventCycle("project-a", components);
+  test("allows separate bursts after debounce quiet period", () => {
+    const onRunStarted = jest.fn();
+
+    scheduleRunEventCycle(
+      "project-a",
+      components,
+      { bypassSnapshot: true },
+      { onRunStarted },
+    );
+    flushDebounce();
     endRunEventCycle();
 
-    expect(
-      beginRunEventCycle("project-a", components, { bypassSnapshot: true }),
-    ).toBe(true);
+    jest.advanceTimersByTime(RUN_EVENT_DEBOUNCE_MS);
+
+    scheduleRunEventCycle(
+      "project-a",
+      components,
+      { bypassSnapshot: true },
+      { onRunStarted },
+    );
+    flushDebounce();
+
+    expect(onRunStarted).toHaveBeenCalledTimes(2);
     expect(shouldEmitRunCompletedEvent()).toBe(true);
   });
 });

--- a/src/components/WebComponentProject/runEventCodeSnapshot.test.js
+++ b/src/components/WebComponentProject/runEventCodeSnapshot.test.js
@@ -1,0 +1,59 @@
+import {
+  beginRunEventCycle,
+  endRunEventCycle,
+  resetRunEventCodeSnapshot,
+  shouldEmitRunCompletedEvent,
+} from "./runEventCodeSnapshot";
+
+const components = [
+  { name: "main", extension: "py", content: "print('hello')" },
+];
+
+describe("runEventCodeSnapshot", () => {
+  beforeEach(() => {
+    resetRunEventCodeSnapshot();
+  });
+
+  test("allows the first run for a project", () => {
+    expect(beginRunEventCycle("project-a", components)).toBe(true);
+    expect(shouldEmitRunCompletedEvent()).toBe(true);
+  });
+
+  test("suppresses repeated runs with unchanged code", () => {
+    beginRunEventCycle("project-a", components);
+    endRunEventCycle();
+
+    expect(beginRunEventCycle("project-a", components)).toBe(false);
+    expect(shouldEmitRunCompletedEvent()).toBe(false);
+  });
+
+  test("allows a run after code changes", () => {
+    beginRunEventCycle("project-a", components);
+    endRunEventCycle();
+
+    const updatedComponents = [
+      { name: "main", extension: "py", content: "print('world')" },
+    ];
+
+    expect(beginRunEventCycle("project-a", updatedComponents)).toBe(true);
+    expect(shouldEmitRunCompletedEvent()).toBe(true);
+  });
+
+  test("resets snapshot when the project identifier changes", () => {
+    beginRunEventCycle("project-a", components);
+    endRunEventCycle();
+
+    expect(beginRunEventCycle("project-b", components)).toBe(true);
+    expect(shouldEmitRunCompletedEvent()).toBe(true);
+  });
+
+  test("allows repeated runs when snapshot bypass is enabled", () => {
+    beginRunEventCycle("project-a", components);
+    endRunEventCycle();
+
+    expect(
+      beginRunEventCycle("project-a", components, { bypassSnapshot: true }),
+    ).toBe(true);
+    expect(shouldEmitRunCompletedEvent()).toBe(true);
+  });
+});

--- a/src/components/WebComponentProject/runEventTrackingState.js
+++ b/src/components/WebComponentProject/runEventTrackingState.js
@@ -1,0 +1,27 @@
+let prevCodeRunTriggered = false;
+let trackedProjectIdentifier = null;
+
+export const getPrevCodeRunTriggered = () => prevCodeRunTriggered;
+
+export const setPrevCodeRunTriggered = (value) => {
+  prevCodeRunTriggered = value;
+};
+
+export const resetCodeRunEventTracking = () => {
+  prevCodeRunTriggered = false;
+  trackedProjectIdentifier = null;
+};
+
+export const syncRunEventTrackingProject = (
+  projectIdentifier,
+  codeRunTriggered,
+) => {
+  if (
+    trackedProjectIdentifier !== null &&
+    trackedProjectIdentifier !== projectIdentifier
+  ) {
+    prevCodeRunTriggered = codeRunTriggered;
+  }
+
+  trackedProjectIdentifier = projectIdentifier ?? null;
+};

--- a/src/components/WebComponentProject/runEventTrackingState.js
+++ b/src/components/WebComponentProject/runEventTrackingState.js
@@ -1,3 +1,5 @@
+import { resetRunEventCodeSnapshot } from "./runEventCodeSnapshot";
+
 let prevCodeRunTriggered = false;
 let trackedProjectIdentifier = null;
 
@@ -10,6 +12,7 @@ export const setPrevCodeRunTriggered = (value) => {
 export const resetCodeRunEventTracking = () => {
   prevCodeRunTriggered = false;
   trackedProjectIdentifier = null;
+  resetRunEventCodeSnapshot();
 };
 
 export const syncRunEventTrackingProject = (

--- a/src/components/WebComponentProject/runEventTrackingState.test.js
+++ b/src/components/WebComponentProject/runEventTrackingState.test.js
@@ -1,0 +1,36 @@
+import {
+  getPrevCodeRunTriggered,
+  resetCodeRunEventTracking,
+  setPrevCodeRunTriggered,
+  syncRunEventTrackingProject,
+} from "./runEventTrackingState";
+
+describe("runEventTrackingState", () => {
+  beforeEach(() => {
+    resetCodeRunEventTracking();
+  });
+
+  test("tracks the previous codeRunTriggered value across calls", () => {
+    expect(getPrevCodeRunTriggered()).toBe(false);
+    setPrevCodeRunTriggered(true);
+    expect(getPrevCodeRunTriggered()).toBe(true);
+  });
+
+  test("resets tracking state", () => {
+    setPrevCodeRunTriggered(true);
+    syncRunEventTrackingProject("project-a", true);
+
+    resetCodeRunEventTracking();
+
+    expect(getPrevCodeRunTriggered()).toBe(false);
+  });
+
+  test("resets prev state when the project identifier changes", () => {
+    syncRunEventTrackingProject("project-a", true);
+    setPrevCodeRunTriggered(true);
+
+    syncRunEventTrackingProject("project-b", false);
+
+    expect(getPrevCodeRunTriggered()).toBe(false);
+  });
+});

--- a/src/web-component.js
+++ b/src/web-component.js
@@ -10,6 +10,7 @@ import camelCase from "camelcase";
 import { stopCodeRun, stopDraw, triggerCodeRun } from "./redux/EditorSlice";
 import { BrowserRouter } from "react-router-dom";
 import { resetStore } from "./redux/RootSlice";
+import { resetCodeRunEventTracking } from "./components/WebComponentProject/runEventTrackingState";
 import dedupeDesignSystemWarnings from "./utils/dedupeDesignSystemWarnings";
 import { setUser } from "./redux/WebComponentAuthSlice";
 import { projectHasChangedSinceInitialLoad } from "./utils/projectHelpers";
@@ -45,6 +46,7 @@ class WebComponent extends HTMLElement {
       console.log("Unmounted web-component...");
       this.root.unmount();
     }
+    resetCodeRunEventTracking();
     store.dispatch(resetStore());
   }
 


### PR DESCRIPTION
## Summary

Issue [1543](https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1543).

Investigation into duplicate `Project - Ran code` and `Project - Run completed` analytics events. I was unable to reproduce the kind of event timings reported in the ticket through normal UI interaction alone. The closest match came from running the following in the browser console on a project page:

```javascript
let n = 0;
const burst = setInterval(() => {
  document.querySelector("editor-wc")?.runCode();
  if (++n >= 15) clearInterval(burst);
}, 50);
```

This PR takes a two-pronged approach: fix several edge cases in how run events are dispatched, and add gating so analytics only records runs that are likely to be meaningful. Should provide some fortification against abuse of the run button and over running the code.

## Bug fixes

Briefly — see commit messages for detail:

- Fire `runCompleted` once per run cycle, not again when error state updates after the run ends.
- Remove leaked `window.message` listeners in `HtmlRunner` that could cause duplicate handling on re-render.
- Keep `runStarted` stable across web-component remounts during an active run.

## Run event dispatch gating 

Commits have been used break this down a little

### Code-change snapshot (editable projects)

Run analytics events (`editor-runStarted` / `editor-runCompleted`) are only dispatched when the project's code differs from the last **counted** run. Repeated runs of unchanged code are suppressed.

This assumes that a user hammering the run button without changing code does not tell us anything useful for analytics — as these do not reflect a new attempt or progress.

Read-only mode (e.g. a teacher viewing student work) bypasses the snapshot check so deliberate re-runs of the same code are still tracked.

### Debounce (250ms quiet period)

A trailing debounce is also applied so bursts of run attempts collapse into a single counted dispatch after 250ms of quiet. This reduces noise on project views where code cannot be edited, or where a code-change snapshot is not practical (e.g. Scratch green-flag runs via `ScratchContainer`).

Together, snapshot gating handles the common student case; debounce handles read-only and Scratch paths where repeated runs without an easy code-diff are still possible.
