### PR TITLE
Make it easier to work with instructions

### DIFF
--- a/src/components/Menus/Sidebar/InstructionsPanel/InstructionsPanel.jsx
+++ b/src/components/Menus/Sidebar/InstructionsPanel/InstructionsPanel.jsx
@@ -7,49 +7,21 @@ import { useDispatch, useSelector } from "react-redux";
 import { Tab, TabList, TabPanel, Tabs } from "react-tabs";
 import SidebarPanel from "../SidebarPanel";
 
-import { marked } from "marked";
-import Prism from "prismjs";
 import PlusIcon from "../../../../assets/icons/plus.svg";
 import demoInstructions from "../../../../assets/markdown/demoInstructions.md?raw";
 import "../../../../assets/stylesheets/Instructions.scss?inline";
-import { quizReadyEvent } from "../../../../events/WebComponentCustomEvents";
 import { setProjectInstructions } from "../../../../redux/EditorSlice";
 import {
   selectInstructionSteps,
   setCurrentStepPosition,
 } from "../../../../redux/InstructionsSlice";
 import populateMarkdownTemplate from "../../../../utils/populateMarkdownTemplate";
-import { scratchblocksInit } from "../../../../utils/scratchblocks";
 import DesignSystemButton from "../../../DesignSystemButton/DesignSystemButton";
 import RemoveInstructionsModal from "../../../Modals/RemoveInstructionsModal";
+import InstructionsStep from "./InstructionsStep/InstructionsStep";
 import ProgressBar from "./ProgressBar/ProgressBar";
 
