### PR TITLE
Serve web component source during development

### DIFF
--- a/public/web-component.js
+++ b/public/web-component.js
@@ -1,0 +1,4 @@
+// This is only used in development so the web component can be imported from other projects
+(() => {
+  import("/src/web-component.dev.js");
+})();

--- a/src/web-component.dev.js
+++ b/src/web-component.dev.js
@@ -1,0 +1,3 @@
+import "@vitejs/plugin-react/preamble";
+
+import("./web-component.jsx");


### PR DESCRIPTION
Related to #1526 

When we migrated to vite we forgot to add a `web-component.js` entry for development so you could run `yarn start` and import the output from another app (such as editor-standalone)

This change adds a development-only file that imports a Vite-transformed entry with the React refresh preamble. Production builds continue to emit the standalone IIFE.