### PR TITLE
Add ignoreErrors to Sentry

### DIFF
--- a/src/web-component.jsx
+++ b/src/web-component.jsx
@@ -22,7 +22,7 @@ Sentry.init({
   integrations: [Sentry.browserTracingIntegration()],
   environment: process.env.REACT_APP_SENTRY_ENV,
   tracesSampleRate: 0.1,
-  ignoreErros: [
+  ignoreErrors: [
     "ResizeObserver loop completed with undelivered notifications",
     "ResizeObserver loop limit exceeded",
   ],

--- a/src/web-component.jsx
+++ b/src/web-component.jsx
@@ -22,6 +22,10 @@ Sentry.init({
   integrations: [Sentry.browserTracingIntegration()],
   environment: process.env.REACT_APP_SENTRY_ENV,
   tracesSampleRate: 0.1,
+  ignoreErros: [
+    "ResizeObserver loop completed with undelivered notifications",
+    "ResizeObserver loop limit exceeded",
+  ],
 });
 
 class WebComponent extends HTMLElement {


### PR DESCRIPTION
Part of https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1660
<img width="948" height="233" alt="Screenshot 2026-07-30 at 13 34 19" src="https://github.com/user-attachments/assets/3e506f42-a937-4368-acfd-85de980fa839" />

<img width="1057" height="569" alt="Screenshot 2026-07-30 at 13 34 31" src="https://github.com/user-attachments/assets/7ad7962a-d8d4-4023-aed0-afe97a4e615f" />


- Initially thought it might have something to do with `src/hooks/useContainerMinWidth.js` which uses `ResizeObserver` within `useLayoutEffect`. 
  - However, this error predates this file's creation.  
  - Also, the stack trace was often useless/empty which seems to indicate it's not a real exception. 
- Turned out it's a native browser warning fired when nested ResizeObservers (CodeMirror, design-system-react's tooltip/dropdown positioning, the 3D canvas, resizable panels) react to each other's layout changes within one frame. So, not a real bug in our code.
- Sentry's default GlobalHandlers integration picks it up and reports it as an error even though there's nothing actionable to fix.
- So, Adding the errors (see screenshots) to ignoreErrors to suppress this frequent noise as was recommended by Sentry: https://sentry.io/answers/react-resizeobserver-loop-completed-with-undelivered-notifications/
- The same filter also to be added to editor-standalone Sentry client. 