### PR TITLE
Do not set usedLeds unless a LED is on

### DIFF
--- a/cypress/e2e/missionZero-wc.cy.js
+++ b/cypress/e2e/missionZero-wc.cy.js
@@ -105,6 +105,15 @@ it("confirms LEDs used when display set", () => {
   getResults().should("contain", '"usedLEDs":true');
 });
 
+it("doesn't show LEDs used when display is all set to 0", () => {
+  runCode(
+    "from sense_hat import SenseHat\nsense = SenseHat()\nsense.set_pixels([[0,0,0]] * 64)",
+  );
+
+  cy.scrollTo("bottom");
+  getResults().should("contain", '"usedLEDs":false');
+});
+
 it("picks up calls to input()", () => {
   runCode("name = input('What is your name?')\nprint('Hello', name)");
 

--- a/public/pyodide/shims/_internal_sense_hat.js
+++ b/public/pyodide/shims/_internal_sense_hat.js
@@ -82,7 +82,9 @@ const init = () => {
 
 // _fb_device specific methods
 const setpixel = (index, value) => {
-  _internal_sense_hat.config.mz_criteria.usedLEDs = true;
+  if (value.v.some(channel => channel.v !== 0)) {
+    _internal_sense_hat.config.mz_criteria.usedLEDs = true;
+  }
 
   const _index = _internal_sense_hat.toJs(index);
   const _value = _internal_sense_hat.toJs(value);
@@ -120,7 +122,8 @@ const setpixels = (indexes, values) => {
   const _indexes = _internal_sense_hat.toJs(indexes);
   const _values = _internal_sense_hat.toJs(values);
 
-  if (_indexes) {
+  // Set usedLeds = true only when there's at least one led on
+  if (_values.some(row => row.some(value => value !== 0))) {
     _internal_sense_hat.config.mz_criteria.usedLEDs = true;
   }
 

--- a/public/shims/sense_hat/_internal_sense_hat.js
+++ b/public/shims/sense_hat/_internal_sense_hat.js
@@ -34,7 +34,9 @@
 
   // _fb_device specific methods
   mod.setpixel = new Sk.builtin.func(function (index, value) {
-      Sk.sense_hat.mz_criteria.usedLEDs = true
+      if (value.v.some(channel => channel.v !== 0)) {
+        Sk.sense_hat.mz_criteria.usedLEDs = true
+      }
       var _index;
       var _value;
 
@@ -81,11 +83,14 @@
   });
 
   mod.setpixels = new Sk.builtin.func(function (indexes, values) {
-      if (Sk.ffi.remapToJs(indexes)) {
-        Sk.sense_hat.mz_criteria.usedLEDs = true
-      }
       _indexes = Sk.ffi.remapToJs(indexes);
       _values = Sk.ffi.remapToJs(values);
+
+      // Set usedLeds = true only when there's at least one led on
+      if (_values.some(row => row.some(value => value !== 0))) {
+        Sk.sense_hat.mz_criteria.usedLEDs = true;
+      }
+
       try {
           Sk.sense_hat.pixels = _values;
       } catch (e) {


### PR DESCRIPTION
## Context

In Astro Pi Mission Zero the participants write a program that needs to fulfil a number of criteria, one of which is using the LEDs on the SenseHAT.

If you use the [staging site](https://staging-missions.astro-pi.org/mz/code_submissions/new), the following program ticks the "Used LEDs" checkbox when it shouldn't.

```python
# Import the libraries
from sense_hat import SenseHat
from time import sleep

# Set up the Sense HAT
sense = SenseHat()
# Rotates & **redraws** with `set_pixels`
sense.set_rotation(270, True)
# LEDs are not being used, the "Used LEDs" checkbox should not be checked
```

<img width="2880" height="4074" alt="staging-missions astro-pi org_mz_code_submissions_new" src="https://github.com/user-attachments/assets/074b7eb4-d0c8-4083-b829-39dcb6642ff1" />


Both the `setpixels` and the `setpixel` functions were emmiting the usedLeds = true message, even when the values passed were zero on every colour channel (id est, a led on "OFF").

In general that wouldn't be much of a problem as it doesn't make sense to set a pixel to zero when it was already off. But the bug was manifest when calling `sense.set_rotation(270, True)` as this function was internally getting the values of the board and redrawing it by calling `setpixels` again. 
So for a board with all leds in OFF, just rotating it, would end up emmitting the usedLeds = True message.

---

This PR makes sure we don't set usedLeds = True on setpixel or setpixels unless there's at least one non-zero value.

Closes #1577 
