### PR TITLE
Introduce Zizmore to audit Github actions

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -22,12 +22,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           persist-credentials: false
 
       - name: Cache dependencies
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
           cache: "yarn"

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Cache dependencies
         uses: actions/setup-node@v4

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -82,7 +82,7 @@ jobs:
       NPM_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1.2.0
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           persist-credentials: false
 
@@ -124,7 +124,7 @@ jobs:
       REACT_APP_SCRATCH_FRAME_URL: "http://localhost:3014"
     steps:
       - name: Checkout
-        uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1.2.0
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -22,12 +22,12 @@ jobs:
       NPM_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           persist-credentials: false
 
       - name: Check for SCSS changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@0e4a8c6effa4802afeda77dc8d303f8176d7dfad # v3.0.4
         id: changes
         with:
           filters: |
@@ -38,7 +38,7 @@ jobs:
               - 'package.json'
 
       - name: Cache dependencies
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
           cache: "yarn"
@@ -63,12 +63,12 @@ jobs:
       NPM_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1.2.0
         with:
           persist-credentials: false
 
       - name: Cache dependencies
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
           cache: "yarn"
@@ -105,12 +105,12 @@ jobs:
       REACT_APP_SCRATCH_FRAME_URL: "http://localhost:3014"
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1.2.0
         with:
           persist-credentials: false
 
       - name: Cache dependencies
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
           cache: "yarn"
@@ -125,7 +125,7 @@ jobs:
         run: yarn build:all
 
       - name: Cypress run
-        uses: cypress-io/github-action@v7
+        uses: cypress-io/github-action@fa4a118725a8f001170d49631ea89e5d66fee626 # v7.4.1
         with:
           install: false
           start: |
@@ -136,7 +136,7 @@ jobs:
           browser: chrome
 
       - name: Archive cypress artifacts
-        uses: actions/upload-artifact@v4.6.0
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         if: failure()
         with:
           name: cypress-artifacts

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Check for SCSS changes
         uses: dorny/paths-filter@v3
@@ -62,6 +64,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
+        with:
+          persist-credentials: false
 
       - name: Cache dependencies
         uses: actions/setup-node@v4
@@ -102,6 +106,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
+        with:
+          persist-credentials: false
 
       - name: Cache dependencies
         uses: actions/setup-node@v4

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -15,6 +15,25 @@ permissions:
   packages: read
 
 jobs:
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
+
+      - name: Run zizmor
+        run: uvx "zizmor@1.29.0" --format=github .
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   lint:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/close_stale_issues_and_prs.yml
+++ b/.github/workflows/close_stale_issues_and_prs.yml
@@ -13,7 +13,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10.4.0
         with:
           stale-issue-message: 'This issue is stale because it has been open for 90 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
           stale-pr-message: 'This PR is stale because it has been open for 30 days with no activity. Remove stale label or comment or this will be closed in 7 days.'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -124,6 +124,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Cache dependencies
         uses: actions/setup-node@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -123,12 +123,12 @@ jobs:
           [ -n "${{ needs.setup-environment.outputs.deploy_dir }}" ]
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           persist-credentials: false
 
       - name: Cache dependencies
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
           cache: "yarn"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,19 +92,25 @@ jobs:
       - id: setup-environment
         run: |
           safe_ref_name="${GITHUB_REF_NAME//[![:alnum:].]/_}"
-          deploy_dir=${{inputs.prefix}}/$safe_ref_name
-          public_url=${{inputs.base_url}}/$deploy_dir
-          assets_url=${{inputs.assets_url}}/$deploy_dir
-          html_renderer_url=${{inputs.html_renderer_url}}/$deploy_dir
+          deploy_dir=${INPUTS_PREFIX}/$safe_ref_name
+          public_url=${INPUTS_BASE_URL}/$deploy_dir
+          assets_url=${INPUTS_ASSETS_URL}/$deploy_dir
+          html_renderer_url=${INPUTS_HTML_RENDERER_URL}/$deploy_dir
           echo "deploy_dir=$deploy_dir" >> $GITHUB_OUTPUT
           echo "public_url=$public_url" >> $GITHUB_OUTPUT
           echo "assets_url=$assets_url" >> $GITHUB_OUTPUT
           echo "html_renderer_url=$html_renderer_url" >> $GITHUB_OUTPUT
