### PR TITLE
Interim fixes for modal input and buttons

### DIFF
--- a/src/assets/stylesheets/Modal.scss
+++ b/src/assets/stylesheets/Modal.scss
@@ -149,7 +149,7 @@
       color: inherit;
 
       &:focus-visible {
-        border: 2px solid var(--rpf-input-active-border);
+        border: 2px solid var(--editor-color-text);
         outline: none;
       }
     }
@@ -179,7 +179,7 @@
       border: 2px solid $rpf-grey-100;
 
       &:focus-visible {
-        border: 2px solid var(--rpf-input-active-border);
+        border: 2px solid var(--editor-color-text);
         outline: none;
       }
     }

--- a/src/components/Modals/ErrorModal.jsx
+++ b/src/components/Modals/ErrorModal.jsx
@@ -4,7 +4,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { useTranslation } from "react-i18next";
 import PropTypes from "prop-types";
 
-import Button from "../Button/Button";
+import DesignSystemButton from "../DesignSystemButton/DesignSystemButton";
 import { closeErrorModal, setError } from "../../redux/EditorSlice";
 import "../../assets/stylesheets/Modal.scss";
 
@@ -56,10 +56,11 @@ const ErrorModal = ({ errorType, additionalOnClose }) => {
         )}
 
         <div className="modal-content__buttons">
-          <Button
-            className="btn--primary"
-            buttonText={t("modal.close")}
-            onClickHandler={closeModal}
+          <DesignSystemButton
+            key="close"
+            type="primary"
+            text={t("modal.close")}
+            onClick={closeModal}
           />
         </div>
       </Modal>

--- a/src/components/Modals/NewFileModal.jsx
+++ b/src/components/Modals/NewFileModal.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 
-import Button from "../Button/Button";
+import DesignSystemButton from "../DesignSystemButton/DesignSystemButton";
 import {
   addProjectComponent,
   closeNewFileModal,
@@ -58,17 +58,17 @@ const NewFileModal = () => {
       ]}
       defaultCallback={createComponent}
       buttons={[
-        <Button
+        <DesignSystemButton
           key="create"
-          className="btn--primary"
-          buttonText={t("filePanel.newFileModal.addFile")}
-          onClickHandler={createComponent}
+          type="primary"
+          text={t("filePanel.newFileModal.addFile")}
+          onClick={createComponent}
         />,
-        <Button
+        <DesignSystemButton
           key="close"
-          className="btn--secondary"
-          buttonText={t("filePanel.newFileModal.cancel")}
-          onClickHandler={closeModal}
+          type="secondary"
+          text={t("filePanel.newFileModal.cancel")}
+          onClick={closeModal}
         />,
       ]}
     />

--- a/src/components/Modals/RenameFileModal.jsx
+++ b/src/components/Modals/RenameFileModal.jsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useTranslation } from "react-i18next";
 import { validateFileName } from "../../utils/componentNameValidation";
-import Button from "../Button/Button";
+import DesignSystemButton from "../DesignSystemButton/DesignSystemButton";
 import {
   closeRenameFileModal,
   updateComponentName,
@@ -74,17 +74,17 @@ const RenameFileModal = () => {
       ]}
       defaultCallback={renameComponent}
       buttons={[
-        <Button
+        <DesignSystemButton
           key="rename"
-          className="btn--primary"
-          buttonText={t("filePanel.renameFileModal.save")}
-          onClickHandler={renameComponent}
+          type="primary"
+          text={t("filePanel.renameFileModal.save")}
+          onClick={renameComponent}
         />,
-        <Button
+        <DesignSystemButton
           key="close"
-          className="btn--secondary"
-          buttonText={t("filePanel.renameFileModal.cancel")}
-          onClickHandler={closeModal}
+          type="secondary"
+          text={t("filePanel.renameFileModal.cancel")}
+          onClick={closeModal}
         />,
       ]}
     />


### PR DESCRIPTION
Part of https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1561

### Notes
- For both fixes, we also need [this editor-standalone fix](https://github.com/RaspberryPiFoundation/editor-standalone/pull/993). 
- For the modal buttons, they are converted to DesignSystemButton. 
  - This restored the buttons; however, overriding the default DS button styling is not possible with current setup. 
  - Interim fix for the styling added to standalone Modal.
  - For proper fix, they will require portal-target fix which can be addressed partly or fully by [another issue](https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1566). 

### Screenshot
<img width="500" alt="Screenshot 2026-07-10 at 14 33 36" src="https://github.com/user-attachments/assets/036adaed-ee1c-4724-ba4b-8627f4b1b3be" />

<img width="500" alt="Screenshot 2026-07-10 at 13 51 10" src="https://github.com/user-attachments/assets/e6a9740d-0fd2-4ede-924d-00ac442a30ab" />

- Also fixes existing Modal secondary buttons in dark mode:
<img width="400" alt="Screenshot 2026-07-10 at 14 37 25" src="https://github.com/user-attachments/assets/7f97df9c-2d99-438f-9ba9-1a149af5c7eb" />

<img width="400" alt="Screenshot 2026-07-10 at 14 38 01" src="https://github.com/user-attachments/assets/a6c313e9-dd9c-4492-a059-766042fc2af1" />
