### PR TITLE
Add licences link to Scratch projects

### DIFF
--- a/public/translations/en.json
+++ b/public/translations/en.json
@@ -284,6 +284,7 @@
     "cookies": "Cookies",
     "accessibility": "Accessibility",
     "safeguarding": "Safeguarding",
+    "licenses": "Licenses",
     "charity": "Raspberry Pi Foundation - UK registered charity 1129409",
     "settingsMenu": {
       "heading": "Settings",

--- a/public/translations/en.json
+++ b/public/translations/en.json
@@ -284,7 +284,7 @@
     "cookies": "Cookies",
     "accessibility": "Accessibility",
     "safeguarding": "Safeguarding",
-    "licenses": "Licenses",
+    "licences": "Licences",
     "charity": "Raspberry Pi Foundation - UK registered charity 1129409",
     "settingsMenu": {
       "heading": "Settings",

--- a/src/assets/stylesheets/InfoPanel.scss
+++ b/src/assets/stylesheets/InfoPanel.scss
@@ -14,7 +14,6 @@
 }
 
 .info-panel__links {
-  align-items: flex-start;
   display: flex;
   flex-direction: column;
 
@@ -27,6 +26,7 @@
 
   button {
     border: 3px solid transparent;
+    cursor: pointer;
     text-align: start;
   }
 

--- a/src/assets/stylesheets/InfoPanel.scss
+++ b/src/assets/stylesheets/InfoPanel.scss
@@ -17,16 +17,19 @@
   display: flex;
   flex-direction: column;
 
-  a {
+  a, button {
     @include font-size-1(regular);
+    font-family: inherit;
     font-weight: $font-weight-bold;
     text-decoration: underline;
   }
-}
 
-.info-panel__link {
-  &:last-of-type {
-    margin-block-end: $space-1;
+  button {
+    border: 3px solid transparent;
+  }
+
+  p {
+    margin-block-start: $space-1;
   }
 }
 
@@ -36,7 +39,8 @@
     background-color: $rpf-grey-600;
   }
 
-  .info-panel__links a {
+  .info-panel__links a,
+  .info-panel__links button {
     color: $rpf-text-primary-darkmode;
   }
 }
@@ -47,7 +51,8 @@
     background-color: $rpf-grey-50;
   }
 
-  .info-panel__links a {
+  .info-panel__links a,
+  .info-panel__links button {
     color: $rpf-text-primary;
   }
 }

--- a/src/assets/stylesheets/InfoPanel.scss
+++ b/src/assets/stylesheets/InfoPanel.scss
@@ -14,6 +14,7 @@
 }
 
 .info-panel__links {
+  align-items: flex-start;
   display: flex;
   flex-direction: column;
 
@@ -26,6 +27,7 @@
 
   button {
     border: 3px solid transparent;
+    text-align: start;
   }
 
   p {

--- a/src/components/Menus/Sidebar/InfoPanel/InfoPanel.jsx
+++ b/src/components/Menus/Sidebar/InfoPanel/InfoPanel.jsx
@@ -1,8 +1,9 @@
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
-import { Modal } from "@raspberrypifoundation/design-system-react";
 import SidebarPanel from "../SidebarPanel";
+import GeneralModal from "../../../Modals/GeneralModal";
+import DesignSystemButton from "../../../DesignSystemButton/DesignSystemButton";
 
 import "../../../../assets/stylesheets/InfoPanel.scss";
 
@@ -93,14 +94,110 @@ const InfoPanel = ({ feedbackFormUrl = CODE_EDITOR_FEEDBACK_URL }) => {
       </div>
 
       {isScratchProject && (
-        <Modal
+        <GeneralModal
           isOpen={isLicensesModalOpen}
-          setIsOpen={setIsLicensesModalOpen}
           heading={t("sidebar.licenses")}
-          showCloseButton
+          closeModal={() => setIsLicensesModalOpen(false)}
+          buttons={[
+            <DesignSystemButton
+              key="close"
+              type="secondary"
+              text={t("modals.close")}
+              onClick={() => setIsLicensesModalOpen(false)}
+            />,
+          ]}
         >
-          <p>Hello, this is a test modal content.</p>
-        </Modal>
+          <section className="info-panel__licenses-modal__section">
+            <h2>Scratch Editor</h2>
+            <p>Copyright (C) Scratch Foundation</p>
+            <p>Modified 2026 by the Raspberry Pi Foundation</p>
+            <p>
+              This program is free software: you can redistribute it and/or
+              modify it under the terms of the GNU Affero General Public License
+              as published by the Free Software Foundation, either version 3 of
+              the License, or (at your option) any later version.
+            </p>
+            <p>
+              This program is distributed in the hope that it will be useful,
+              but WITHOUT ANY WARRANTY; without even the implied warranty of
+              MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+              Affero General Public License for more details.
+            </p>
+            <p>
+              You should have received a copy of the GNU Affero General Public
+              License along with this program. If not, see{" "}
+              <a
+                href="https://www.gnu.org/licenses/"
+                target="_blank"
+                rel="noreferrer"
+              >
+                https://www.gnu.org/licenses/
+              </a>
+              .
+            </p>
+            <p>
+              See original source code and full licence at{" "}
+              <a
+                href="https://github.com/scratchfoundation/scratch-editor"
+                target="_blank"
+                rel="noreferrer"
+              >
+                https://github.com/scratchfoundation/scratch-editor
+              </a>
+              .
+            </p>
+            <p>
+              See modified source code and full licence at{" "}
+              <a
+                href="https://github.com/RaspberryPiFoundation/scratch-editor/tree/code-classroom"
+                target="_blank"
+                rel="noreferrer"
+              >
+                https://github.com/RaspberryPiFoundation/scratch-editor/tree/code-classroom
+              </a>
+              .
+            </p>
+          </section>
+          <section className="licenses-modal__section">
+            <h2>Scratch Frame</h2>
+            <p>Copyright (C) 2026 Raspberry Pi Foundation</p>
+            <p>
+              This program is free software: you can redistribute it and/or
+              modify it under the terms of the GNU Affero General Public License
+              as published by the Free Software Foundation, either version 3 of
+              the License, or (at your option) any later version.
+            </p>
+            <p>
+              This program is distributed in the hope that it will be useful,
+              but WITHOUT ANY WARRANTY; without even the implied warranty of
+              MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+              Affero General Public License for more details.
+            </p>
+            <p>
+              You should have received a copy of the GNU Affero General Public
+              License along with this program. If not, see{" "}
+              <a
+                href="https://www.gnu.org/licenses/"
+                target="_blank"
+                rel="noreferrer"
+              >
+                https://www.gnu.org/licenses/
+              </a>
+              .
+            </p>
+            <p>
+              See source code and full licence at{" "}
+              <a
+                href="https://github.com/RaspberryPiFoundation/editor-ui/tree/main/apps/scratch-frame"
+                target="_blank"
+                rel="noreferrer"
+              >
+                https://github.com/RaspberryPiFoundation/editor-ui/tree/main/apps/scratch-frame
+              </a>
+              .
+            </p>
+          </section>
+        </GeneralModal>
       )}
     </SidebarPanel>
   );

--- a/src/components/Menus/Sidebar/InfoPanel/InfoPanel.jsx
+++ b/src/components/Menus/Sidebar/InfoPanel/InfoPanel.jsx
@@ -1,5 +1,7 @@
-import React from "react";
+import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { useSelector } from "react-redux";
+import { Modal } from "@raspberrypifoundation/design-system-react";
 import SidebarPanel from "../SidebarPanel";
 
 import "../../../../assets/stylesheets/InfoPanel.scss";
@@ -24,6 +26,10 @@ const feedbackUrl = (url) => {
 
 const InfoPanel = ({ feedbackFormUrl = CODE_EDITOR_FEEDBACK_URL }) => {
   const { t } = useTranslation();
+  const [isLicensesModalOpen, setIsLicensesModalOpen] = useState(false);
+  const projectType = useSelector((state) => state.editor.project.project_type);
+  const isScratchProject = projectType === "code_editor_scratch";
+
   const links = [
     {
       id: "help",
@@ -74,8 +80,28 @@ const InfoPanel = ({ feedbackFormUrl = CODE_EDITOR_FEEDBACK_URL }) => {
             {link.text}
           </a>
         ))}
+        {isScratchProject && (
+          <button
+            type="button"
+            className="info-panel__link"
+            onClick={() => setIsLicensesModalOpen(true)}
+          >
+            {t("sidebar.licenses")}
+          </button>
+        )}
         <p>{t("sidebar.charity")}</p>
       </div>
+
+      {isScratchProject && (
+        <Modal
+          isOpen={isLicensesModalOpen}
+          setIsOpen={setIsLicensesModalOpen}
+          heading={t("sidebar.licenses")}
+          showCloseButton
+        >
+          <p>Hello, this is a test modal content.</p>
+        </Modal>
+      )}
     </SidebarPanel>
   );
 };

--- a/src/components/Menus/Sidebar/InfoPanel/InfoPanel.jsx
+++ b/src/components/Menus/Sidebar/InfoPanel/InfoPanel.jsx
@@ -27,7 +27,7 @@ const feedbackUrl = (url) => {
 
 const InfoPanel = ({ feedbackFormUrl = CODE_EDITOR_FEEDBACK_URL }) => {
   const { t } = useTranslation();
-  const [isLicensesModalOpen, setIsLicensesModalOpen] = useState(false);
+  const [isLicencesModalOpen, setIsLicencesModalOpen] = useState(false);
   const projectType = useSelector((state) => state.editor.project.project_type);
   const isScratchProject = projectType === "code_editor_scratch";
 
@@ -85,9 +85,9 @@ const InfoPanel = ({ feedbackFormUrl = CODE_EDITOR_FEEDBACK_URL }) => {
           <button
             type="button"
             className="info-panel__link"
-            onClick={() => setIsLicensesModalOpen(true)}
+            onClick={() => setIsLicencesModalOpen(true)}
           >
-            {t("sidebar.licenses")}
+            {t("sidebar.licences")}
           </button>
         )}
         <p>{t("sidebar.charity")}</p>
@@ -95,19 +95,19 @@ const InfoPanel = ({ feedbackFormUrl = CODE_EDITOR_FEEDBACK_URL }) => {
 
       {isScratchProject && (
         <GeneralModal
-          isOpen={isLicensesModalOpen}
-          heading={t("sidebar.licenses")}
-          closeModal={() => setIsLicensesModalOpen(false)}
+          isOpen={isLicencesModalOpen}
+          heading={t("sidebar.licences")}
+          closeModal={() => setIsLicencesModalOpen(false)}
           buttons={[
             <DesignSystemButton
               key="close"
               type="secondary"
               text={t("modals.close")}
-              onClick={() => setIsLicensesModalOpen(false)}
+              onClick={() => setIsLicencesModalOpen(false)}
             />,
           ]}
         >
-          <section className="info-panel__licenses-modal__section">
+          <section className="info-panel__licences-modal__section">
             <h2>Scratch Editor</h2>
             <p>Copyright (C) Scratch Foundation</p>
             <p>Modified 2026 by the Raspberry Pi Foundation</p>
@@ -158,7 +158,7 @@ const InfoPanel = ({ feedbackFormUrl = CODE_EDITOR_FEEDBACK_URL }) => {
               .
             </p>
           </section>
-          <section className="licenses-modal__section">
+          <section className="licences-modal__section">
             <h2>Scratch Frame</h2>
             <p>Copyright (C) 2026 Raspberry Pi Foundation</p>
             <p>

--- a/src/components/Menus/Sidebar/InfoPanel/InfoPanel.test.js
+++ b/src/components/Menus/Sidebar/InfoPanel/InfoPanel.test.js
@@ -43,12 +43,6 @@ describe("Info panel", () => {
     expect(screen.queryByText("sidebar.privacy")).toBeInTheDocument();
   });
 
-  test("The licenses link is not rendered for non-Scratch projects", () => {
-    renderInfoPanel();
-
-    expect(screen.queryByText("sidebar.licenses")).not.toBeInTheDocument();
-  });
-
   test("Links have the expected default source", () => {
     renderInfoPanel();
 
@@ -91,10 +85,10 @@ describe("Info panel", () => {
     },
   );
 
-  test("the licenses modal is not rendered for non-Scratch projects", () => {
+  test("the licences modal is not rendered for non-Scratch projects", () => {
     renderInfoPanel();
 
-    expect(screen.queryByText("sidebar.licenses")).not.toBeInTheDocument();
+    expect(screen.queryByText("sidebar.licences")).not.toBeInTheDocument();
   });
 });
 
@@ -114,16 +108,16 @@ describe("when the project is a Scratch project", () => {
     Modal.setAppElement("#app");
   });
 
-  test("the licenses link is rendered", () => {
+  test("the licences link is rendered", () => {
     renderInfoPanel({}, scratchInitialState);
 
-    expect(screen.queryByText("sidebar.licenses")).toBeInTheDocument();
+    expect(screen.queryByText("sidebar.licences")).toBeInTheDocument();
   });
 
-  test("the licenses modal opens when the licenses link is clicked", () => {
+  test("the licences modal opens when the licences link is clicked", () => {
     renderInfoPanel({}, scratchInitialState);
 
-    fireEvent.click(screen.getByText("sidebar.licenses"));
+    fireEvent.click(screen.getByText("sidebar.licences"));
 
     expect(screen.queryByText("Scratch Editor")).toBeInTheDocument();
     expect(screen.queryByText("Scratch Frame")).toBeInTheDocument();

--- a/src/components/Menus/Sidebar/InfoPanel/InfoPanel.test.js
+++ b/src/components/Menus/Sidebar/InfoPanel/InfoPanel.test.js
@@ -1,26 +1,28 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 import { MemoryRouter } from "react-router-dom";
+import Modal from "react-modal";
 
 import InfoPanel from "./InfoPanel";
 
-const renderInfoPanel = (props = {}) => {
+const defaultInitialState = {
+  editor: {
+    project: {
+      components: [
+        {
+          name: "main",
+          extension: "py",
+        },
+      ],
+    },
+  },
+};
+
+const renderInfoPanel = (props = {}, initialState = defaultInitialState) => {
   const middlewares = [];
   const mockStore = configureStore(middlewares);
-  const initialState = {
-    editor: {
-      project: {
-        components: [
-          {
-            name: "main",
-            extension: "py",
-          },
-        ],
-      },
-    },
-  };
   const store = mockStore(initialState);
 
   render(
@@ -39,6 +41,12 @@ describe("Info panel", () => {
     expect(screen.queryByText("sidebar.help")).toBeInTheDocument();
     expect(screen.queryByText("sidebar.feedback")).toBeInTheDocument();
     expect(screen.queryByText("sidebar.privacy")).toBeInTheDocument();
+  });
+
+  test("The licenses link is not rendered for non-Scratch projects", () => {
+    renderInfoPanel();
+
+    expect(screen.queryByText("sidebar.licenses")).not.toBeInTheDocument();
   });
 
   test("Links have the expected default source", () => {
@@ -82,4 +90,42 @@ describe("Info panel", () => {
       );
     },
   );
+
+  test("the licenses modal is not rendered for non-Scratch projects", () => {
+    renderInfoPanel();
+
+    expect(screen.queryByText("sidebar.licenses")).not.toBeInTheDocument();
+  });
+});
+
+describe("when the project is a Scratch project", () => {
+  const scratchInitialState = {
+    editor: {
+      project: {
+        project_type: "code_editor_scratch",
+      },
+    },
+  };
+
+  beforeAll(() => {
+    const root = global.document.createElement("div");
+    root.setAttribute("id", "app");
+    global.document.body.appendChild(root);
+    Modal.setAppElement("#app");
+  });
+
+  test("the licenses link is rendered", () => {
+    renderInfoPanel({}, scratchInitialState);
+
+    expect(screen.queryByText("sidebar.licenses")).toBeInTheDocument();
+  });
+
+  test("the licenses modal opens when the licenses link is clicked", () => {
+    renderInfoPanel({}, scratchInitialState);
+
+    fireEvent.click(screen.getByText("sidebar.licenses"));
+
+    expect(screen.queryByText("Scratch Editor")).toBeInTheDocument();
+    expect(screen.queryByText("Scratch Frame")).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Part of https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1553

### Notes
- The licence text are in English and not localised.
  - We could have translated summaries perhaps in the future. 
- Couldn't use Design System Modal as it required a lot of overriding.
- Used the existing GeneralModal for now.
  - Although it looks fine locally, it may not in staging and prod like other modals currently. 
     - The Close button may not render properly, but will have to see in staging if that's the case
  - Max wrote this issue on the broken modals: https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1561
  
 ### Screenshots
- For blocks project:
<img width="857" alt="Screenshot 2026-07-10 at 08 57 03" src="https://github.com/user-attachments/assets/a2237ca7-9d88-4752-b249-e0edb872b876" />
<img width="834" alt="Screenshot 2026-07-10 at 08 56 43" src="https://github.com/user-attachments/assets/4dad441f-a50e-428b-b744-eab0c01bf165" />

- For non blocks project, no Licences link in the info panel:
<img width="486" alt="Screenshot 2026-07-10 at 10 09 32" src="https://github.com/user-attachments/assets/ea31259b-af1d-4dcb-b1a3-95cb04ef616a" />