-const markdownRenderer = new marked.Renderer();
-markdownRenderer.link = function (data) {
-  return `<a href="${data.href}" target="_blank" rel="noreferrer"
-    }">${data.text}</a>`;
-};
-marked.setOptions({ renderer: markdownRenderer });
-
 const InstructionsPanel = () => {
-  useEffect(() => {
-    // prism and prism plugin config
-    Prism.manual = true;
-    if (Prism.plugins.NormalizeWhitespace) {
-      Prism.plugins.NormalizeWhitespace.setDefaults({
-        "remove-indent": false,
-        "remove-initial-line-feed": true,
-        "left-trim": false,
-      });
-      Prism.hooks.add("before-sanity-check", function (env) {
-        if (!env.code) return;
-
-        // Remove multiple leading blank lines (empty or whitespace-only)
-        env.code = env.code.replace(/^(?:\s*\n)+/, "");
-      });
-    }
-  }, []);
-
   const [showModal, setShowModal] = useState(false);
   const instructionsEditable = useSelector(
     (state) => state.editor?.instructionsEditable,
@@ -62,10 +34,8 @@ const InstructionsPanel = () => {
     (state) => state.instructions.currentStepPosition,
   );
   const { t, i18n } = useTranslation();
-  const stepContent = useRef();
 
   const [isQuiz, setIsQuiz] = useState(false);
-  const [instructionsTab, setInstructionsTab] = useState(0);
 
   const quizCompleted = useMemo(() => {
     return quiz?.currentQuestion === quiz?.questionCount;
@@ -77,26 +47,10 @@ const InstructionsPanel = () => {
   const hasMultipleSteps = numberOfSteps > 1;
   const isScratchProject = project?.project_type === "code_editor_scratch";
 
-  const getStepHtml = (step) => {
-    if (step.content !== undefined) {
-      return step.content;
-    }
-    return marked.parse(step.markdown_content ?? "");
-  };
-
-  const applySyntaxHighlighting = (container) => {
-    const codeElements = container.querySelectorAll(
-      ".language-python, .language-html, .language-css, .language-javascript",
-    );
-
-    codeElements.forEach((element) => {
-      if (window.syntaxHighlight) {
-        window.syntaxHighlight.highlightElement(element);
-      } else {
-        Prism.highlightElement(element);
-      }
-    });
-  };
+  const isQuizStep = isQuiz && !quizCompleted;
+  const currentStep = isQuizStep
+    ? { content: quiz.questions[quiz.currentQuestion] }
+    : steps[currentStepPosition];
 
   useEffect(() => {
     const stepIsQuizAndHasQuestions = () => {
@@ -108,35 +62,6 @@ const InstructionsPanel = () => {
     };
     stepIsQuizAndHasQuestions() ? setIsQuiz(true) : setIsQuiz(false);
   }, [quiz, steps, currentStepPosition, quizCompleted]);
-
-  useEffect(() => {
-    const setStepContent = (html) => {
-      if (stepContent.current) {
-        stepContent.current?.parentElement.scrollTo({ top: 0 });
-        stepContent.current.innerHTML = html;
-        applySyntaxHighlighting(stepContent.current);
-        if (isScratchProject) {
-          scratchblocksInit(i18n.language, stepContent.current);
-        }
-      }
-    };
-    if (isQuiz && !quizCompleted) {
-      setStepContent(quiz.questions[quiz.currentQuestion]);
-      document.dispatchEvent(quizReadyEvent);
-    } else if (hasInstructions && steps[currentStepPosition]) {
-      setStepContent(getStepHtml(steps[currentStepPosition]));
-    }
-  }, [
-    hasInstructions,
-    steps,
-    currentStepPosition,
-    quiz,
-    quizCompleted,
-    isQuiz,
-    instructionsTab,
-    isScratchProject,
-    i18n.language,
-  ]);
 
   useEffect(() => {
     if (quizCompleted && isQuiz) {
@@ -206,11 +131,7 @@ const InstructionsPanel = () => {
         {instructionsEditable ? (
           hasInstructions ? (
             <div className="c-instruction-tabs" key="instruction-tabs">
-              <Tabs
-                onSelect={(index) => {
-                  setInstructionsTab(index);
-                }}
-              >
+              <Tabs>
                 <TabList>
                   <Tab>{t("instructionsPanel.edit")}</Tab>
                   <Tab>{t("instructionsPanel.view")}</Tab>
@@ -223,7 +144,13 @@ const InstructionsPanel = () => {
                   />
                 </TabPanel>
                 <TabPanel>
-                  <div className="project-instructions" ref={stepContent} />
+                  <InstructionsStep
+                    className="project-instructions"
+                    step={currentStep}
+                    isQuiz={isQuizStep}
+                    isScratchProject={isScratchProject}
+                    language={i18n.language}
+                  />
                 </TabPanel>
               </Tabs>
             </div>
@@ -253,10 +180,13 @@ const InstructionsPanel = () => {
             </div>
           )
         ) : (
-          <div
+          <InstructionsStep
             className="project-instructions__content"
             key="instruction-content"
-            ref={stepContent}
+            step={currentStep}
+            isQuiz={isQuizStep}
+            isScratchProject={isScratchProject}
+            language={i18n.language}
           />
         )}
       </div>

--- a/src/components/Menus/Sidebar/InstructionsPanel/InstructionsPanel.jsx
+++ b/src/components/Menus/Sidebar/InstructionsPanel/InstructionsPanel.jsx
@@ -14,7 +14,10 @@ import demoInstructions from "../../../../assets/markdown/demoInstructions.md?ra
 import "../../../../assets/stylesheets/Instructions.scss?inline";
 import { quizReadyEvent } from "../../../../events/WebComponentCustomEvents";
 import { setProjectInstructions } from "../../../../redux/EditorSlice";
-import { setCurrentStepPosition } from "../../../../redux/InstructionsSlice";
+import {
+  selectInstructionSteps,
+  setCurrentStepPosition,
+} from "../../../../redux/InstructionsSlice";
 import populateMarkdownTemplate from "../../../../utils/populateMarkdownTemplate";
 import { scratchblocksInit } from "../../../../utils/scratchblocks";
 import DesignSystemButton from "../../../DesignSystemButton/DesignSystemButton";
@@ -52,7 +55,7 @@ const InstructionsPanel = () => {
     (state) => state.editor?.instructionsEditable,
   );
   const project = useSelector((state) => state.editor?.project);
-  const steps = useSelector((state) => state.instructions.project?.steps);
+  const steps = useSelector(selectInstructionSteps);
   const quiz = useSelector((state) => state.instructions?.quiz);
   const dispatch = useDispatch();
   const currentStepPosition = useSelector(
@@ -68,9 +71,7 @@ const InstructionsPanel = () => {
     return quiz?.currentQuestion === quiz?.questionCount;
   }, [quiz]);
 
-  const numberOfSteps = useSelector(
-    (state) => state.instructions.project?.steps?.length || 0,
-  );
+  const numberOfSteps = steps?.length || 0;
 
   const hasInstructions = steps && steps.length > 0;
   const hasMultipleSteps = numberOfSteps > 1;

--- a/src/components/Menus/Sidebar/InstructionsPanel/InstructionsPanel.jsx
+++ b/src/components/Menus/Sidebar/InstructionsPanel/InstructionsPanel.jsx
@@ -76,6 +76,13 @@ const InstructionsPanel = () => {
   const hasMultipleSteps = numberOfSteps > 1;
   const isScratchProject = project?.project_type === "code_editor_scratch";
 
+  const getStepHtml = (step) => {
+    if (step.content !== undefined) {
+      return step.content;
+    }
+    return marked.parse(step.markdown_content ?? "");
+  };
+
   const applySyntaxHighlighting = (container) => {
     const codeElements = container.querySelectorAll(
       ".language-python, .language-html, .language-css, .language-javascript",
@@ -102,10 +109,10 @@ const InstructionsPanel = () => {
   }, [quiz, steps, currentStepPosition, quizCompleted]);
 
   useEffect(() => {
-    const setStepContent = (content) => {
+    const setStepContent = (html) => {
       if (stepContent.current) {
         stepContent.current?.parentElement.scrollTo({ top: 0 });
-        stepContent.current.innerHTML = marked.parse(content);
+        stepContent.current.innerHTML = html;
         applySyntaxHighlighting(stepContent.current);
         if (isScratchProject) {
           scratchblocksInit(i18n.language, stepContent.current);
@@ -116,7 +123,7 @@ const InstructionsPanel = () => {
       setStepContent(quiz.questions[quiz.currentQuestion]);
       document.dispatchEvent(quizReadyEvent);
     } else if (hasInstructions && steps[currentStepPosition]) {
-      setStepContent(steps[currentStepPosition].content);
+      setStepContent(getStepHtml(steps[currentStepPosition]));
     }
   }, [
     hasInstructions,

--- a/src/components/Menus/Sidebar/InstructionsPanel/InstructionsPanel.jsx
+++ b/src/components/Menus/Sidebar/InstructionsPanel/InstructionsPanel.jsx
@@ -7,6 +7,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { Tab, TabList, TabPanel, Tabs } from "react-tabs";
 import SidebarPanel from "../SidebarPanel";
 
+import { marked } from "marked";
 import Prism from "prismjs";
 import PlusIcon from "../../../../assets/icons/plus.svg";
 import demoInstructions from "../../../../assets/markdown/demoInstructions.md?raw";
@@ -19,6 +20,13 @@ import { scratchblocksInit } from "../../../../utils/scratchblocks";
 import DesignSystemButton from "../../../DesignSystemButton/DesignSystemButton";
 import RemoveInstructionsModal from "../../../Modals/RemoveInstructionsModal";
 import ProgressBar from "./ProgressBar/ProgressBar";
+
+const markdownRenderer = new marked.Renderer();
+markdownRenderer.link = function (data) {
+  return `<a href="${data.href}" target="_blank" rel="noreferrer"
+    }">${data.text}</a>`;
+};
+marked.setOptions({ renderer: markdownRenderer });
 
 const InstructionsPanel = () => {
   useEffect(() => {
@@ -97,7 +105,7 @@ const InstructionsPanel = () => {
     const setStepContent = (content) => {
       if (stepContent.current) {
         stepContent.current?.parentElement.scrollTo({ top: 0 });
-        stepContent.current.innerHTML = content;
+        stepContent.current.innerHTML = marked.parse(content);
         applySyntaxHighlighting(stepContent.current);
         if (isScratchProject) {
           scratchblocksInit(i18n.language, stepContent.current);

--- a/src/components/Menus/Sidebar/InstructionsPanel/InstructionsPanel.test.jsx
+++ b/src/components/Menus/Sidebar/InstructionsPanel/InstructionsPanel.test.jsx
@@ -308,7 +308,7 @@ describe("When instructions are not editable", () => {
     });
   });
 
-  describe("When step content is unconverted markdown", () => {
+  describe("When a step has markdown_content", () => {
     beforeEach(() => {
       renderWithProviders(<InstructionsPanel />, {
         preloadedState: {
@@ -318,7 +318,11 @@ describe("When instructions are not editable", () => {
           },
           instructions: {
             project: {
-              steps: [{ content: "# Title\n\n[Link](https://example.com)" }],
+              steps: [
+                {
+                  markdown_content: "# Title\n\n[Link](https://example.com)",
+                },
+              ],
             },
             quiz: {},
             currentStepPosition: 0,
@@ -338,6 +342,33 @@ describe("When instructions are not editable", () => {
       expect(link).toHaveAttribute("href", "https://example.com");
       expect(link).toHaveAttribute("target", "_blank");
       expect(link).toHaveAttribute("rel", "noreferrer");
+    });
+  });
+
+  describe("When a step has content", () => {
+    beforeEach(() => {
+      renderWithProviders(<InstructionsPanel />, {
+        preloadedState: {
+          editor: {
+            project: {},
+            instructionsEditable: false,
+          },
+          instructions: {
+            project: {
+              steps: [{ content: "# Title\n\n[Link](https://example.com)" }],
+            },
+            quiz: {},
+            currentStepPosition: 0,
+          },
+        },
+      });
+    });
+
+    test("Displays content as is, without markdown conversion", () => {
+      expect(
+        screen.queryByRole("heading", { level: 1, name: "Title" }),
+      ).not.toBeInTheDocument();
+      expect(screen.getByText("# Title", { exact: false })).toBeInTheDocument();
     });
   });
 

--- a/src/components/Menus/Sidebar/InstructionsPanel/InstructionsPanel.test.jsx
+++ b/src/components/Menus/Sidebar/InstructionsPanel/InstructionsPanel.test.jsx
@@ -285,129 +285,9 @@ describe("When instructions are not editable", () => {
       expect(screen.queryByRole("progressbar")).toBeInTheDocument();
     });
 
-    test("Applies syntax highlighting to python code", () => {
+    test("Applies syntax highlighting to step content", () => {
       const codeElement = document.getElementsByClassName("language-python")[0];
       expect(Prism.highlightElement).toHaveBeenCalledWith(codeElement);
-    });
-
-    test("Applies syntax highlighting to HTML code", () => {
-      const codeElement = document.getElementsByClassName("language-html")[0];
-      expect(Prism.highlightElement).toHaveBeenCalledWith(codeElement);
-    });
-
-    test("Applies syntax highlighting to CSS code", () => {
-      const codeElement = document.getElementsByClassName("language-css")[0];
-      expect(Prism.highlightElement).toHaveBeenCalledWith(codeElement);
-    });
-
-    test("Applies syntax highlighting to javascript code", () => {
-      const codeElement = document.getElementsByClassName(
-        "language-javascript",
-      )[0];
-      expect(Prism.highlightElement).toHaveBeenCalledWith(codeElement);
-    });
-  });
-
-  describe("When a step has markdown_content", () => {
-    beforeEach(() => {
-      renderWithProviders(<InstructionsPanel />, {
-        preloadedState: {
-          editor: {
-            project: {},
-            instructionsEditable: false,
-          },
-          instructions: {
-            project: {
-              steps: [
-                {
-                  markdown_content: "# Title\n\n[Link](https://example.com)",
-                },
-              ],
-            },
-            quiz: {},
-            currentStepPosition: 0,
-          },
-        },
-      });
-    });
-
-    test("Converts markdown headings to HTML", () => {
-      expect(
-        screen.getByRole("heading", { level: 1, name: "Title" }),
-      ).toBeInTheDocument();
-    });
-
-    test("Renders links to open in a new tab", () => {
-      const link = screen.getByRole("link", { name: "Link" });
-      expect(link).toHaveAttribute("href", "https://example.com");
-      expect(link).toHaveAttribute("target", "_blank");
-      expect(link).toHaveAttribute("rel", "noreferrer");
-    });
-  });
-
-  describe("When a step has content", () => {
-    beforeEach(() => {
-      renderWithProviders(<InstructionsPanel />, {
-        preloadedState: {
-          editor: {
-            project: {},
-            instructionsEditable: false,
-          },
-          instructions: {
-            project: {
-              steps: [{ content: "# Title\n\n[Link](https://example.com)" }],
-            },
-            quiz: {},
-            currentStepPosition: 0,
-          },
-        },
-      });
-    });
-
-    test("Displays content as is, without markdown conversion", () => {
-      expect(
-        screen.queryByRole("heading", { level: 1, name: "Title" }),
-      ).not.toBeInTheDocument();
-      expect(screen.getByText("# Title", { exact: false })).toBeInTheDocument();
-    });
-  });
-
-  describe("When window.syntaxHighlight is defined", () => {
-    beforeEach(() => {
-      window.syntaxHighlight = {
-        highlightElement: jest.fn(),
-      };
-      renderWithProviders(<InstructionsPanel />, {
-        preloadedState: {
-          editor: {
-            project: {},
-            instructionsEditable: false,
-          },
-          instructions: {
-            project: {
-              steps: [
-                {
-                  content:
-                    "<code class='language-python'>print('hello')</code>",
-                },
-              ],
-            },
-            quiz: {},
-            currentStepPosition: 0,
-          },
-        },
-      });
-    });
-
-    test("Applies syntax highlighting using window.syntaxHighlight", () => {
-      const codeElement = document.getElementsByClassName("language-python")[0];
-      expect(window.syntaxHighlight.highlightElement).toHaveBeenCalledWith(
-        codeElement,
-      );
-    });
-
-    afterEach(() => {
-      delete window.syntaxHighlight;
     });
   });
 
@@ -467,14 +347,6 @@ describe("When instructions are not editable", () => {
     test("Renders the scratch block as an svg", () => {
       renderAtStep(0);
       expect(screen.getByTestId("scratchblock")).toBeInTheDocument();
-    });
-
-    test("Initialises scratchblocks with the step content container", () => {
-      renderAtStep(0);
-      expect(scratchblocksInit).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.any(HTMLElement),
-      );
     });
 
     test("Re-renders scratch blocks when navigating to another step", () => {
@@ -553,19 +425,8 @@ describe("When instructions are not editable", () => {
       expect(screen.queryByText("Test quiz")).toBeInTheDocument();
     });
 
-    test("Scrolls instructions to the top", () => {
-      expect(window.HTMLElement.prototype.scrollTo).toHaveBeenCalledWith({
-        top: 0,
-      });
-    });
-
     test("Retains the progress bar", () => {
       expect(screen.queryByRole("progressbar")).toBeInTheDocument();
-    });
-
-    test("Applies syntax highlighting", () => {
-      const codeElement = document.getElementsByClassName("language-python")[0];
-      expect(Prism.highlightElement).toHaveBeenCalledWith(codeElement);
     });
 
     test("Fires a quizIsReady event", () => {

--- a/src/components/Menus/Sidebar/InstructionsPanel/InstructionsPanel.test.jsx
+++ b/src/components/Menus/Sidebar/InstructionsPanel/InstructionsPanel.test.jsx
@@ -308,6 +308,39 @@ describe("When instructions are not editable", () => {
     });
   });
 
+  describe("When step content is unconverted markdown", () => {
+    beforeEach(() => {
+      renderWithProviders(<InstructionsPanel />, {
+        preloadedState: {
+          editor: {
+            project: {},
+            instructionsEditable: false,
+          },
+          instructions: {
+            project: {
+              steps: [{ content: "# Title\n\n[Link](https://example.com)" }],
+            },
+            quiz: {},
+            currentStepPosition: 0,
+          },
+        },
+      });
+    });
+
+    test("Converts markdown headings to HTML", () => {
+      expect(
+        screen.getByRole("heading", { level: 1, name: "Title" }),
+      ).toBeInTheDocument();
+    });
+
+    test("Renders links to open in a new tab", () => {
+      const link = screen.getByRole("link", { name: "Link" });
+      expect(link).toHaveAttribute("href", "https://example.com");
+      expect(link).toHaveAttribute("target", "_blank");
+      expect(link).toHaveAttribute("rel", "noreferrer");
+    });
+  });
+
   describe("When window.syntaxHighlight is defined", () => {
     beforeEach(() => {
       window.syntaxHighlight = {

--- a/src/components/Menus/Sidebar/InstructionsPanel/InstructionsStep/InstructionsStep.jsx
+++ b/src/components/Menus/Sidebar/InstructionsPanel/InstructionsStep/InstructionsStep.jsx
@@ -1,0 +1,79 @@
+import React, { useEffect, useRef } from "react";
+import { marked } from "marked";
+import Prism from "prismjs";
+import { quizReadyEvent } from "../../../../../events/WebComponentCustomEvents";
+import { scratchblocksInit } from "../../../../../utils/scratchblocks";
+
+const markdownRenderer = new marked.Renderer();
+markdownRenderer.link = function (data) {
+  return `<a href="${data.href}" target="_blank" rel="noreferrer"
+    }">${data.text}</a>`;
+};
+marked.setOptions({ renderer: markdownRenderer });
+
+const getStepHtml = (step) => {
+  if (step.content !== undefined) {
+    return step.content;
+  }
+  return marked.parse(step.markdown_content ?? "");
+};
+
+const applySyntaxHighlighting = (container) => {
+  const codeElements = container.querySelectorAll(
+    ".language-python, .language-html, .language-css, .language-javascript",
+  );
+
+  codeElements.forEach((element) => {
+    if (window.syntaxHighlight) {
+      window.syntaxHighlight.highlightElement(element);
+    } else {
+      Prism.highlightElement(element);
+    }
+  });
+};
+
+const InstructionsStep = ({
+  className,
+  step,
+  isQuiz = false,
+  isScratchProject = false,
+  language,
+}) => {
+  const stepContent = useRef();
+
+  useEffect(() => {
+    Prism.manual = true;
+    if (Prism.plugins.NormalizeWhitespace) {
+      Prism.plugins.NormalizeWhitespace.setDefaults({
+        "remove-indent": false,
+        "remove-initial-line-feed": true,
+        "left-trim": false,
+      });
+      Prism.hooks.add("before-sanity-check", function (env) {
+        if (!env.code) return;
+
+        // Remove multiple leading blank lines (empty or whitespace-only)
+        env.code = env.code.replace(/^(?:\s*\n)+/, "");
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!stepContent.current || !step) return;
+
+    stepContent.current.parentElement?.scrollTo({ top: 0 });
+    stepContent.current.innerHTML = getStepHtml(step);
+    applySyntaxHighlighting(stepContent.current);
+
+    if (isScratchProject) {
+      scratchblocksInit(language, stepContent.current);
+    }
+    if (isQuiz) {
+      document.dispatchEvent(quizReadyEvent);
+    }
+  }, [step, isQuiz, isScratchProject, language]);
+
+  return <div className={className} ref={stepContent} />;
+};
+
+export default InstructionsStep;

--- a/src/components/Menus/Sidebar/InstructionsPanel/InstructionsStep/InstructionsStep.test.jsx
+++ b/src/components/Menus/Sidebar/InstructionsPanel/InstructionsStep/InstructionsStep.test.jsx
@@ -1,0 +1,139 @@
+import { render, screen } from "@testing-library/react";
+import Prism from "prismjs";
+import InstructionsStep from "./InstructionsStep";
+import { scratchblocksInit } from "../../../../../utils/scratchblocks";
+
+window.HTMLElement.prototype.scrollTo = vi.fn();
+vi.mock("../../../../../utils/scratchblocks", () => ({
+  scratchblocksInit: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.spyOn(Prism, "highlightElement").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("When the step has content", () => {
+  test("Renders it as-is, without markdown conversion", () => {
+    render(<InstructionsStep step={{ content: "<p># not a heading</p>" }} />);
+
+    expect(screen.getByText("# not a heading")).toBeInTheDocument();
+  });
+});
+
+describe("When the step has markdown_content", () => {
+  test("Converts markdown headings to HTML", () => {
+    render(<InstructionsStep step={{ markdown_content: "# Title" }} />);
+
+    expect(
+      screen.getByRole("heading", { level: 1, name: "Title" }),
+    ).toBeInTheDocument();
+  });
+
+  test("Renders links to open in a new tab", () => {
+    render(
+      <InstructionsStep
+        step={{ markdown_content: "[Link](https://example.com)" }}
+      />,
+    );
+
+    const link = screen.getByRole("link", { name: "Link" });
+    expect(link).toHaveAttribute("href", "https://example.com");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noreferrer");
+  });
+});
+
+describe("When there is no step", () => {
+  test("Renders without crashing", () => {
+    const { container } = render(<InstructionsStep step={undefined} />);
+
+    expect(container.firstChild).toBeEmptyDOMElement();
+  });
+});
+
+describe("Syntax highlighting", () => {
+  test("Applies syntax highlighting to code blocks", () => {
+    render(
+      <InstructionsStep
+        step={{ content: "<code class='language-python'>print(1)</code>" }}
+      />,
+    );
+
+    const codeElement = document.getElementsByClassName("language-python")[0];
+    expect(Prism.highlightElement).toHaveBeenCalledWith(codeElement);
+  });
+
+  test("Uses window.syntaxHighlight when defined", () => {
+    window.syntaxHighlight = { highlightElement: vi.fn() };
+
+    render(
+      <InstructionsStep
+        step={{ content: "<code class='language-python'>print(1)</code>" }}
+      />,
+    );
+
+    const codeElement = document.getElementsByClassName("language-python")[0];
+    expect(window.syntaxHighlight.highlightElement).toHaveBeenCalledWith(
+      codeElement,
+    );
+
+    delete window.syntaxHighlight;
+  });
+});
+
+describe("When isScratchProject is true", () => {
+  test("Initialises scratchblocks with the step content and language", () => {
+    render(
+      <InstructionsStep
+        step={{ content: "<p>step</p>" }}
+        isScratchProject={true}
+        language="en"
+      />,
+    );
+
+    expect(scratchblocksInit).toHaveBeenCalledWith(
+      "en",
+      expect.any(HTMLElement),
+    );
+  });
+});
+
+describe("When isScratchProject is false", () => {
+  test("Does not initialise scratchblocks", () => {
+    render(<InstructionsStep step={{ content: "<p>step</p>" }} />);
+
+    expect(scratchblocksInit).not.toHaveBeenCalled();
+  });
+});
+
+describe("When isQuiz is true", () => {
+  test("Dispatches a quizReady event", () => {
+    const quizReadyHandler = vi.fn();
+    document.addEventListener("editor-quizReady", quizReadyHandler);
+
+    render(
+      <InstructionsStep step={{ content: "<p>quiz</p>" }} isQuiz={true} />,
+    );
+
+    expect(quizReadyHandler).toHaveBeenCalled();
+
+    document.removeEventListener("editor-quizReady", quizReadyHandler);
+  });
+});
+
+describe("When isQuiz is false", () => {
+  test("Does not dispatch a quizReady event", () => {
+    const quizReadyHandler = vi.fn();
+    document.addEventListener("editor-quizReady", quizReadyHandler);
+
+    render(<InstructionsStep step={{ content: "<p>step</p>" }} />);
+
+    expect(quizReadyHandler).not.toHaveBeenCalled();
+
+    document.removeEventListener("editor-quizReady", quizReadyHandler);
+  });
+});

--- a/src/components/Menus/Sidebar/InstructionsPanel/ProgressBar/ProgressBar.jsx
+++ b/src/components/Menus/Sidebar/InstructionsPanel/ProgressBar/ProgressBar.jsx
@@ -1,6 +1,9 @@
 import React from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { setCurrentStepPosition } from "../../../../../redux/InstructionsSlice";
+import {
+  selectInstructionSteps,
+  setCurrentStepPosition,
+} from "../../../../../redux/InstructionsSlice";
 import ChevronLeft from "../../../../../assets/icons/chevron_left.svg";
 import ChevronRight from "../../../../../assets/icons/chevron_right.svg";
 import Button from "../../../../Button/Button";
@@ -10,7 +13,7 @@ import { useTranslation } from "react-i18next";
 
 const ProgressBar = ({ panelRef }) => {
   const numberOfSteps = useSelector(
-    (state) => state.instructions.project.steps.length,
+    (state) => selectInstructionSteps(state).length,
   );
   const currentStepPosition = useSelector(
     (state) => state.instructions.currentStepPosition,

--- a/src/components/Menus/Sidebar/InstructionsPanel/ProgressBar/ProgressBar.test.jsx
+++ b/src/components/Menus/Sidebar/InstructionsPanel/ProgressBar/ProgressBar.test.jsx
@@ -17,6 +17,7 @@ const renderProgressBarOnStep = (
   }));
 
   const initialState = {
+    editor: { project: {} },
     instructions: {
       project: {
         steps,

--- a/src/components/Menus/Sidebar/Sidebar.jsx
+++ b/src/components/Menus/Sidebar/Sidebar.jsx
@@ -27,6 +27,7 @@ import SidebarPanel from "./SidebarPanel";
 import PluginSlot from "./PluginSlot";
 import MaterialSymbol from "./MaterialSymbol";
 import { setSidebarOption } from "../../../redux/EditorSlice";
+import { selectInstructionSteps } from "../../../redux/InstructionsSlice";
 
 const resolvePluginIcon = (icon) => {
   if (typeof icon === "string") {
@@ -85,9 +86,7 @@ const Sidebar = ({
   const dispatch = useDispatch();
   const projectType = useSelector((state) => state.editor.project.project_type);
   const projectImages = useSelector((state) => state.editor.project.image_list);
-  const instructionsSteps = useSelector(
-    (state) => state.instructions?.project?.steps,
-  );
+  const instructionsSteps = useSelector(selectInstructionSteps);
   const instructionsEditable = useSelector(
     (state) => state.editor.instructionsEditable,
   );

--- a/src/components/Menus/Sidebar/Sidebar.test.jsx
+++ b/src/components/Menus/Sidebar/Sidebar.test.jsx
@@ -270,6 +270,37 @@ describe("When the project has instructions", () => {
   });
 });
 
+describe("When the project instructions are a markdown string", () => {
+  beforeEach(() => {
+    const mockStore = configureStore([]);
+    const initialState = {
+      editor: {
+        project: {
+          components: [],
+          image_list: [],
+          instructions: "# Some instructions",
+        },
+      },
+      instructions: {
+        permitOverride: true,
+        project: {},
+      },
+    };
+    const store = mockStore(initialState);
+    render(
+      <Provider store={store}>
+        <div id="app">
+          <Sidebar options={options} />
+        </div>
+      </Provider>,
+    );
+  });
+
+  test("Shows instructions icon", () => {
+    expect(screen.queryByTitle("sidebar.instructions")).toBeInTheDocument();
+  });
+});
+
 describe("When the project has no instructions", () => {
   describe("When instructions are not editable", () => {
     beforeEach(() => {

--- a/src/components/WebComponentProject/WebComponentProject.jsx
+++ b/src/components/WebComponentProject/WebComponentProject.jsx
@@ -15,7 +15,6 @@ import {
   setIsOutputOnly,
   setInstructionsEditable,
 } from "../../redux/EditorSlice";
-import { setInstructions } from "../../redux/InstructionsSlice";
 import { MOBILE_MEDIA_QUERY } from "../../utils/mediaQueryBreakpoints";
 import {
   codeChangedEvent,
@@ -69,14 +68,8 @@ const WebComponentProject = ({
     (state) => state.editor.project.components,
   );
   const readOnly = useSelector((state) => state.editor.readOnly);
-  const projectInstructions = useSelector(
-    (state) => state.editor.project.instructions,
-  );
   const currentStepPosition = useSelector(
     (state) => state.instructions.currentStepPosition,
-  );
-  const permitInstructionsOverride = useSelector(
-    (state) => state.instructions.permitOverride,
   );
   const isMobile = useMediaQuery({ query: MOBILE_MEDIA_QUERY });
   const dispatch = useDispatch();
@@ -124,28 +117,6 @@ const WebComponentProject = ({
       document.dispatchEvent(projectIdentifierChangedEvent(projectIdentifier));
     }
   }, [projectIdentifier]);
-
-  useEffect(() => {
-    if (!permitInstructionsOverride) return;
-
-    dispatch(
-      setInstructions({
-        project: {
-          steps:
-            typeof projectInstructions === "string"
-              ? [
-                  {
-                    quiz: false,
-                    title: "",
-                    markdown_content: projectInstructions,
-                  },
-                ]
-              : projectInstructions || [],
-        },
-        permitOverride: true,
-      }),
-    );
-  }, [dispatch, projectInstructions, permitInstructionsOverride]);
 
   useEffect(() => {
     syncRunEventTrackingProject(projectIdentifier, codeRunTriggered);

--- a/src/components/WebComponentProject/WebComponentProject.jsx
+++ b/src/components/WebComponentProject/WebComponentProject.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useRef } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useMediaQuery } from "react-responsive";
-import { marked } from "marked";
 
 import "../../assets/stylesheets/Project.scss?inline";
 import "../../assets/stylesheets/EmbeddedViewer.scss?inline";
@@ -81,7 +80,6 @@ const WebComponentProject = ({
   );
   const isMobile = useMediaQuery({ query: MOBILE_MEDIA_QUERY });
   const dispatch = useDispatch();
-  const renderer = new marked.Renderer();
 
   const buildRunCompletedPayloadRef = useRef(() => ({}));
   buildRunCompletedPayloadRef.current = () => {
@@ -127,15 +125,6 @@ const WebComponentProject = ({
     }
   }, [projectIdentifier]);
 
-  renderer.link = function (data) {
-    return `<a href="${data.href}" target="_blank" rel="noreferrer"
-    }">${data.text}</a>`;
-  };
-
-  marked.setOptions({
-    renderer: renderer,
-  });
-
   useEffect(() => {
     if (!permitInstructionsOverride) return;
 
@@ -148,7 +137,7 @@ const WebComponentProject = ({
                   {
                     quiz: false,
                     title: "",
-                    content: marked.parse(projectInstructions),
+                    content: projectInstructions,
                   },
                 ]
               : projectInstructions || [],

--- a/src/components/WebComponentProject/WebComponentProject.jsx
+++ b/src/components/WebComponentProject/WebComponentProject.jsx
@@ -151,7 +151,7 @@ const WebComponentProject = ({
                     content: marked.parse(projectInstructions),
                   },
                 ]
-              : [],
+              : projectInstructions || [],
         },
         permitOverride: true,
       }),

--- a/src/components/WebComponentProject/WebComponentProject.jsx
+++ b/src/components/WebComponentProject/WebComponentProject.jsx
@@ -137,7 +137,7 @@ const WebComponentProject = ({
                   {
                     quiz: false,
                     title: "",
-                    content: projectInstructions,
+                    markdown_content: projectInstructions,
                   },
                 ]
               : projectInstructions || [],

--- a/src/components/WebComponentProject/WebComponentProject.test.jsx
+++ b/src/components/WebComponentProject/WebComponentProject.test.jsx
@@ -141,7 +141,7 @@ describe("When state set", () => {
               steps: [
                 {
                   title: "",
-                  content: "My amazing instructions",
+                  markdown_content: "My amazing instructions",
                   quiz: false,
                 },
               ],
@@ -178,9 +178,10 @@ describe("When there are instructions", () => {
       .getActions()
       .find((e) => e.type === "instructions/setInstructions");
 
-    const content = instructions.payload.project.steps[0].content;
+    const markdownContent =
+      instructions.payload.project.steps[0].markdown_content;
 
-    expect(content).toEqual("[Link](https://example.com)");
+    expect(markdownContent).toEqual("[Link](https://example.com)");
   });
 });
 
@@ -203,7 +204,7 @@ describe("When instructions are an empty string", () => {
               steps: [
                 {
                   title: "",
-                  content: "",
+                  markdown_content: "",
                   quiz: false,
                 },
               ],

--- a/src/components/WebComponentProject/WebComponentProject.test.jsx
+++ b/src/components/WebComponentProject/WebComponentProject.test.jsx
@@ -141,7 +141,7 @@ describe("When state set", () => {
               steps: [
                 {
                   title: "",
-                  content: "<p>My amazing instructions</p>\n",
+                  content: "My amazing instructions",
                   quiz: false,
                 },
               ],
@@ -173,16 +173,14 @@ describe("When there are instructions", () => {
     });
   });
 
-  test("Renders a tag with target _blank", () => {
+  test("Stores the unconverted markdown as instructions content", () => {
     const instructions = store
       .getActions()
       .find((e) => e.type === "instructions/setInstructions");
 
     const content = instructions.payload.project.steps[0].content;
 
-    expect(content).toEqual(
-      '<p><a href="https://example.com" target="_blank" rel="noreferrer"\n    }">Link</a></p>\n',
-    );
+    expect(content).toEqual("[Link](https://example.com)");
   });
 });
 

--- a/src/components/WebComponentProject/WebComponentProject.test.jsx
+++ b/src/components/WebComponentProject/WebComponentProject.test.jsx
@@ -35,9 +35,7 @@ let store;
 
 const renderWebComponentProject = ({
   projectType,
-  instructions,
   imageList = [],
-  permitOverride = true,
   loading,
   codeRunTriggered = false,
   codeHasBeenRun = false,
@@ -57,7 +55,6 @@ const renderWebComponentProject = ({
           { name: "main", extension: "py", content: "print('hello')" },
         ],
         image_list: imageList,
-        instructions,
       },
       loading,
       openFiles: [],
@@ -70,7 +67,7 @@ const renderWebComponentProject = ({
     },
     instructions: {
       currentStepPosition: 3,
-      permitOverride,
+      permitOverride: true,
     },
     auth: {},
   };
@@ -88,7 +85,6 @@ describe("When state set", () => {
     runStartedHandler.mockClear();
     renderWebComponentProject({
       projectType: "python",
-      instructions: "My amazing instructions",
       codeRunTriggered: true,
     });
     flushRunEventDebounce();
@@ -129,28 +125,6 @@ describe("When state set", () => {
   test("Defaults to not showing the projectbar", () => {
     expect(screen.queryByText("header.newProject")).not.toBeInTheDocument();
   });
-
-  test("Dispatches action to set instructions", () => {
-    expect(store.getActions()).toEqual(
-      expect.arrayContaining([
-        {
-          type: "instructions/setInstructions",
-          payload: {
-            permitOverride: true,
-            project: {
-              steps: [
-                {
-                  title: "",
-                  markdown_content: "My amazing instructions",
-                  quiz: false,
-                },
-              ],
-            },
-          },
-        },
-      ]),
-    );
-  });
 });
 
 describe("When project type is scratch", () => {
@@ -162,99 +136,6 @@ describe("When project type is scratch", () => {
 
   test("Renders a blank screen", () => {
     expect(screen.queryByText("output.textOutput")).not.toBeInTheDocument();
-  });
-});
-
-describe("When there are instructions", () => {
-  beforeEach(() => {
-    renderWebComponentProject({
-      instructions: "[Link](https://example.com)",
-      codeRunTriggered: true,
-    });
-  });
-
-  test("Stores the unconverted markdown as instructions content", () => {
-    const instructions = store
-      .getActions()
-      .find((e) => e.type === "instructions/setInstructions");
-
-    const markdownContent =
-      instructions.payload.project.steps[0].markdown_content;
-
-    expect(markdownContent).toEqual("[Link](https://example.com)");
-  });
-});
-
-describe("When instructions are an empty string", () => {
-  beforeEach(() => {
-    renderWebComponentProject({
-      instructions: "",
-      codeRunTriggered: true,
-    });
-  });
-
-  test("Dispatches action to set instructions", () => {
-    expect(store.getActions()).toEqual(
-      expect.arrayContaining([
-        {
-          type: "instructions/setInstructions",
-          payload: {
-            permitOverride: true,
-            project: {
-              steps: [
-                {
-                  title: "",
-                  markdown_content: "",
-                  quiz: false,
-                },
-              ],
-            },
-          },
-        },
-      ]),
-    );
-  });
-});
-
-describe("When there are no instructions", () => {
-  beforeEach(() => {
-    renderWebComponentProject({});
-  });
-
-  test("Does not dispatch action to set instructions", () => {
-    expect(store.getActions()).toEqual(
-      expect.arrayContaining([
-        {
-          type: "instructions/setInstructions",
-          payload: {
-            permitOverride: true,
-            project: {
-              steps: [],
-            },
-          },
-        },
-      ]),
-    );
-  });
-});
-
-describe("When overriding instructions is not permitted", () => {
-  beforeEach(() => {
-    renderWebComponentProject({
-      instructions: "My amazing instructions",
-      permitOverride: false,
-    });
-  });
-
-  test("Does not dispatch action to set instructions", () => {
-    expect(store.getActions()).not.toEqual(
-      expect.arrayContaining([
-        {
-          type: "instructions/setInstructions",
-          payload: expect.any(Object),
-        },
-      ]),
-    );
   });
 });
 

--- a/src/projects/cool-html.json
+++ b/src/projects/cool-html.json
@@ -4,10 +4,13 @@
   "locale": "en",
   "name": "Cool HTML: Spotlight Gradient",
   "user_id": null,
-  "instructions": {
-    "content": "## Cool HTML: Spotlight Gradient\n\nA tiny project with **one** cool trick: an animated gradient background with a mouse/touch **spotlight** that follows you.\n\n### Controls\n- Move cursor / drag: move the spotlight\n- Click: cycle color palettes\n\nFiles: `index.html`, `styles.css`, `script.js`\n",
-    "permitOverride": false
-  },
+  "instructions": [{
+    "content": "<h1>This is an example of instructions with html</h1> step 1"
+  }, {
+    "content": "step 2"
+  }, {
+    "content": "step 3"
+  }],
   "components": [
     {
       "id": "1c7ab1a8-5f09-4b3e-9d0d-6c8c2f2d2a8a",

--- a/src/projects/cool-python.json
+++ b/src/projects/cool-python.json
@@ -4,10 +4,7 @@
   "locale": "en",
   "name": "Cool Python: ASCII Orb",
   "user_id": null,
-  "instructions": {
-    "content": "## Cool Python: ASCII Orb\n\nA minimal project that prints a single shaded **ASCII orb** (a circle with simple lighting).\n\n### Try this\n- Change `WIDTH` / `HEIGHT` in `main.py`\n- Change the `light_dx` / `light_dy` values to move the highlight\n- Swap the `SHADES` string in `ascii_orb.py` to change the look\n\nFiles:\n- `main.py` (entry point)\n- `ascii_orb.py` (helper that renders the orb)\n",
-    "permitOverride": false
-  },
+  "instructions": "## Cool Python: ASCII Orb\n\nA minimal project that prints a single shaded **ASCII orb** (a circle with simple lighting).\n\n### Try this\n- Change `WIDTH` / `HEIGHT` in `main.py`\n- Change the `light_dx` / `light_dy` values to move the highlight\n- Swap the `SHADES` string in `ascii_orb.py` to change the look\n\nFiles:\n- `main.py` (entry point)\n- `ascii_orb.py` (helper that renders the orb)\n",
   "components": [
     {
       "id": "9b5a24a8-7d15-4a34-8a59-7b0a1f1b19b2",

--- a/src/projects/cool-scratch.json
+++ b/src/projects/cool-scratch.json
@@ -4,10 +4,7 @@
   "locale": "en",
   "name": "Sample Scratch Project",
   "user_id": null,
-  "instructions": {
-    "content": "instructions go here",
-    "permitOverride": false
-  },
+  "instructions": "instructions go here",
   "components": [],
   "image_list": [],
   "videos": [],

--- a/src/redux/InstructionsSlice.js
+++ b/src/redux/InstructionsSlice.js
@@ -1,4 +1,4 @@
-import { createSlice } from "@reduxjs/toolkit";
+import { createSelector, createSlice } from "@reduxjs/toolkit";
 import { reducers } from "./reducers/instructionsReducers";
 
 export const instructionsInitialState = {
@@ -16,3 +16,22 @@ const InstructionsSlice = createSlice({
 export const { setCurrentStepPosition, setInstructions } =
   InstructionsSlice.actions;
 export default InstructionsSlice.reducer;
+
+export const selectInstructionSteps = createSelector(
+  [
+    (state) => state.editor.project?.instructions,
+    (state) => state.instructions.permitOverride,
+    (state) => state.instructions.project?.steps,
+  ],
+  (projectInstructions, permitOverride, loadedSteps) => {
+    if (!permitOverride) {
+      return loadedSteps || [];
+    }
+    if (typeof projectInstructions === "string") {
+      return [
+        { quiz: false, title: "", markdown_content: projectInstructions },
+      ];
+    }
+    return projectInstructions || [];
+  },
+);

--- a/src/redux/InstructionsSlice.js
+++ b/src/redux/InstructionsSlice.js
@@ -19,9 +19,9 @@ export default InstructionsSlice.reducer;
 
 export const selectInstructionSteps = createSelector(
   [
-    (state) => state.editor.project?.instructions,
-    (state) => state.instructions.permitOverride,
-    (state) => state.instructions.project?.steps,
+    (state) => state.editor?.project?.instructions,
+    (state) => state.instructions?.permitOverride,
+    (state) => state.instructions?.project?.steps,
   ],
   (projectInstructions, permitOverride, loadedSteps) => {
     if (!permitOverride) {

--- a/src/redux/InstructionsSlice.test.js
+++ b/src/redux/InstructionsSlice.test.js
@@ -51,4 +51,10 @@ describe("selectInstructionSteps", () => {
 
     expect(selectInstructionSteps(state)).toEqual([]);
   });
+
+  test("Returns an empty array when the instructions slice is not present", () => {
+    const state = { editor: { project: {} } };
+
+    expect(selectInstructionSteps(state)).toEqual([]);
+  });
 });

--- a/src/redux/InstructionsSlice.test.js
+++ b/src/redux/InstructionsSlice.test.js
@@ -1,0 +1,54 @@
+import { selectInstructionSteps } from "./InstructionsSlice";
+
+describe("selectInstructionSteps", () => {
+  test("Wraps a markdown string project instructions into a single step", () => {
+    const state = {
+      editor: { project: { instructions: "# Title" } },
+      instructions: { permitOverride: true, project: { steps: [] } },
+    };
+
+    expect(selectInstructionSteps(state)).toEqual([
+      { quiz: false, title: "", markdown_content: "# Title" },
+    ]);
+  });
+
+  test("Uses an authored steps array from project instructions as-is", () => {
+    const steps = [{ quiz: false, title: "Step 1", content: "<p>Go</p>" }];
+    const state = {
+      editor: { project: { instructions: steps } },
+      instructions: { permitOverride: true, project: { steps: [] } },
+    };
+
+    expect(selectInstructionSteps(state)).toBe(steps);
+  });
+
+  test("Returns an empty array when there are no project instructions", () => {
+    const state = {
+      editor: { project: { instructions: undefined } },
+      instructions: { permitOverride: true, project: { steps: [] } },
+    };
+
+    expect(selectInstructionSteps(state)).toEqual([]);
+  });
+
+  test("Ignores project instructions when overriding is not permitted", () => {
+    const loadedSteps = [
+      { quiz: false, title: "Step 1", content: "<p>Loaded</p>" },
+    ];
+    const state = {
+      editor: { project: { instructions: "# Title" } },
+      instructions: { permitOverride: false, project: { steps: loadedSteps } },
+    };
+
+    expect(selectInstructionSteps(state)).toBe(loadedSteps);
+  });
+
+  test("Returns an empty array when overriding is not permitted and nothing has loaded", () => {
+    const state = {
+      editor: { project: { instructions: "# Title" } },
+      instructions: { permitOverride: false, project: {} },
+    };
+
+    expect(selectInstructionSteps(state)).toEqual([]);
+  });
+});


### PR DESCRIPTION
Done to make https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1681 easier

This are some refactors and improvements to instructions that:

- Fixes instruction format in example projects
- Make it possible to preview code club project style instructions from example projects
- Simplifying instruction state management and rendering 
   - Previously the rendering happened far away from the instruction panel which was hard to follow
   - The state management was also complex as we would store the rendered instructions in state and have to have an effect to re-create them rather than just rendering when needed.
- Splitting out large Instruction panel into separate components

See commits for more

*Made with help from Claude*