### PR TITLE
Fix Python runner freezing on continuous output

### DIFF
--- a/cypress/e2e/spec-wc-pyodide.cy.js
+++ b/cypress/e2e/spec-wc-pyodide.cy.js
@@ -56,6 +56,13 @@ describe("Running the code with pyodide", () => {
     getErrorMessage().should("contain", "Execution interrupted");
   });
 
+  it("interrupts code that continuously writes output", () => {
+    runCode("i = 0\nwhile True:\n\tprint(i)\n\ti += 1");
+    getPythonConsoleOutput().should("contain", "Output limit reached");
+    stopProject();
+    getErrorMessage().should("contain", "Execution interrupted");
+  });
+
   it("runs a simple program with an input", () => {
     runCode('name = input("What is your name?")\nprint("Hello", name)');
     getEditorShadow()

--- a/public/translations/en.json
+++ b/public/translations/en.json
@@ -166,6 +166,7 @@
     "errors": {
       "interrupted": "Execution interrupted"
     },
+    "limitReached": "Output limit reached. Further output is hidden, but your program is still running.",
     "newTab": "Preview in new tab",
     "preview": "preview",
     "senseHat": {

--- a/src/PyodideWorker.js
+++ b/src/PyodideWorker.js
@@ -2,6 +2,12 @@
 
 const PYODIDE_INDEX_URL =
   "https://editor-assets.raspberrypi.org/pyodide/0.26.2/";
+// Batch output and cap each run so the main thread remains responsive.
+const MIN_OUTPUT_FLUSH_INTERVAL_MS = 50;
+const MAX_OUTPUT_LINES = 10_000;
+const MAX_OUTPUT_CHARACTERS = 250_000;
+// Prompts bypass the output limit so input remains usable.
+const MAX_INPUT_PROMPT_CHARACTERS = 10_000;
 
 // Nest the PyodideWorker function inside a globalThis object so we control when its initialised.
 const PyodideWorker = () => {
@@ -36,6 +42,11 @@ const PyodideWorker = () => {
     );
   }
   let pyodide, pyodidePromise, stdinBuffer, interruptBuffer, stopped;
+  let outputBuffer = [];
+  let lastOutputFlushAt = 0;
+  let outputLineCount = 0;
+  let outputCharacterCount = 0;
+  let outputLimitReached = false;
 
   const onmessage = async ({ data }) => {
     pyodide = await pyodidePromise;
@@ -63,12 +74,14 @@ const PyodideWorker = () => {
 
   const runPython = async (python) => {
     stopped = false;
+    resetOutputState();
 
     try {
       await withSupportForPackages(python, async () => {
         await pyodide.runPython(python);
       });
     } catch (error) {
+      flushOutput();
       if (error instanceof pyodide.ffi.PythonError) {
         postMessage({ method: "handleError", ...parsePythonError(error) });
       } else {
@@ -83,9 +96,79 @@ const PyodideWorker = () => {
         });
       }
     } finally {
+      flushOutput();
       await clearPyodideData();
+      flushOutput();
       postMessage({ method: "handleRunComplete" });
     }
+  };
+
+  const resetOutputState = () => {
+    outputBuffer = [];
+    lastOutputFlushAt = 0;
+    outputLineCount = 0;
+    outputCharacterCount = 0;
+    outputLimitReached = false;
+  };
+
+  const bufferOutput = (stream, content) => {
+    if (outputLimitReached) {
+      return;
+    }
+
+    const text = String(content || " ");
+    const remainingCharacters = MAX_OUTPUT_CHARACTERS - outputCharacterCount;
+
+    if (outputLineCount >= MAX_OUTPUT_LINES || remainingCharacters <= 1) {
+      markOutputLimitReached();
+      return;
+    }
+
+    const visibleText = text.slice(0, remainingCharacters - 1);
+    const lastChunk = outputBuffer[outputBuffer.length - 1];
+
+    if (lastChunk?.stream === stream) {
+      lastChunk.lines.push(visibleText);
+    } else {
+      outputBuffer.push({ stream, lines: [visibleText] });
+    }
+
+    outputLineCount += 1;
+    outputCharacterCount += visibleText.length + 1;
+
+    if (visibleText.length < text.length) {
+      markOutputLimitReached();
+      return;
+    }
+
+    const now = Date.now();
+    if (now - lastOutputFlushAt >= MIN_OUTPUT_FLUSH_INTERVAL_MS) {
+      flushOutput(now);
+    }
+  };
+
+  const markOutputLimitReached = () => {
+    if (outputLimitReached) {
+      return;
+    }
+
+    outputLimitReached = true;
+    flushOutput();
+    postMessage({ method: "handleOutputLimit" });
+  };
+
+  const flushOutput = (now = Date.now()) => {
+    if (outputBuffer.length === 0) {
+      return;
+    }
+
+    const chunks = outputBuffer.map(({ stream, lines }) => ({
+      stream,
+      content: lines.join("\n"),
+    }));
+    outputBuffer = [];
+    lastOutputFlushAt = now;
+    postMessage({ method: "handleOutput", chunks });
   };
 
   const checkIfStopped = () => {
@@ -422,6 +505,17 @@ const PyodideWorker = () => {
         const mode = event.toJs().get("mode");
         postMessage({ method: "handleFileWrite", filename, content, mode });
       },
+      input_prompt: (prompt) => {
+        const content = String(prompt || " ").slice(
+          0,
+          MAX_INPUT_PROMPT_CHARACTERS,
+        );
+        flushOutput();
+        postMessage({
+          method: "handleOutput",
+          chunks: [{ stream: "stdout", content }],
+        });
+      },
       locals: () => pyodide.runPython("globals()"),
     },
   };
@@ -447,10 +541,8 @@ const PyodideWorker = () => {
 
     pyodidePromise = loadPyodide({
       indexURL: PYODIDE_INDEX_URL,
-      stdout: (content) =>
-        postMessage({ method: "handleOutput", stream: "stdout", content }),
-      stderr: (content) =>
-        postMessage({ method: "handleOutput", stream: "stderr", content }),
+      stdout: (content) => bufferOutput("stdout", content),
+      stderr: (content) => bufferOutput("stderr", content),
     });
 
     pyodide = await pyodidePromise;
@@ -458,10 +550,11 @@ const PyodideWorker = () => {
     pyodide.registerJsModule("basthon", fakeBasthonPackage);
 
     await pyodide.runPythonAsync(`
+    import basthon as __basthon
     __old_input__ = input
     def __patched_input__(prompt=False):
         if (prompt):
-            print(prompt)
+            __basthon.kernel.input_prompt(str(prompt))
         return __old_input__()
     __builtins__.input = __patched_input__
     `);
@@ -494,6 +587,8 @@ const PyodideWorker = () => {
 
   const readFromStdin = (bufferToWrite) => {
     const previousLength = stdinBuffer[0];
+    // Atomics.wait blocks worker timers, so make sure the prompt is visible.
+    flushOutput();
     postMessage({ method: "handleInput" });
 
     while (true) {

--- a/src/PyodideWorker.js
+++ b/src/PyodideWorker.js
@@ -2,8 +2,7 @@
 
 const PYODIDE_INDEX_URL =
   "https://editor-assets.raspberrypi.org/pyodide/0.26.2/";
-// Batch output and cap each run so the main thread remains responsive.
-const MIN_OUTPUT_FLUSH_INTERVAL_MS = 50;
+// Cap each run before its output reaches the main thread.
 const MAX_OUTPUT_LINES = 10_000;
 const MAX_OUTPUT_CHARACTERS = 250_000;
 // Prompts bypass the output limit so input remains usable.
@@ -42,8 +41,6 @@ const PyodideWorker = () => {
     );
   }
   let pyodide, pyodidePromise, stdinBuffer, interruptBuffer, stopped;
-  let outputBuffer = [];
-  let lastOutputFlushAt = 0;
   let outputLineCount = 0;
   let outputCharacterCount = 0;
   let outputLimitReached = false;
@@ -81,7 +78,6 @@ const PyodideWorker = () => {
         await pyodide.runPython(python);
       });
     } catch (error) {
-      flushOutput();
       if (error instanceof pyodide.ffi.PythonError) {
         postMessage({ method: "handleError", ...parsePythonError(error) });
       } else {
@@ -96,22 +92,18 @@ const PyodideWorker = () => {
         });
       }
     } finally {
-      flushOutput();
       await clearPyodideData();
-      flushOutput();
       postMessage({ method: "handleRunComplete" });
     }
   };
 
   const resetOutputState = () => {
-    outputBuffer = [];
-    lastOutputFlushAt = 0;
     outputLineCount = 0;
     outputCharacterCount = 0;
     outputLimitReached = false;
   };
 
-  const bufferOutput = (stream, content) => {
+  const sendOutput = (stream, content) => {
     if (outputLimitReached) {
       return;
     }
@@ -125,25 +117,15 @@ const PyodideWorker = () => {
     }
 
     const visibleText = text.slice(0, remainingCharacters - 1);
-    const lastChunk = outputBuffer[outputBuffer.length - 1];
-
-    if (lastChunk?.stream === stream) {
-      lastChunk.lines.push(visibleText);
-    } else {
-      outputBuffer.push({ stream, lines: [visibleText] });
-    }
-
     outputLineCount += 1;
     outputCharacterCount += visibleText.length + 1;
+    postMessage({
+      method: "handleOutput",
+      chunks: [{ stream, content: visibleText }],
+    });
 
     if (visibleText.length < text.length) {
       markOutputLimitReached();
-      return;
-    }
-
-    const now = Date.now();
-    if (now - lastOutputFlushAt >= MIN_OUTPUT_FLUSH_INTERVAL_MS) {
-      flushOutput(now);
     }
   };
 
@@ -153,22 +135,7 @@ const PyodideWorker = () => {
     }
 
     outputLimitReached = true;
-    flushOutput();
     postMessage({ method: "handleOutputLimit" });
-  };
-
-  const flushOutput = (now = Date.now()) => {
-    if (outputBuffer.length === 0) {
-      return;
-    }
-
-    const chunks = outputBuffer.map(({ stream, lines }) => ({
-      stream,
-      content: lines.join("\n"),
-    }));
-    outputBuffer = [];
-    lastOutputFlushAt = now;
-    postMessage({ method: "handleOutput", chunks });
   };
 
   const checkIfStopped = () => {
@@ -510,7 +477,6 @@ const PyodideWorker = () => {
           0,
           MAX_INPUT_PROMPT_CHARACTERS,
         );
-        flushOutput();
         postMessage({
           method: "handleOutput",
           chunks: [{ stream: "stdout", content }],
@@ -541,8 +507,8 @@ const PyodideWorker = () => {
 
     pyodidePromise = loadPyodide({
       indexURL: PYODIDE_INDEX_URL,
-      stdout: (content) => bufferOutput("stdout", content),
-      stderr: (content) => bufferOutput("stderr", content),
+      stdout: (content) => sendOutput("stdout", content),
+      stderr: (content) => sendOutput("stderr", content),
     });
 
     pyodide = await pyodidePromise;
@@ -587,8 +553,6 @@ const PyodideWorker = () => {
 
   const readFromStdin = (bufferToWrite) => {
     const previousLength = stdinBuffer[0];
-    // Atomics.wait blocks worker timers, so make sure the prompt is visible.
-    flushOutput();
     postMessage({ method: "handleInput" });
 
     while (true) {

--- a/src/components/Editor/Runners/PythonRunner/PyodideRunner/PyodideRunner.jsx
+++ b/src/components/Editor/Runners/PythonRunner/PyodideRunner/PyodideRunner.jsx
@@ -118,7 +118,22 @@ const PyodideRunner = ({
             handleInput();
             break;
           case "handleOutput":
-            handleOutput(data.stream, data.content);
+            handleOutput(
+              data.chunks || [
+                {
+                  stream: data.stream,
+                  content: data.content || " ",
+                },
+              ],
+            );
+            break;
+          case "handleOutputLimit":
+            handleOutput([
+              {
+                stream: "system",
+                content: t("output.limitReached"),
+              },
+            ]);
             break;
           case "handleError":
             handleError(
@@ -210,13 +225,19 @@ const PyodideRunner = ({
     }
   };
 
-  const handleOutput = (stream, content) => {
+  const handleOutput = (chunks) => {
     const node = output.current;
-    const div = document.createElement("span");
-    div.classList.add("pythonrunner-console-output-line");
-    div.classList.add(stream);
-    div.innerHTML = new Option(content || " ").innerHTML + "\n";
-    node.appendChild(div);
+    const fragment = document.createDocumentFragment();
+
+    chunks.forEach(({ stream, content }) => {
+      const span = document.createElement("span");
+      span.classList.add("pythonrunner-console-output-line");
+      span.classList.add(stream);
+      span.textContent = `${content}\n`;
+      fragment.appendChild(span);
+    });
+
+    node.appendChild(fragment);
     node.scrollTop = node.scrollHeight;
   };
 

--- a/src/components/Editor/Runners/PythonRunner/PyodideRunner/PyodideRunner.jsx
+++ b/src/components/Editor/Runners/PythonRunner/PyodideRunner/PyodideRunner.jsx
@@ -30,6 +30,8 @@ import OutputViewToggle from "../OutputViewToggle";
 import { SettingsContext } from "../../../../../utils/settings";
 import RunnerControls from "../../../../RunButton/RunnerControls";
 
+const OUTPUT_BATCH_WINDOW_MS = 50;
+
 const getWorkerURL = (url) => {
   const content = `
     /* global PyodideWorker */
@@ -67,6 +69,8 @@ const PyodideRunner = ({
   const codeRunTriggered = useSelector((s) => s.editor.codeRunTriggered);
   const codeRunStopped = useSelector((s) => s.editor.codeRunStopped);
   const output = useRef();
+  const queuedOutput = useRef([]);
+  const outputBatchTimeout = useRef(null);
   const dispatch = useDispatch();
   const { t, i18n } = useTranslation();
   const settings = useContext(SettingsContext);
@@ -115,20 +119,23 @@ const PyodideRunner = ({
             handleLoaded(data.stdinBuffer, data.interruptBuffer);
             break;
           case "handleInput":
+            flushQueuedOutput();
             handleInput();
             break;
           case "handleOutput":
-            handleOutput(
-              data.chunks || [
+            if (data.chunks) {
+              queueOutput(data.chunks);
+            } else {
+              appendOutput([
                 {
                   stream: data.stream,
                   content: data.content || " ",
                 },
-              ],
-            );
+              ]);
+            }
             break;
           case "handleOutputLimit":
-            handleOutput([
+            queueOutput([
               {
                 stream: "system",
                 content: t("output.limitReached"),
@@ -136,6 +143,7 @@ const PyodideRunner = ({
             ]);
             break;
           case "handleError":
+            flushQueuedOutput();
             handleError(
               data.file,
               data.line,
@@ -162,6 +170,7 @@ const PyodideRunner = ({
             handleSenseHatEvent(data.type);
             break;
           case "handleRunComplete":
+            flushQueuedOutput();
             handleRunComplete();
             break;
           default:
@@ -170,6 +179,8 @@ const PyodideRunner = ({
       };
     }
   }, [pyodideWorker, projectCode, openFiles, focussedFileIndex]);
+
+  useEffect(() => discardQueuedOutput, []);
 
   useEffect(() => {
     if (codeRunTriggered && active && output.current) {
@@ -225,7 +236,7 @@ const PyodideRunner = ({
     }
   };
 
-  const handleOutput = (chunks) => {
+  const appendOutput = (chunks) => {
     const node = output.current;
     const fragment = document.createDocumentFragment();
 
@@ -239,6 +250,55 @@ const PyodideRunner = ({
 
     node.appendChild(fragment);
     node.scrollTop = node.scrollHeight;
+  };
+
+  const queueOutput = (chunks) => {
+    chunks.forEach(({ stream, content }) => {
+      const lastChunk = queuedOutput.current[queuedOutput.current.length - 1];
+
+      if (lastChunk?.stream === stream) {
+        lastChunk.lines.push(content);
+      } else {
+        queuedOutput.current.push({ stream, lines: [content] });
+      }
+    });
+
+    if (outputBatchTimeout.current === null) {
+      outputBatchTimeout.current = window.setTimeout(
+        renderQueuedOutput,
+        OUTPUT_BATCH_WINDOW_MS,
+      );
+    }
+  };
+
+  const renderQueuedOutput = () => {
+    outputBatchTimeout.current = null;
+
+    if (queuedOutput.current.length === 0) {
+      return;
+    }
+
+    const chunks = queuedOutput.current.map(({ stream, lines }) => ({
+      stream,
+      content: lines.join("\n"),
+    }));
+    queuedOutput.current = [];
+    appendOutput(chunks);
+  };
+
+  const flushQueuedOutput = () => {
+    if (outputBatchTimeout.current !== null) {
+      window.clearTimeout(outputBatchTimeout.current);
+    }
+    renderQueuedOutput();
+  };
+
+  const discardQueuedOutput = () => {
+    if (outputBatchTimeout.current !== null) {
+      window.clearTimeout(outputBatchTimeout.current);
+    }
+    outputBatchTimeout.current = null;
+    queuedOutput.current = [];
   };
 
   const handleError = (file, line, mistake, type, info, rawTraceback) => {
@@ -347,6 +407,7 @@ const PyodideRunner = ({
 
   const handleRun = async () => {
     dispatch(beginCodeRun());
+    discardQueuedOutput();
     output.current.innerHTML = "";
     dispatch(setError(""));
     dispatch(setErrorDetails({}));

--- a/src/components/Editor/Runners/PythonRunner/PyodideRunner/PyodideRunner.test.js
+++ b/src/components/Editor/Runners/PythonRunner/PyodideRunner/PyodideRunner.test.js
@@ -300,6 +300,33 @@ describe("When output is received", () => {
   test("it displays the output", () => {
     expect(screen.queryByText("hello")).toBeInTheDocument();
   });
+
+  test("it displays batched output", () => {
+    const worker = PyodideWorker.getLastInstance();
+    worker.postMessageFromWorker({
+      method: "handleOutput",
+      chunks: [
+        { stream: "stdout", content: "first\nsecond" },
+        { stream: "stderr", content: "third" },
+      ],
+    });
+
+    const [stdoutOutput, stderrOutput] = [
+      ...document.querySelectorAll(".pythonrunner-console-output-line"),
+    ].slice(-2);
+    expect(stdoutOutput).toHaveClass("stdout");
+    expect(stdoutOutput).toHaveTextContent("first second");
+    expect(stderrOutput).toHaveClass("stderr");
+    expect(stderrOutput).toHaveTextContent("third");
+  });
+
+  test("it explains when further output is hidden", () => {
+    const worker = PyodideWorker.getLastInstance();
+    worker.postMessageFromWorker({ method: "handleOutputLimit" });
+
+    const message = screen.getByText("output.limitReached");
+    expect(message).toHaveClass("system");
+  });
 });
 
 describe("When a python run completes", () => {

--- a/src/components/Editor/Runners/PythonRunner/PyodideRunner/PyodideRunner.test.js
+++ b/src/components/Editor/Runners/PythonRunner/PyodideRunner/PyodideRunner.test.js
@@ -301,30 +301,32 @@ describe("When output is received", () => {
     expect(screen.queryByText("hello")).toBeInTheDocument();
   });
 
-  test("it displays batched output", () => {
+  test("it displays queued output while the program is still running", async () => {
     const worker = PyodideWorker.getLastInstance();
-    worker.postMessageFromWorker({
-      method: "handleOutput",
-      chunks: [
-        { stream: "stdout", content: "first\nsecond" },
-        { stream: "stderr", content: "third" },
-      ],
-    });
+    for (let i = 1; i <= 10; i += 1) {
+      worker.postMessageFromWorker({
+        method: "handleOutput",
+        chunks: [{ stream: "stdout", content: `Iteration ${i}` }],
+      });
+    }
 
-    const [stdoutOutput, stderrOutput] = [
+    await waitFor(() =>
+      expect(screen.queryByText(/Iteration 10/)).toBeInTheDocument(),
+    );
+    const outputs = [
       ...document.querySelectorAll(".pythonrunner-console-output-line"),
-    ].slice(-2);
-    expect(stdoutOutput).toHaveClass("stdout");
-    expect(stdoutOutput).toHaveTextContent("first second");
-    expect(stderrOutput).toHaveClass("stderr");
-    expect(stderrOutput).toHaveTextContent("third");
+    ];
+    const output = outputs[outputs.length - 1];
+    expect(output).toHaveClass("stdout");
+    expect(output).toHaveTextContent("Iteration 1");
+    expect(output).toHaveTextContent("Iteration 10");
   });
 
-  test("it explains when further output is hidden", () => {
+  test("it explains when further output is hidden", async () => {
     const worker = PyodideWorker.getLastInstance();
     worker.postMessageFromWorker({ method: "handleOutputLimit" });
 
-    const message = screen.getByText("output.limitReached");
+    const message = await screen.findByText("output.limitReached");
     expect(message).toHaveClass("system");
   });
 });

--- a/src/components/Editor/Runners/PythonRunner/PyodideRunner/PyodideWorker.test.js
+++ b/src/components/Editor/Runners/PythonRunner/PyodideRunner/PyodideWorker.test.js
@@ -1,4 +1,4 @@
-/* global globalThis */
+/* global globalThis, Atomics */
 
 import { waitFor } from "@testing-library/react";
 import { TextEncoder } from "util";
@@ -14,6 +14,20 @@ global.importScripts = jest.fn();
 global.TextEncoder = TextEncoder;
 global.pygal = {};
 global._internal_sense_hat = {};
+
+const OUTPUT_LINE_LIMIT = 10_000;
+const OUTPUT_CHARACTER_LIMIT = 250_000;
+
+const getPostedMessages = (method) =>
+  global.postMessage.mock.calls
+    .map(([message]) => message)
+    .filter((message) => message.method === method);
+
+const getPostedOutput = () =>
+  getPostedMessages("handleOutput")
+    .flatMap(({ chunks }) => chunks)
+    .map(({ content }) => content)
+    .join("\n");
 
 describe("PyodideWorker", () => {
   let worker;
@@ -39,6 +53,7 @@ describe("PyodideWorker", () => {
       micropip: {
         install: jest.fn().mockReturnValue({ catch: jest.fn() }),
       },
+      checkInterrupt: jest.fn(),
       pyimport: jest.fn(),
       registerJsModule: jest.fn(),
       runPython: jest.fn(),
@@ -49,6 +64,10 @@ describe("PyodideWorker", () => {
     global.loadPyodide = jest.fn().mockResolvedValue(pyodide);
     require("../../../../../PyodideWorker.js");
     worker = globalThis.PyodideWorker();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   test("it imports the pyodide script", () => {
@@ -96,7 +115,7 @@ describe("PyodideWorker", () => {
 
   test("it patches the input function", async () => {
     expect(pyodide.runPythonAsync).toHaveBeenCalledWith(
-      expect.stringMatching(/__builtins__.input = __patched_input__/),
+      expect.stringMatching(/__basthon\.kernel\.input_prompt\(str\(prompt\)\)/),
     );
   });
 
@@ -203,6 +222,129 @@ describe("PyodideWorker", () => {
     await waitFor(() => {
       expect(pyodide.runPython).toHaveBeenCalledWith("print('hello')");
     });
+  });
+
+  test("it sends fewer messages than lines produced in quick succession", async () => {
+    jest.spyOn(Date, "now").mockReturnValue(1000);
+    const { stdout } = global.loadPyodide.mock.calls[0][0];
+    pyodide.runPython.mockImplementation((python) => {
+      if (python === "print lots") {
+        stdout("0");
+        stdout("1");
+        stdout("2");
+      }
+    });
+    global.postMessage.mockClear();
+
+    worker.onmessage({
+      data: {
+        method: "runPython",
+        python: "print lots",
+      },
+    });
+
+    await waitFor(() =>
+      expect(global.postMessage).toHaveBeenCalledWith({
+        method: "handleRunComplete",
+      }),
+    );
+    const outputMessages = getPostedMessages("handleOutput");
+
+    expect(outputMessages.length).toBeGreaterThan(0);
+    expect(outputMessages.length).toBeLessThan(3);
+    expect(getPostedOutput()).toBe("0\n1\n2");
+  });
+
+  test("it limits the number of output lines sent to the UI", () => {
+    jest.spyOn(Date, "now").mockReturnValue(1000);
+    const { stdout } = global.loadPyodide.mock.calls[0][0];
+    global.postMessage.mockClear();
+
+    for (let i = 0; i <= OUTPUT_LINE_LIMIT; i += 1) {
+      stdout(String(i));
+    }
+
+    expect(getPostedOutput().split("\n")).toHaveLength(OUTPUT_LINE_LIMIT);
+    expect(getPostedMessages("handleOutputLimit")).toHaveLength(1);
+  });
+
+  test("it truncates a single output line at the character limit", () => {
+    const { stdout } = global.loadPyodide.mock.calls[0][0];
+    global.postMessage.mockClear();
+
+    stdout("x".repeat(OUTPUT_CHARACTER_LIMIT + 1));
+    stdout("not forwarded");
+
+    const output = getPostedOutput();
+    expect(`${output}\n`).toHaveLength(OUTPUT_CHARACTER_LIMIT);
+    expect(output).not.toContain("not forwarded");
+    expect(getPostedMessages("handleOutputLimit")).toHaveLength(1);
+  });
+
+  test("it resets an exhausted output limit when a run starts", async () => {
+    const { stdout } = global.loadPyodide.mock.calls[0][0];
+    stdout("x".repeat(OUTPUT_CHARACTER_LIMIT + 1));
+    pyodide.runPython.mockImplementation((python) => {
+      if (python === "next run") {
+        stdout("visible again");
+      }
+    });
+    global.postMessage.mockClear();
+
+    worker.onmessage({
+      data: {
+        method: "runPython",
+        python: "next run",
+      },
+    });
+
+    await waitFor(() =>
+      expect(global.postMessage).toHaveBeenCalledWith({
+        method: "handleRunComplete",
+      }),
+    );
+    expect(global.postMessage).toHaveBeenCalledWith({
+      method: "handleOutput",
+      chunks: [{ stream: "stdout", content: "visible again" }],
+    });
+  });
+
+  test("it shows input prompts after the output limit is reached", () => {
+    const { stdout } = global.loadPyodide.mock.calls[0][0];
+    const basthon = pyodide.registerJsModule.mock.calls.find(
+      ([name]) => name === "basthon",
+    )[1];
+    stdout("x".repeat(OUTPUT_CHARACTER_LIMIT + 1));
+    global.postMessage.mockClear();
+
+    basthon.kernel.input_prompt("What is your name?");
+
+    expect(global.postMessage).toHaveBeenCalledWith({
+      method: "handleOutput",
+      chunks: [{ stream: "stdout", content: "What is your name?" }],
+    });
+  });
+
+  test("it flushes buffered output before requesting input", async () => {
+    jest.spyOn(Date, "now").mockReturnValue(1);
+    jest.spyOn(Atomics, "wait").mockReturnValue("not-equal");
+    const { stdout } = global.loadPyodide.mock.calls[0][0];
+    await waitFor(() => expect(pyodide.setStdin).toHaveBeenCalled());
+    const { read } = pyodide.setStdin.mock.calls[0][0];
+    global.postMessage.mockClear();
+
+    stdout("before");
+    stdout("prompt");
+    read(new Uint8Array(1));
+
+    const messages = global.postMessage.mock.calls.map(([message]) => message);
+    expect(messages.slice(0, 2)).toEqual([
+      {
+        method: "handleOutput",
+        chunks: [{ stream: "stdout", content: "before\nprompt" }],
+      },
+      { method: "handleInput" },
+    ]);
   });
 
   test("it clears the pyodide variables after running the code", async () => {

--- a/src/components/Editor/Runners/PythonRunner/PyodideRunner/PyodideWorker.test.js
+++ b/src/components/Editor/Runners/PythonRunner/PyodideRunner/PyodideWorker.test.js
@@ -1,4 +1,4 @@
-/* global globalThis, Atomics */
+/* global globalThis */
 
 import { waitFor } from "@testing-library/react";
 import { TextEncoder } from "util";
@@ -53,7 +53,6 @@ describe("PyodideWorker", () => {
       micropip: {
         install: jest.fn().mockReturnValue({ catch: jest.fn() }),
       },
-      checkInterrupt: jest.fn(),
       pyimport: jest.fn(),
       registerJsModule: jest.fn(),
       runPython: jest.fn(),
@@ -64,10 +63,6 @@ describe("PyodideWorker", () => {
     global.loadPyodide = jest.fn().mockResolvedValue(pyodide);
     require("../../../../../PyodideWorker.js");
     worker = globalThis.PyodideWorker();
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
   });
 
   test("it imports the pyodide script", () => {
@@ -224,39 +219,20 @@ describe("PyodideWorker", () => {
     });
   });
 
-  test("it sends fewer messages than lines produced in quick succession", async () => {
-    jest.spyOn(Date, "now").mockReturnValue(1000);
+  test("it sends output without waiting for the run to finish", () => {
     const { stdout } = global.loadPyodide.mock.calls[0][0];
-    pyodide.runPython.mockImplementation((python) => {
-      if (python === "print lots") {
-        stdout("0");
-        stdout("1");
-        stdout("2");
-      }
-    });
     global.postMessage.mockClear();
 
-    worker.onmessage({
-      data: {
-        method: "runPython",
-        python: "print lots",
-      },
-    });
+    for (let i = 1; i <= 10; i += 1) {
+      stdout(`Iteration ${i}`);
+    }
 
-    await waitFor(() =>
-      expect(global.postMessage).toHaveBeenCalledWith({
-        method: "handleRunComplete",
-      }),
-    );
-    const outputMessages = getPostedMessages("handleOutput");
-
-    expect(outputMessages.length).toBeGreaterThan(0);
-    expect(outputMessages.length).toBeLessThan(3);
-    expect(getPostedOutput()).toBe("0\n1\n2");
+    expect(getPostedOutput()).toContain("Iteration 10");
+    expect(getPostedMessages("handleOutput")).toHaveLength(10);
+    expect(getPostedMessages("handleRunComplete")).toHaveLength(0);
   });
 
   test("it limits the number of output lines sent to the UI", () => {
-    jest.spyOn(Date, "now").mockReturnValue(1000);
     const { stdout } = global.loadPyodide.mock.calls[0][0];
     global.postMessage.mockClear();
 
@@ -323,28 +299,6 @@ describe("PyodideWorker", () => {
       method: "handleOutput",
       chunks: [{ stream: "stdout", content: "What is your name?" }],
     });
-  });
-
-  test("it flushes buffered output before requesting input", async () => {
-    jest.spyOn(Date, "now").mockReturnValue(1);
-    jest.spyOn(Atomics, "wait").mockReturnValue("not-equal");
-    const { stdout } = global.loadPyodide.mock.calls[0][0];
-    await waitFor(() => expect(pyodide.setStdin).toHaveBeenCalled());
-    const { read } = pyodide.setStdin.mock.calls[0][0];
-    global.postMessage.mockClear();
-
-    stdout("before");
-    stdout("prompt");
-    read(new Uint8Array(1));
-
-    const messages = global.postMessage.mock.calls.map(([message]) => message);
-    expect(messages.slice(0, 2)).toEqual([
-      {
-        method: "handleOutput",
-        chunks: [{ stream: "stdout", content: "before\nprompt" }],
-      },
-      { method: "handleInput" },
-    ]);
   });
 
   test("it clears the pyodide variables after running the code", async () => {


### PR DESCRIPTION
Closes: https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/533

## What does this PR change?

This PR keeps the Python editor responsive when a program prints a large amount of output.

Previously, every printed line was sent to the page separately. An infinite loop could overwhelm the browser and make the Stop button unresponsive.

The output is now sent in batches and displayed up to a limit of:

- 10,000 lines
- 250,000 characters

When the limit is reached, further output is hidden and the user sees this message:

> Output limit reached. Further output is hidden, but your program is still running.

The program continues running, so the user can still click Stop. The limit resets each time the program starts.