### PR TITLE
Remove save_disabled setting

### DIFF
--- a/src/components/ProjectBar/ProjectBar.jsx
+++ b/src/components/ProjectBar/ProjectBar.jsx
@@ -19,7 +19,6 @@ const ProjectBar = ({ nameEditable = true }) => {
   const loading = useSelector((state) => state.editor.loading);
   const lastSavedTime = useSelector((state) => state.editor.lastSavedTime);
   const offlineEnabled = useSelector((state) => state.editor.offlineEnabled);
-  const saveDisabled = useSelector((state) => state.editor.saveDisabled);
   const projectOwner = isOwner(user, project);
   const readOnly = useSelector((state) => state.editor.readOnly);
   const isOnline = useIsOnline();
@@ -40,7 +39,7 @@ const ProjectBar = ({ nameEditable = true }) => {
             type="tertiary"
           />
         </div>
-        {!projectOwner && !readOnly && !saveDisabled && (
+        {!projectOwner && !readOnly && (
           <div className="project-bar__btn-wrapper">
             <SaveButton className="project-bar__btn btn--save" />
           </div>

--- a/src/components/ProjectBar/ProjectBar.test.js
+++ b/src/components/ProjectBar/ProjectBar.test.js
@@ -95,25 +95,6 @@ describe("When logged in and user owns project", () => {
   });
 });
 
-describe("When logged in and save is disabled", () => {
-  beforeEach(() => {
-    renderProjectBar({
-      editor: {
-        project: { ...project, user_id: "someone-else" },
-        saveDisabled: true,
-        lastSavedTime: new Date().getTime(),
-      },
-      auth: {
-        user,
-      },
-    });
-  });
-
-  test("Save button is not shown", () => {
-    expect(screen.queryByText("header.save")).not.toBeInTheDocument();
-  });
-});
-
 describe("When logged in and no project identifier", () => {
   const projectWithoutId = { ...project, identifier: null };
 

--- a/src/components/ProjectBar/ScratchProjectBar.jsx
+++ b/src/components/ProjectBar/ScratchProjectBar.jsx
@@ -30,9 +30,8 @@ const ScratchProjectBar = ({ nameEditable = true }) => {
   const saving = useSelector((state) => state.editor.saving);
   const lastSavedTime = useSelector((state) => state.editor.lastSavedTime);
   const canSave = Boolean(user && !readOnly);
-  const saveDisabled = useSelector((state) => state.editor.saveDisabled);
   const { saveScratchProject, shouldRemixOnSave } = useScratchSave({
-    enabled: canSave && !saveDisabled,
+    enabled: canSave,
   });
 
   const projectIdentifier = project?.identifier;
@@ -40,8 +39,7 @@ const ScratchProjectBar = ({ nameEditable = true }) => {
   const isScratchSaveFailed = saving === "failed";
   const isNewProject = !projectIdentifier;
   const canAutoSave = Boolean(projectIdentifier && !shouldRemixOnSave);
-  const showSaveButton =
-    canSave && (isNewProject || shouldRemixOnSave) && !saveDisabled;
+  const showSaveButton = canSave && (isNewProject || shouldRemixOnSave);
   const showSaveStatus =
     canSave && canAutoSave && Boolean(lastSavedTime) && !isScratchSaveFailed;
   const projectLastSavedTime = getProjectLastSavedTime(project?.updated_at);

--- a/src/components/ProjectBar/ScratchProjectBar.test.js
+++ b/src/components/ProjectBar/ScratchProjectBar.test.js
@@ -209,19 +209,6 @@ describe("When project is Scratch", () => {
       type: "scratch-gui-save",
     });
   });
-
-  test("does not show the manual Save button if save is disabled", () => {
-    renderSignedInScratchProjectBar({
-      project: { ...scratchProject, user_id: "someone-else" },
-      editor: {
-        saveDisabled: true,
-      },
-    });
-
-    expect(
-      screen.queryByRole("button", { name: "header.save" }),
-    ).not.toBeInTheDocument();
-  });
 });
 
 describe("Additional Scratch manual save states", () => {

--- a/src/components/SaveButton/SaveButton.jsx
+++ b/src/components/SaveButton/SaveButton.jsx
@@ -22,7 +22,6 @@ const SaveButton = ({ className, type, fill = false }) => {
   const user = useSelector((state) => state.auth.user);
   const project = useSelector((state) => state.editor.project);
   const offlineEnabled = useSelector((state) => state.editor.offlineEnabled);
-  const saveDisabled = useSelector((state) => state.editor.saveDisabled);
   const isOnline = useIsOnline();
 
   useEffect(() => {
@@ -41,8 +40,7 @@ const SaveButton = ({ className, type, fill = false }) => {
 
   const projectOwner = isOwner(user, project);
 
-  if (loading !== "success" || projectOwner || !buttonType || saveDisabled)
-    return null;
+  if (loading !== "success" || projectOwner || !buttonType) return null;
 
   if (offlineEnabled && !isOnline) {
     return <OfflineBadge className={className} />;

--- a/src/components/SaveButton/SaveButton.test.js
+++ b/src/components/SaveButton/SaveButton.test.js
@@ -74,41 +74,6 @@ describe("When project is loaded", () => {
       });
     });
 
-    describe("who doesn't own the project and save is disabled", () => {
-      beforeEach(() => {
-        const middlewares = [];
-        const mockStore = configureStore(middlewares);
-        const initialState = {
-          editor: {
-            loading: "success",
-            webComponent: true,
-            project: {
-              identifier: "hot-diggity-dog",
-              user_id: "some-other-user",
-            },
-            saveDisabled: true,
-          },
-          auth: {
-            user: {
-              profile: {
-                user: "some-dummy-user",
-              },
-            },
-          },
-        };
-        store = mockStore(initialState);
-        render(
-          <Provider store={store}>
-            <SaveButton />
-          </Provider>,
-        );
-      });
-
-      test("Does not render save button", () => {
-        expect(screen.queryByText("header.save")).not.toBeInTheDocument();
-      });
-    });
-
     describe("who does own the project", () => {
       beforeEach(() => {
         const middlewares = [];

--- a/src/containers/WebComponentLoader.jsx
+++ b/src/containers/WebComponentLoader.jsx
@@ -5,7 +5,6 @@ import {
   setSenseHatAlwaysEnabled,
   setOfflineEnabled,
   setFriendlyErrorsEnabled,
-  setSaveDisabled,
   setLoadRemixDisabled,
   setReactAppApiEndpoint,
   setScratchApiEndpoint,
@@ -73,7 +72,6 @@ const WebComponentLoader = (props) => {
     loadCache = true, // Always use cache unless explicitly disabled
     initialProject = null,
     offlineEnabled = false,
-    saveDisabled = false,
   } = props;
   const dispatch = useDispatch();
 
@@ -205,10 +203,6 @@ const WebComponentLoader = (props) => {
   useEffect(() => {
     dispatch(setOfflineEnabled(offlineEnabled));
   }, [offlineEnabled, dispatch]);
-
-  useEffect(() => {
-    dispatch(setSaveDisabled(saveDisabled));
-  }, [saveDisabled, dispatch]);
 
   useEffect(() => {
     // Create a script element to save the existing Prism object if there is one

--- a/src/redux/EditorSlice.js
+++ b/src/redux/EditorSlice.js
@@ -128,7 +128,6 @@ export const editorInitialState = {
   scratchIframeProjectIdentifier: null,
   friendlyErrorsEnabled: false,
   friendlyError: null,
-  saveDisabled: false,
 };
 
 const isScratchProject = (state) =>
@@ -300,9 +299,6 @@ const EditorSlice = createSlice({
     },
     setFriendlyError: (state, action) => {
       state.friendlyError = action.payload;
-    },
-    setSaveDisabled: (state, action) => {
-      state.saveDisabled = action.payload;
     },
     setLoadRemixDisabled: (state, action) => {
       state.loadRemixDisabled = action.payload;
@@ -535,7 +531,6 @@ export const {
   setSenseHatEnabled,
   setFriendlyErrorsEnabled,
   setLoadRemixDisabled,
-  setSaveDisabled,
   setReactAppApiEndpoint,
   setScratchApiEndpoint,
   stopCodeRun,

--- a/src/redux/EditorSlice.test.js
+++ b/src/redux/EditorSlice.test.js
@@ -23,7 +23,6 @@ import reducer, {
   scratchSaveFailed,
   setFriendlyErrorsEnabled,
   setFriendlyError,
-  setSaveDisabled,
 } from "./EditorSlice";
 
 const mockCreateRemix = jest.fn();
@@ -127,12 +126,6 @@ test("Action setOfflineEnabled correctly sets offlineEnabled", () => {
   expect(reducer(previousState, setOfflineEnabled(true))).toEqual(
     expectedState,
   );
-});
-
-test("Action setSaveDisabled sets saveDisabled", () => {
-  const previousState = { saveDisabled: false };
-  const expectedState = { saveDisabled: true };
-  expect(reducer(previousState, setSaveDisabled(true))).toEqual(expectedState);
 });
 
 test("Action addProjectComponent adds component to project with correct content", () => {

--- a/src/web-component.js
+++ b/src/web-component.js
@@ -81,7 +81,6 @@ class WebComponent extends HTMLElement {
       "load_cache",
       "offline_enabled",
       "friendly_errors_enabled",
-      "save_disabled",
     ];
   }
 
@@ -102,7 +101,6 @@ class WebComponent extends HTMLElement {
       "load_cache",
       "offline_enabled",
       "friendly_errors_enabled",
-      "save_disabled",
     ];
     const jsonAttrs = [
       "instructions",


### PR DESCRIPTION
Partially closing: https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/636

Removes the unused save_disabled setting.
The editor now uses the project ownership information from the API to decide whether to save the original project or offer a remix.

This is a change in the direction you had in mind i think @zetter-rpf 

Now the existing ownership and read_only states already describe every required behaviour:

  - Can update the original: API returns the user as the effective project owner. The editor autosaves and shows no Save/remix button.
  - Can only remix: The project belongs to someone else and is not read-only. The editor shows Save and creates a remix.
  - Cannot save or remix: The project is read_only, such as when an educator views Student Work. No Save button is shown.