### PR TITLE
Fix variable name clashes

### DIFF
--- a/cypress/e2e/spec-wc-pyodide.cy.js
+++ b/cypress/e2e/spec-wc-pyodide.cy.js
@@ -253,6 +253,39 @@ print(text_out)
       "NameError: name 'math' is not defined",
     );
   });
+
+  it("clears a user-defined variable named 'name' between code runs", () => {
+    runCode("name = 'Jane'\nprint(name)");
+    getPythonConsoleOutput().should("contain", "Jane");
+    runCode("print(name)");
+    getErrorMessage().should(
+      "contain",
+      "NameError: name 'name' is not defined",
+    );
+  });
+
+  it("clears a user-defined variable named 'sys' between code runs", () => {
+    runCode("sys = 1\nprint(sys)");
+    getPythonConsoleOutput().should("contain", "1");
+    runCode("print(sys)");
+    getErrorMessage().should("contain", "NameError: name 'sys' is not defined");
+  });
+
+  it("does not silently reuse a stale 'name' variable in an input loop across runs", () => {
+    runCode(
+      'name = input("What is your name?")\nwhile name != "Jane":\n\tprint("Try again Jane")\n\tname = input("What is your name?")\nprint("Hello", name)',
+    );
+    getProgramInput().should("be.visible").type("Jane{enter}");
+    getPythonConsoleOutput().should("contain", "Hello Jane");
+
+    runCode(
+      'while name != "Jane":\n\tprint("Try again Jane")\n\tname = input("What is your name?")\nprint("Hello", name)',
+    );
+    getErrorMessage().should(
+      "contain",
+      "NameError: name 'name' is not defined",
+    );
+  });
 });
 
 describe("When friendly errors enabled with pyodide", () => {

--- a/cypress/e2e/spec-wc-pyodide.cy.js
+++ b/cypress/e2e/spec-wc-pyodide.cy.js
@@ -270,22 +270,6 @@ print(text_out)
     runCode("print(sys)");
     getErrorMessage().should("contain", "NameError: name 'sys' is not defined");
   });
-
-  it("does not silently reuse a stale 'name' variable in an input loop across runs", () => {
-    runCode(
-      'name = input("What is your name?")\nwhile name != "Jane":\n\tprint("Try again Jane")\n\tname = input("What is your name?")\nprint("Hello", name)',
-    );
-    getProgramInput().should("be.visible").type("Jane{enter}");
-    getPythonConsoleOutput().should("contain", "Hello Jane");
-
-    runCode(
-      'while name != "Jane":\n\tprint("Try again Jane")\n\tname = input("What is your name?")\nprint("Hello", name)',
-    );
-    getErrorMessage().should(
-      "contain",
-      "NameError: name 'name' is not defined",
-    );
-  });
 });
 
 describe("When friendly errors enabled with pyodide", () => {

--- a/src/PyodideWorker.js
+++ b/src/PyodideWorker.js
@@ -416,15 +416,15 @@ const PyodideWorker = () => {
   const clearPyodideData = async () => {
     postMessage({ method: "handleLoading" });
     await pyodide.runPythonAsync(`
-        import sys
-        for name in list(sys.modules):
-            module = sys.modules[name]
-            if hasattr(module, '__file__') and module.__file__ and module.__file__.startswith('/home/pyodide/'):
-                del sys.modules[name]
+      import sys
+      for _mod_name in list(sys.modules):
+          module = sys.modules[_mod_name]
+          if hasattr(module, '__file__') and module.__file__ and module.__file__.startswith('/home/pyodide/'):
+              del sys.modules[_mod_name]
 
-        for name in dir():
-            if not name.startswith('_') and not name=='basthon':
-                del globals()[name]
+      for _var_name in dir():
+          if not _var_name.startswith('_') and _var_name != 'basthon':
+              del globals()[_var_name]
       `);
     postMessage({ method: "handleLoaded", stdinBuffer, interruptBuffer });
   };

--- a/src/PyodideWorker.js
+++ b/src/PyodideWorker.js
@@ -416,15 +416,15 @@ const PyodideWorker = () => {
   const clearPyodideData = async () => {
     postMessage({ method: "handleLoading" });
     await pyodide.runPythonAsync(`
-      import sys
-      for _mod_name in list(sys.modules):
-          module = sys.modules[_mod_name]
-          if hasattr(module, '__file__') and module.__file__ and module.__file__.startswith('/home/pyodide/'):
-              del sys.modules[_mod_name]
+        import sys
+        for _mod_name in list(sys.modules):
+            module = sys.modules[_mod_name]
+            if hasattr(module, '__file__') and module.__file__ and module.__file__.startswith('/home/pyodide/'):
+                del sys.modules[_mod_name]
 
-      for _var_name in dir():
-          if not _var_name.startswith('_') and _var_name != 'basthon':
-              del globals()[_var_name]
+        for _var_name in dir():
+            if not _var_name.startswith('_') and _var_name != 'basthon':
+                del globals()[_var_name]
       `);
     postMessage({ method: "handleLoaded", stdinBuffer, interruptBuffer });
   };

--- a/src/components/Editor/Runners/PythonRunner/PyodideRunner/PyodideWorker.test.js
+++ b/src/components/Editor/Runners/PythonRunner/PyodideRunner/PyodideWorker.test.js
@@ -210,7 +210,7 @@ describe("PyodideWorker", () => {
     });
     await waitFor(() =>
       expect(pyodide.runPythonAsync).toHaveBeenCalledWith(
-        expect.stringContaining("del globals()[name]"),
+        expect.stringContaining("del globals()[_var_name]"),
       ),
     );
   });


### PR DESCRIPTION
Closes https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/499

- Turned out caching clearing was working fine, but there was variable name clash. 
- When printed out the variable `name` of the example code, it was assigned to `sys`, indicating it was getting mixed up with the global variable `name` used in the `runPythonAsync` . 

<img width="451" alt="Screenshot 2026-07-16 at 11 14 41" src="https://github.com/user-attachments/assets/e660546e-acea-4e05-aeef-157bb719cd0e" />

- Updated the variables and now it shows the expected error.

<img width="470" alt="Screenshot 2026-07-16 at 11 17 29" src="https://github.com/user-attachments/assets/69f40e5f-a2ca-44a0-a20b-b61d33559951" />
