### PR TITLE
Add margin to bottom of instructions panel

### DIFF
--- a/src/assets/stylesheets/Instructions.scss
+++ b/src/assets/stylesheets/Instructions.scss
@@ -432,6 +432,7 @@
     }
 
     .react-tabs__tab-panel {
+      margin-block-end: var(--space-1);
       .project-instructions {
         padding-inline: var(--space-1);
       }


### PR DESCRIPTION
closes https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/410

Before:
<img width="548" height="291" alt="image" src="https://github.com/user-attachments/assets/953ff1ea-1cec-49b1-9306-4d6590e72044" />


After:
<img width="548" height="291" alt="image" src="https://github.com/user-attachments/assets/3015c284-862e-4dd8-8035-022c4924d54f" />
