### PR TITLE
fix: stop instructions preview lingering above edit/view tabs

### DIFF
--- a/src/components/Menus/Sidebar/InstructionsPanel/InstructionsPanel.jsx
+++ b/src/components/Menus/Sidebar/InstructionsPanel/InstructionsPanel.jsx
@@ -189,7 +189,7 @@ const InstructionsPanel = () => {
       <div className="project-instructions">
         {instructionsEditable ? (
           hasInstructions ? (
-            <div className="c-instruction-tabs">
+            <div className="c-instruction-tabs" key="instruction-tabs">
               <Tabs
                 onSelect={(index) => {
                   setInstructionsTab(index);
@@ -237,7 +237,11 @@ const InstructionsPanel = () => {
             </div>
           )
         ) : (
-          <div className="project-instructions__content" ref={stepContent} />
+          <div
+            className="project-instructions__content"
+            key="instruction-content"
+            ref={stepContent}
+          />
         )}
       </div>
       {showModal && (

--- a/src/components/Menus/Sidebar/InstructionsPanel/InstructionsPanel.test.js
+++ b/src/components/Menus/Sidebar/InstructionsPanel/InstructionsPanel.test.js
@@ -31,6 +31,39 @@ const fakeScratchblocksInit = (_locale, container) => {
   });
 };
 
+describe("When instructionsEditable changes from false to true", () => {
+  const buildStore = (instructionsEditable) =>
+    configureStore([])({
+      editor: {
+        project: { instructions: "# Title" },
+        instructionsEditable,
+      },
+      instructions: {
+        project: { steps: [{ content: "<h1>Rendered preview</h1>" }] },
+        quiz: {},
+        currentStepPosition: 0,
+      },
+    });
+
+  test("does not leave the rendered preview above the edit/view tabs", () => {
+    const { container, rerender } = render(
+      <Provider store={buildStore(false)}>
+        <InstructionsPanel />
+      </Provider>,
+    );
+
+    rerender(
+      <Provider store={buildStore(true)}>
+        <InstructionsPanel />
+      </Provider>,
+    );
+
+    const tabsWrapper = container.querySelector(".c-instruction-tabs");
+    expect(tabsWrapper).toBeInTheDocument();
+    expect(tabsWrapper.firstElementChild).toHaveClass("react-tabs");
+  });
+});
+
 describe("When instructionsEditable is true", () => {
   describe("When there are instructions", () => {
     let store;


### PR DESCRIPTION
> 🤖 Generated with AI (Claude Code)
> 👨‍💻 Reviewed and steered by @maxelkins

## Summary

- Educators saw a stray rendered copy of the instructions above the Edit/View tabs.
- On refresh the panel renders read-only instructions (injected via `innerHTML`) before the teacher role resolves, then swaps to the editable tabs.
- React reused the same `<div>` for both branches, leaving the injected markup stranded above the tabs.
- Keying the two branch divs forces a remount so the stale content is removed.

Fixes RaspberryPiFoundation/digital-editor-issues#1650

## Changes

- Add distinct `key` props to the read-only and editable-tabs branch divs so React remounts instead of reusing the node.
- Add a regression test covering the `instructionsEditable` false → true transition.

## Note on fix

- This is a minimal fix, it gives the two renders distinct identity without disturbing the Prism/scratchblocks pipeline that relies on imperative `innerHTML`.
- It does treat a symptom of a deeper problem: read-only (Projects site instructions) and editable instructions (Code Classroom) share one component, one `stepContent` ref, and one imperative `innerHTML` effect in the same JSX slot. That combination is what let React reuse the node.
- In the future though we may want two different components that are used in the instruction panel - `ReadOnlyInstructions` / `EditableInstructions`.

## Screenshots

_To be added._