### PR TITLE
Update brackground colour from teal to code classroom

### DIFF
--- a/apps/scratch-frame/src/stylesheets/Scratch.scss
+++ b/apps/scratch-frame/src/stylesheets/Scratch.scss
@@ -2,15 +2,15 @@
 
 :root {
   --rpf-black: hsl(0deg 0% 0% / 15%);
+  --rpf-off-white-warm: hsl(36deg 38.5% 97.5% / 100%);
   --rpf-white: hsl(0deg 0% 100% / 100%);
-  --rpf-teal-100: hsl(176deg 55% 94% / 100%);
 }
 
 html,
 body,
 #app {
   block-size: 100%;
-  background-color: var(--rpf-teal-100);
+  background-color: var(--rpf-off-white-warm);
 }
 
 body {
@@ -31,11 +31,11 @@ div[class^="stage-selector_stage-selector_"] {
 }
 
 div[class^="gui_stage-and-target-wrapper_"] {
-  background-color: var(--rpf-teal-100);
+  background-color: var(--rpf-off-white-warm);
 }
 
 div[class^="gui_body-wrapper_"] {
-  background-color: var(--rpf-teal-100);
+  background-color: var(--rpf-off-white-warm);
 }
 
 div[class^="stage-header_stage-header-wrapper-overlay_"] {


### PR DESCRIPTION
Closing: https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1552

Before:
<img width="1481" height="677" alt="image" src="https://github.com/user-attachments/assets/1c262408-f08d-4111-bf93-36fd41c4cfc4" />

After:
<img width="1503" height="686" alt="image" src="https://github.com/user-attachments/assets/121baa42-6774-4d9a-afd5-dbd0dbdf8e81" />
