### PR TITLE
chore: bump version to v0.34.33

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raspberrypifoundation/editor-ui",
-  "version": "0.34.31",
+  "version": "0.34.33",
   "private": true,
   "dependencies": {
     "@babel/core": "^7.17.10",


### PR DESCRIPTION
v0.34.31 was released under the tag v0.34.32, explaining th jump from 1 to 3