-          if [ "${{inputs.react_app_base_url}}" = "unspecified" ] ; then
+          if [ "${INPUTS_REACT_APP_BASE_URL}" = "unspecified" ] ; then
             echo "react_app_base_url=$deploy_dir" >> $GITHUB_OUTPUT
           else
-            echo "react_app_base_url=${{inputs.react_app_base_url}}" >> $GITHUB_OUTPUT
+            echo "react_app_base_url=${INPUTS_REACT_APP_BASE_URL}" >> $GITHUB_OUTPUT
           fi
+        env:
+          INPUTS_PREFIX: ${{inputs.prefix}}
+          INPUTS_BASE_URL: ${{inputs.base_url}}
+          INPUTS_ASSETS_URL: ${{inputs.assets_url}}
+          INPUTS_HTML_RENDERER_URL: ${{inputs.html_renderer_url}}
+          INPUTS_REACT_APP_BASE_URL: ${{inputs.react_app_base_url}}
 
   build-deploy:
     runs-on: ubuntu-latest
@@ -119,8 +125,10 @@ jobs:
     steps:
       - name: Check deployment path
         run: |
-          echo "Deploying to '${{ needs.setup-environment.outputs.deploy_dir }}' -- job will fail if this is empty!"
-          [ -n "${{ needs.setup-environment.outputs.deploy_dir }}" ]
+          echo "Deploying to '${NEEDS_SETUP_ENVIRONMENT_OUTPUTS_DEPLOY_DIR}' -- job will fail if this is empty!"
+          [ -n "${NEEDS_SETUP_ENVIRONMENT_OUTPUTS_DEPLOY_DIR}" ]
+        env:
+          NEEDS_SETUP_ENVIRONMENT_OUTPUTS_DEPLOY_DIR: ${{ needs.setup-environment.outputs.deploy_dir }}
 
       - name: Checkout
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
@@ -160,12 +168,13 @@ jobs:
       - name: Deploy site to S3 bucket
         if: env.AWS_SECRET_ACCESS_KEY != ''
         run: |
-          aws s3 sync ./build/ s3://${{ secrets.AWS_S3_BUCKET }}/${{ needs.setup-environment.outputs.deploy_dir }} --endpoint ${{ secrets.AWS_ENDPOINT }} --progress-frequency 5
+          aws s3 sync ./build/ s3://${{ secrets.AWS_S3_BUCKET }}/${NEEDS_SETUP_ENVIRONMENT_OUTPUTS_DEPLOY_DIR} --endpoint ${{ secrets.AWS_ENDPOINT }} --progress-frequency 5
           aws s3 sync ./build/chunks/ s3://${{ secrets.AWS_S3_BUCKET }}/chunks/ --endpoint ${{ secrets.AWS_ENDPOINT }} --exclude "*" --include "fetch-worker*" --include "mediapipe/**" --progress-frequency 5
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: ${{ secrets.AWS_REGION }}
+          NEEDS_SETUP_ENVIRONMENT_OUTPUTS_DEPLOY_DIR: ${{ needs.setup-environment.outputs.deploy_dir }}
 
       - name: Update latest version file
         if: env.AWS_SECRET_ACCESS_KEY != '' && github.ref_type == 'tag'
@@ -176,11 +185,12 @@ jobs:
           fi
 
           # Use no-cache so latest_version is revalidated after tag deploys.
-          echo -n "${{ needs.setup-environment.outputs.deploy_dir }}" | aws s3 cp - s3://${{ secrets.AWS_S3_BUCKET }}/latest_version --endpoint ${{ secrets.AWS_ENDPOINT }} --content-type "text/plain" --cache-control "no-cache"
+          echo -n "${NEEDS_SETUP_ENVIRONMENT_OUTPUTS_DEPLOY_DIR}" | aws s3 cp - s3://${{ secrets.AWS_S3_BUCKET }}/latest_version --endpoint ${{ secrets.AWS_ENDPOINT }} --content-type "text/plain" --cache-control "no-cache"
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: ${{ secrets.AWS_REGION }}
+          NEEDS_SETUP_ENVIRONMENT_OUTPUTS_DEPLOY_DIR: ${{ needs.setup-environment.outputs.deploy_dir }}
 
       - name: Purge Cloudflare cache
         if: env.HAS_CLOUDFLARE_SECRETS == 'true'

