### PR TITLE
Scratch frame documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ This project provides a web component containing the Raspberry Pi Code Editor fo
 
 This repository uses Yarn (see `package.json` → `packageManager`).
 
-`@RaspberryPiFoundation/scratch-gui` is installed from [GitHub Packages](https://github.com/RaspberryPiFoundation/scratch-editor/pkgs/npm/scratch-gui). Complete the steps below, then run `yarn install`.
+The scratch-frame project depends on `@RaspberryPiFoundation/scratch-gui` which is installed from [GitHub Packages](https://github.com/RaspberryPiFoundation/scratch-editor/pkgs/npm/scratch-gui). Complete the steps below, then run `yarn install`.
+
+Or skip installing scratch-frame dependencies run: `yarn workspaces focus @raspberrypifoundation/editor-ui`
 
 ### Set a personal access token
 
@@ -65,10 +67,14 @@ Open [http://localhost:3011](http://localhost:3011) to view the web component te
 The page will reload if you make edits.\
 You will also see any lint errors in the console.
 
+`yarn start:all` will also run with support for Scratch projects.
+
 ### `yarn test`
 
 Launches the test runner in interactive watch mode.\
 See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
+
+`yarn test:scratch-frame` will run the tests for the Scratch Frame project
 
 ### `yarn build`
 
@@ -79,6 +85,8 @@ The build is minified and the filenames include the hashes.\
 Your app is ready to be deployed!
 
 See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
+
+`yarn build:all` will also build support for Scratch projects
 
 ## Linting
 

--- a/apps/scratch-frame/README.md
+++ b/apps/scratch-frame/README.md
@@ -1,1 +1,52 @@
-# scratch-frame
+# Scratch Frame
+
+Scratch Frame is a wrapper for the Scratch Editor, allowing more control over Scratch dependencies and isolation from the containing page.
+
+## Commands
+
+- Run: `yarn start`
+- Build: `yarn build`
+- Test: `yarn test`
+
+The Vite dev server runs on port `3014`.
+
+
+## Iframe Parameters
+
+| Parameter | Required | Description |
+| --- | --- | --- |
+| `project_id` | Yes | Scratch project identifier to load. |
+| `api_url` | Yes | Base URL for project and asset requests. |
+| `parent_origin` | No | Origin to receive iframe messages. Defaults to the iframe origin. |
+| `scratchMetadata` | Yes | Required to allow Scratch to send customer headers with API requests |
+
+## Messages
+
+Scratch Frame uses messages to communicate with it's containing page.
+
+### Received from the containing page
+
+| Type | Payload | Action |
+| --- | --- | --- |
+| `scratch-gui-set-token` | `nonce`, `accessToken`, `requiresAuth` | Completes the startup handshake and mounts Scratch. |
+| `scratch-gui-update-token` | `accessToken` | Updates the API authorization token. |
+| `scratch-gui-download` | `filename` | Saves the current project as an `.sb3` file. |
+| `scratch-gui-upload` | `file` | Loads a Scratch project from the supplied file. |
+| `scratch-gui-save` | - | Triggers a manual save. |
+| `scratch-gui-remix` | - | Triggers a remix. |
+
+### Sent to the containing page
+
+| Type | Payload | When |
+| --- | --- | --- |
+| `scratch-gui-ready` | `nonce` | Repeated until the container replies with `scratch-gui-set-token`. |
+| `scratch-gui-project-changed` | - | The Scratch VM project changes, including after upload. |
+| `scratch-gui-project-run-started` | - | The Scratch project starts running. |
+| `scratch-gui-project-id-updated` | `projectId` | Scratch creates or updates a project id. |
+| `scratch-gui-saving-started` | - | Save starts. |
+| `scratch-gui-saving-succeeded` | - | Save succeeds. |
+| `scratch-gui-saving-failed` | - | Save fails. |
+| `scratch-gui-remixing-started` | - | Remix starts. |
+| `scratch-gui-remixing-succeeded` | - | Remix succeeds. |
+| `scratch-gui-remixing-failed` | - | Remix fails. |
+

--- a/docs/linking-scratch-editor.md
+++ b/docs/linking-scratch-editor.md
@@ -28,10 +28,10 @@ Development/
 
 ## Temporary changes in editor-ui
 
-**1. `package.json`** — replace the GitHub Packages dependency with a file link (the name must match the package in scratch-editor):
+**1. `apps/scratch-frame/package.json`** — replace the GitHub Packages dependency with a file link (the name must match the package in scratch-editor):
 
 ```json
-"@RaspberryPiFoundation/scratch-gui": "file:../scratch-editor/packages/scratch-gui"
+"@RaspberryPiFoundation/scratch-gui": "file:../../../scratch-editor/packages/scratch-gui"
 ```
 
 **2. `docker-compose.yml`** — mount the scratch-editor repo into the container (read-only):
@@ -81,8 +81,6 @@ The container runs `yarn install` then `yarn start` on each start. The first sta
 
 ## Verify in the browser
 
-Scratch runs in an iframe served from editor-ui (port **3011**), not from the main web-component bundle alone.
-
 - Web component test page: open a **Scratch** sample, e.g.
   `http://localhost:3011/web-component.html`
   then choose **cool-scratch**.
@@ -90,7 +88,7 @@ Scratch runs in an iframe served from editor-ui (port **3011**), not from the ma
 
 ## Revert when finished
 
-1. Restore the GitHub Packages pin in `package.json`, for example:
+1. Restore the GitHub Packages pin in `apps/scratch-frame/package.json`, for example:
 
    ```json
    "@RaspberryPiFoundation/scratch-gui": "13.7.3-code-classroom.20260522151700"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.34.27",
   "private": true,
   "dependencies": {
-    "@RaspberryPiFoundation/scratch-gui": "13.7.3-code-classroom.20260522151700",
     "@babel/core": "^7.17.10",
     "@codemirror/commands": "^6.1.1",
     "@codemirror/lang-css": "^6.0.0",
@@ -66,8 +65,6 @@
     "react-toastify": "^11.1.0",
     "redux": "^4.2.1",
     "redux-oidc": "^4.0.0-beta1",
-    "scratchReactDomVendor": "npm:react-dom@18.3.1",
-    "scratchReactVendor": "npm:react@18.3.1",
     "scratchblocks": "^3.7.0",
     "skulpt": "^1.2.0",
     "stream-browserify": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4171,7 +4171,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@raspberrypifoundation/editor-ui@workspace:."
   dependencies:
-    "@RaspberryPiFoundation/scratch-gui": "npm:13.7.3-code-classroom.20260522151700"
     "@babel/core": "npm:^7.17.10"
     "@codemirror/commands": "npm:^6.1.1"
     "@codemirror/lang-css": "npm:^6.0.0"
@@ -4286,8 +4285,6 @@ __metadata:
     resolve-url-loader: "npm:^3.1.2"
     sass: "npm:^1.51.0"
     sass-loader: "npm:^16.0.8"
-    scratchReactDomVendor: "npm:react-dom@18.3.1"
-    scratchReactVendor: "npm:react@18.3.1"
     scratchblocks: "npm:^3.7.0"
     skulpt: "npm:^1.2.0"
     stream-browserify: "npm:^3.0.0"
@@ -18536,7 +18533,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dom@npm:18.3.1, scratchReactDomVendor@npm:react-dom@18.3.1":
+"react-dom@npm:18.3.1":
   version: 18.3.1
   resolution: "react-dom@npm:18.3.1"
   dependencies:
@@ -18945,7 +18942,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react@npm:18.3.1, scratchReactVendor@npm:react@18.3.1":
+"react@npm:18.3.1":
   version: 18.3.1
   resolution: "react@npm:18.3.1"
   dependencies:


### PR DESCRIPTION
Improve documentation around new Scratch Frame project 

Follow on from: https://github.com/RaspberryPiFoundation/editor-ui/pull/1518
Related to: https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1533


I also removed a dependency that is no longer required in the root project. See commits for more.