### PR TITLE
Add 1Password GitHub PAT instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,32 @@ What you do next depends on whether you use 1Password for local secrets (if you'
 <details>
 
 <summary>RPF employees - using 1Password</summary>
-todo
+
+3. Add the token to your employee 1Password as e.g. "Github token"
+
+4. Add the secret reference to the token in 1Password to your shell profile (e.g. `~/.zshrc`):
+
+   ```bash
+    export GITHUB_TOKEN="op://Employee/GitHub token/credential"  # You can get this from 1Password using the dropdown in the credential field -> "Copy secret reference"
+    export NPM_AUTH_TOKEN=$GITHUB_TOKEN
+   ```
+
+5. Confirm GitHub Packages is reachable from this directory:
+
+   ```bash
+   # "op run --" is needed to fetch the secret from 1Password. If this doesn't work, make sure you have 1Password CLI set up and linked to your desktop client.
+   op run -- yarn npm info @RaspberryPiFoundation/scratch-gui version
+   ```
+
+   You should see the version pinned in `package.json` (for example `13.7.3-code-classroom.20260522151700`), not an authentication error. If you see `unauthenticated` or `401`, run `source ~/.zshrc` again, check the token scopes and SSO authorisation.
+
+6. Then install dependencies:
+
+```bash
+# You will need to use "op run --" every time, but you can set up an alias to make it easier.
+op run -- yarn install
+```
+
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -12,10 +12,23 @@ Or skip installing scratch-frame dependencies run: `yarn workspaces focus @raspb
 
 ### Set a personal access token
 
-If you don't already have this set up you will need it to access deps in the RPF private registry
+If you don't already have this set up you will need it to access deps in the RPF private registry.
 
 1. On GitHub, create a **classic** personal access token: [Settings → Developer settings → Personal access tokens](https://github.com/settings/tokens). Enable **`read:packages`** and **`repo`**. For packages tied to private repositories, `read:packages` alone can cause `yarn install` to fail with `401`/`403`.
 2. If your organisation uses SAML SSO, open the token on GitHub and **Authorize** it for **RaspberryPiFoundation** (Configure SSO).
+
+What you do next depends on whether you use 1Password for local secrets (if you're an RPF employee, you do). 
+
+<details>
+
+<summary>RPF employees - using 1Password</summary>
+todo
+</details>
+
+<details>
+
+<summary>Others - using your shell profile</summary>
+
 3. Add the token to your shell profile (for example `~/.zshrc` on macOS):
 
    ```bash
@@ -23,7 +36,7 @@ If you don't already have this set up you will need it to access deps in the RPF
    export NPM_AUTH_TOKEN=$GITHUB_TOKEN
    ```
 
-   Replace `ghp_your_token_here` with your token.
+Replace `ghp_your_token_here` with your token.
 
 4. Load the profile in any terminal you are currently using for this project:
 
@@ -46,6 +59,8 @@ Then install dependencies:
 ```
 yarn install
 ```
+
+</details>
 
 ## Environment variables
 


### PR DESCRIPTION
Adds updated instructions for accessing the private NPM registry using a GitHub PAT.