--- a/.github/workflows/dispatch-learner-experience-e2e.yml
+++ b/.github/workflows/dispatch-learner-experience-e2e.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 1
           persist-credentials: false

--- a/.github/workflows/dispatch-learner-experience-e2e.yml
+++ b/.github/workflows/dispatch-learner-experience-e2e.yml
@@ -31,6 +31,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Trigger learner-experience integration tests
         env:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,33 +1,5 @@
-# Configuration for zizmor (https://docs.zizmor.sh/configuration/), a static
-# analysis tool for GitHub Actions workflows.
-#
-# This grandfathers in every offense zizmor reports against the workflows as
-# they existed on 2026-08-05, so that running zizmor going forward only
-# surfaces newly introduced issues rather than the pre-existing backlog.
-# Entries are `file:line` pairs pointing at each finding's primary location;
-# regenerate with `zizmor --format json-v1 .` after fixing/reviewing findings.
-#
-# `artipacked` has been fixed (persist-credentials: false added everywhere)
-# and removed from this list.
-#
-# `unpinned-uses` has been fixed (all `uses:` refs pinned to a commit SHA,
-# with the original tag kept as a trailing comment) and removed from this
-# list.
-#
-# `template-injection` has been fixed (`${{ }}` expressions moved out of
-# `run:` scripts into `env:` vars) and removed from this list.
-#
-# `cache-poisoning` and `secrets-inherit` have no zizmor autofix; they
-# remain ignored pending manual review.
 rules:
   cache-poisoning:
-    ignore:
-      - ci-cd.yml:41
-      - ci-cd.yml:71
-      - ci-cd.yml:113
+    disable: true
   secrets-inherit:
-    ignore:
-      - ci-cd.yml:148
-      - ci-cd.yml:167
-      - ci-cd.yml:178
-      - ci-cd.yml:185
+    disable: true

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,57 @@
+# Configuration for zizmor (https://docs.zizmor.sh/configuration/), a static
+# analysis tool for GitHub Actions workflows.
+#
+# This grandfathers in every offense zizmor reports against the workflows as
+# they existed on 2026-08-05, so that running zizmor going forward only
+# surfaces newly introduced issues rather than the pre-existing backlog.
+# Entries are `file:line` pairs pointing at each finding's primary location;
+# regenerate with `zizmor --format json-v1 .` after fixing/reviewing findings.
+rules:
+  artipacked:
+    ignore:
+      - bump-version.yml:24
+      - ci-cd.yml:24
+      - ci-cd.yml:63
+      - ci-cd.yml:103
+      - deploy.yml:125
+      - dispatch-learner-experience-e2e.yml:30
+  cache-poisoning:
+    ignore:
+      - ci-cd.yml:39
+      - ci-cd.yml:67
+      - ci-cd.yml:107
+  secrets-inherit:
+    ignore:
+      - ci-cd.yml:142
+      - ci-cd.yml:161
+      - ci-cd.yml:172
+      - ci-cd.yml:179
+  template-injection:
+    ignore:
+      - deploy.yml:95
+      - deploy.yml:96
+      - deploy.yml:97
+      - deploy.yml:98
+      - deploy.yml:103
+      - deploy.yml:106
+      - deploy.yml:122
+      - deploy.yml:123
+      - deploy.yml:161
+      - deploy.yml:177
+  unpinned-uses:
+    ignore:
+      - bump-version.yml:25
+      - bump-version.yml:28
+      - ci-cd.yml:25
+      - ci-cd.yml:28
+      - ci-cd.yml:39
+      - ci-cd.yml:64
+      - ci-cd.yml:67
+      - ci-cd.yml:104
+      - ci-cd.yml:107
+      - ci-cd.yml:122
+      - ci-cd.yml:133
+      - close_stale_issues_and_prs.yml:16
+      - deploy.yml:126
+      - deploy.yml:129
+      - dispatch-learner-experience-e2e.yml:31

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -9,6 +9,10 @@
 #
 # `artipacked` has been fixed (persist-credentials: false added everywhere)
 # and removed from this list.
+#
+# `unpinned-uses` has been fixed (all `uses:` refs pinned to a commit SHA,
+# with the original tag kept as a trailing comment) and removed from this
+# list.
 rules:
   cache-poisoning:
     ignore:
@@ -33,20 +37,3 @@ rules:
       - deploy.yml:123
       - deploy.yml:163
       - deploy.yml:179
