### PR TITLE
Add scrollbar to Python output

### DIFF
--- a/src/assets/stylesheets/PythonRunner.scss
+++ b/src/assets/stylesheets/PythonRunner.scss
@@ -17,9 +17,9 @@
   white-space: -moz-pre-wrap;
   white-space: -pre-wrap;
   white-space: -o-pre-wrap;
-  inline-size: 100%;
   overflow-wrap: break-word;
   overflow-y: auto;
+  scrollbar-width: thin;
 
   &--medium {
     @include font-size-1-5(regular);


### PR DESCRIPTION
Closes https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1545

## After
<img width="556" height="272" alt="Screenshot 2026-07-02 at 09 52 31" src="https://github.com/user-attachments/assets/9908d5da-2a66-4e02-9b0e-35dedfd332ba" />

<img width="561" height="369" alt="Screenshot 2026-07-02 at 09 49 36" src="https://github.com/user-attachments/assets/f8be34ea-2574-44ea-9088-a609eb7eab16" />