-  unpinned-uses:
-    ignore:
-      - bump-version.yml:25
-      - bump-version.yml:30
-      - ci-cd.yml:25
-      - ci-cd.yml:30
-      - ci-cd.yml:41
-      - ci-cd.yml:66
-      - ci-cd.yml:71
-      - ci-cd.yml:108
-      - ci-cd.yml:113
-      - ci-cd.yml:128
-      - ci-cd.yml:139
-      - close_stale_issues_and_prs.yml:16
-      - deploy.yml:126
-      - deploy.yml:131
-      - dispatch-learner-experience-e2e.yml:31

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -6,26 +6,21 @@
 # surfaces newly introduced issues rather than the pre-existing backlog.
 # Entries are `file:line` pairs pointing at each finding's primary location;
 # regenerate with `zizmor --format json-v1 .` after fixing/reviewing findings.
+#
+# `artipacked` has been fixed (persist-credentials: false added everywhere)
+# and removed from this list.
 rules:
-  artipacked:
-    ignore:
-      - bump-version.yml:24
-      - ci-cd.yml:24
-      - ci-cd.yml:63
-      - ci-cd.yml:103
-      - deploy.yml:125
-      - dispatch-learner-experience-e2e.yml:30
   cache-poisoning:
     ignore:
-      - ci-cd.yml:39
-      - ci-cd.yml:67
-      - ci-cd.yml:107
+      - ci-cd.yml:41
+      - ci-cd.yml:71
+      - ci-cd.yml:113
   secrets-inherit:
     ignore:
-      - ci-cd.yml:142
-      - ci-cd.yml:161
-      - ci-cd.yml:172
-      - ci-cd.yml:179
+      - ci-cd.yml:148
+      - ci-cd.yml:167
+      - ci-cd.yml:178
+      - ci-cd.yml:185
   template-injection:
     ignore:
       - deploy.yml:95
@@ -36,22 +31,22 @@ rules:
       - deploy.yml:106
       - deploy.yml:122
       - deploy.yml:123
-      - deploy.yml:161
-      - deploy.yml:177
+      - deploy.yml:163
+      - deploy.yml:179
   unpinned-uses:
     ignore:
       - bump-version.yml:25
-      - bump-version.yml:28
+      - bump-version.yml:30
       - ci-cd.yml:25
-      - ci-cd.yml:28
-      - ci-cd.yml:39
-      - ci-cd.yml:64
-      - ci-cd.yml:67
-      - ci-cd.yml:104
-      - ci-cd.yml:107
-      - ci-cd.yml:122
-      - ci-cd.yml:133
+      - ci-cd.yml:30
+      - ci-cd.yml:41
+      - ci-cd.yml:66
+      - ci-cd.yml:71
+      - ci-cd.yml:108
+      - ci-cd.yml:113
+      - ci-cd.yml:128
+      - ci-cd.yml:139
       - close_stale_issues_and_prs.yml:16
       - deploy.yml:126
-      - deploy.yml:129
+      - deploy.yml:131
       - dispatch-learner-experience-e2e.yml:31

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -13,6 +13,12 @@
 # `unpinned-uses` has been fixed (all `uses:` refs pinned to a commit SHA,
 # with the original tag kept as a trailing comment) and removed from this
 # list.
+#
+# `template-injection` has been fixed (`${{ }}` expressions moved out of
+# `run:` scripts into `env:` vars) and removed from this list.
+#
+# `cache-poisoning` and `secrets-inherit` have no zizmor autofix; they
+# remain ignored pending manual review.
 rules:
   cache-poisoning:
     ignore:
@@ -25,15 +31,3 @@ rules:
       - ci-cd.yml:167
       - ci-cd.yml:178
       - ci-cd.yml:185
-  template-injection:
-    ignore:
-      - deploy.yml:95
-      - deploy.yml:96
-      - deploy.yml:97
-      - deploy.yml:98
-      - deploy.yml:103
-      - deploy.yml:106
-      - deploy.yml:122
-      - deploy.yml:123
-      - deploy.yml:163
-      - deploy.yml:179


### PR DESCRIPTION
Related to https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1695

This introduces Zizmore and autofixes many of the issues (see commits for more)

I've ignored the remaining issues that aren't autofixable. These are lower risk as we don't run actions automatically for untrusted users, but we could choose to fix them in the future.