### PR TITLE
Remove support for quizzes in instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,6 @@ The web component communicates with the host page via the following custom event
 - `editor-stepChanged`: When the instructions step changes - event detail contains the new step position
 - `editor-logIn`: When the user requests to log in
 - `editor-signUp`: When the user requests to sign up
-- `editor-quizReady`: When the quiz is ready
 - `editor-themeUpdated`: When the theme changes to light/dark mode - event detail contains the new theme
 
 These events allow the host page to respond to requests or changes made in the editor, for example, handling login or displaying data about the owner of a project or the latest code run.

--- a/src/components/Menus/Sidebar/InstructionsPanel/InstructionsPanel.jsx
+++ b/src/components/Menus/Sidebar/InstructionsPanel/InstructionsPanel.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable jsx-a11y/anchor-has-content */
 // This is disabled because the empty anchor tag is used for translation and will have content when rendered.
 
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useRef, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { Tab, TabList, TabPanel, Tabs } from "react-tabs";
@@ -11,10 +11,7 @@ import PlusIcon from "../../../../assets/icons/plus.svg";
 import demoInstructions from "../../../../assets/markdown/demoInstructions.md?raw";
 import "../../../../assets/stylesheets/Instructions.scss?inline";
 import { setProjectInstructions } from "../../../../redux/EditorSlice";
-import {
-  selectInstructionSteps,
-  setCurrentStepPosition,
-} from "../../../../redux/InstructionsSlice";
+import { selectInstructionSteps } from "../../../../redux/InstructionsSlice";
 import populateMarkdownTemplate from "../../../../utils/populateMarkdownTemplate";
 import DesignSystemButton from "../../../DesignSystemButton/DesignSystemButton";
 import RemoveInstructionsModal from "../../../Modals/RemoveInstructionsModal";
@@ -28,18 +25,11 @@ const InstructionsPanel = () => {
   );
   const project = useSelector((state) => state.editor?.project);
   const steps = useSelector(selectInstructionSteps);
-  const quiz = useSelector((state) => state.instructions?.quiz);
   const dispatch = useDispatch();
   const currentStepPosition = useSelector(
     (state) => state.instructions.currentStepPosition,
   );
   const { t, i18n } = useTranslation();
-
-  const [isQuiz, setIsQuiz] = useState(false);
-
-  const quizCompleted = useMemo(() => {
-    return quiz?.currentQuestion === quiz?.questionCount;
-  }, [quiz]);
 
   const numberOfSteps = steps?.length || 0;
 
@@ -47,31 +37,7 @@ const InstructionsPanel = () => {
   const hasMultipleSteps = numberOfSteps > 1;
   const isScratchProject = project?.project_type === "code_editor_scratch";
 
-  const isQuizStep = isQuiz && !quizCompleted;
-  const currentStep = isQuizStep
-    ? { content: quiz.questions[quiz.currentQuestion] }
-    : steps[currentStepPosition];
-
-  useEffect(() => {
-    const stepIsQuizAndHasQuestions = () => {
-      return (
-        !quizCompleted &&
-        !!quiz?.questionCount &&
-        typeof steps[currentStepPosition]?.knowledgeQuiz === "string"
-      );
-    };
-    stepIsQuizAndHasQuestions() ? setIsQuiz(true) : setIsQuiz(false);
-  }, [quiz, steps, currentStepPosition, quizCompleted]);
-
-  useEffect(() => {
-    if (quizCompleted && isQuiz) {
-      dispatch(
-        setCurrentStepPosition(
-          Math.min(currentStepPosition + 1, numberOfSteps - 1),
-        ),
-      );
-    }
-  }, [quizCompleted, currentStepPosition, numberOfSteps, dispatch, isQuiz]);
+  const currentStep = steps[currentStepPosition];
 
   const addInstructions = () => {
     const translatedInstructions = populateMarkdownTemplate(
@@ -147,7 +113,6 @@ const InstructionsPanel = () => {
                   <InstructionsStep
                     className="project-instructions"
                     step={currentStep}
-                    isQuiz={isQuizStep}
                     isScratchProject={isScratchProject}
                     language={i18n.language}
                   />
@@ -184,7 +149,6 @@ const InstructionsPanel = () => {
             className="project-instructions__content"
             key="instruction-content"
             step={currentStep}
-            isQuiz={isQuizStep}
             isScratchProject={isScratchProject}
             language={i18n.language}
           />

--- a/src/components/Menus/Sidebar/InstructionsPanel/InstructionsPanel.test.jsx
+++ b/src/components/Menus/Sidebar/InstructionsPanel/InstructionsPanel.test.jsx
@@ -41,7 +41,6 @@ describe("When instructionsEditable changes from false to true", () => {
         },
         instructions: {
           project: { steps: [{ content: "<h1>Rendered preview</h1>" }] },
-          quiz: {},
           currentStepPosition: 0,
         },
       },
@@ -79,7 +78,6 @@ describe("When instructionsEditable is true", () => {
             project: {
               steps: [{ content: "instructions" }],
             },
-            quiz: {},
             currentStepPosition: 1,
           },
         },
@@ -145,7 +143,6 @@ describe("When instructionsEditable is true", () => {
             project: {
               steps: [],
             },
-            quiz: {},
             currentStepPosition: 1,
           },
         },
@@ -198,7 +195,6 @@ describe("When instructions are not editable", () => {
             project: {
               steps: [],
             },
-            quiz: {},
             currentStepPosition: 1,
           },
         },
@@ -256,7 +252,6 @@ describe("When instructions are not editable", () => {
                 },
               ],
             },
-            quiz: {},
             currentStepPosition: 1,
           },
         },
@@ -302,7 +297,6 @@ describe("When instructions are not editable", () => {
             project: {
               steps: [{ content: "<p>step 0</p>" }],
             },
-            quiz: {},
             currentStepPosition: 0,
           },
         },
@@ -334,7 +328,6 @@ describe("When instructions are not editable", () => {
           },
           instructions: {
             project: { steps: scratchSteps },
-            quiz: {},
             currentStepPosition,
           },
         },
@@ -380,7 +373,6 @@ describe("When instructions are not editable", () => {
                 },
               ],
             },
-            quiz: {},
             currentStepPosition: 0,
           },
         },
@@ -389,48 +381,6 @@ describe("When instructions are not editable", () => {
 
     test("Does not initialise scratchblocks", () => {
       expect(scratchblocksInit).not.toHaveBeenCalled();
-    });
-  });
-
-  describe("When there is a quiz", () => {
-    const quizHandler = jest.fn();
-
-    beforeAll(() => {
-      document.addEventListener("editor-quizReady", quizHandler);
-    });
-    beforeEach(() => {
-      renderWithProviders(<InstructionsPanel />, {
-        preloadedState: {
-          instructions: {
-            project: {
-              steps: [
-                { content: "<p>step 0</p>" },
-                { content: "<p>step 1</p>", knowledgeQuiz: "quizPath" },
-              ],
-            },
-            quiz: {
-              questions: [
-                "<h2>Test quiz</h2><p>step 1</p><code class='language-python'>print('hello')</code>",
-              ],
-              questionCount: 1,
-              currentQuestion: 0,
-            },
-            currentStepPosition: 1,
-          },
-        },
-      });
-    });
-
-    test("Renders the quiz content", () => {
-      expect(screen.queryByText("Test quiz")).toBeInTheDocument();
-    });
-
-    test("Retains the progress bar", () => {
-      expect(screen.queryByRole("progressbar")).toBeInTheDocument();
-    });
-
-    test("Fires a quizIsReady event", () => {
-      expect(quizHandler).toHaveBeenCalled();
     });
   });
 });

--- a/src/components/Menus/Sidebar/InstructionsPanel/InstructionsStep/InstructionsStep.jsx
+++ b/src/components/Menus/Sidebar/InstructionsPanel/InstructionsStep/InstructionsStep.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useRef } from "react";
 import { marked } from "marked";
 import Prism from "prismjs";
-import { quizReadyEvent } from "../../../../../events/WebComponentCustomEvents";
 import { scratchblocksInit } from "../../../../../utils/scratchblocks";
 
 const markdownRenderer = new marked.Renderer();
@@ -35,7 +34,6 @@ const applySyntaxHighlighting = (container) => {
 const InstructionsStep = ({
   className,
   step,
-  isQuiz = false,
   isScratchProject = false,
   language,
 }) => {
@@ -68,10 +66,7 @@ const InstructionsStep = ({
     if (isScratchProject) {
       scratchblocksInit(language, stepContent.current);
     }
-    if (isQuiz) {
-      document.dispatchEvent(quizReadyEvent);
-    }
-  }, [step, isQuiz, isScratchProject, language]);
+  }, [step, isScratchProject, language]);
 
   return <div className={className} ref={stepContent} />;
 };

--- a/src/components/Menus/Sidebar/InstructionsPanel/InstructionsStep/InstructionsStep.test.jsx
+++ b/src/components/Menus/Sidebar/InstructionsPanel/InstructionsStep/InstructionsStep.test.jsx
@@ -109,31 +109,3 @@ describe("When isScratchProject is false", () => {
     expect(scratchblocksInit).not.toHaveBeenCalled();
   });
 });
-
-describe("When isQuiz is true", () => {
-  test("Dispatches a quizReady event", () => {
-    const quizReadyHandler = vi.fn();
-    document.addEventListener("editor-quizReady", quizReadyHandler);
-
-    render(
-      <InstructionsStep step={{ content: "<p>quiz</p>" }} isQuiz={true} />,
-    );
-
-    expect(quizReadyHandler).toHaveBeenCalled();
-
-    document.removeEventListener("editor-quizReady", quizReadyHandler);
-  });
-});
-
-describe("When isQuiz is false", () => {
-  test("Does not dispatch a quizReady event", () => {
-    const quizReadyHandler = vi.fn();
-    document.addEventListener("editor-quizReady", quizReadyHandler);
-
-    render(<InstructionsStep step={{ content: "<p>step</p>" }} />);
-
-    expect(quizReadyHandler).not.toHaveBeenCalled();
-
-    document.removeEventListener("editor-quizReady", quizReadyHandler);
-  });
-});

--- a/src/components/Menus/Sidebar/SidebarBar.test.jsx
+++ b/src/components/Menus/Sidebar/SidebarBar.test.jsx
@@ -94,7 +94,6 @@ describe("SidebarBar", () => {
               {
                 title: "My testing title",
                 content: "My testing content",
-                quiz: false,
               },
             ]}
           />

--- a/src/containers/WebComponentLoader.test.jsx
+++ b/src/containers/WebComponentLoader.test.jsx
@@ -45,7 +45,7 @@ let store;
 let cookies;
 const code = "print('This project is amazing')";
 const identifier = "My amazing project";
-const steps = [{ quiz: false, title: "Step 1", content: "Do something" }];
+const steps = [{ title: "Step 1", content: "Do something" }];
 const instructions = {
   currentStepPosition: 3,
   project: { steps: steps },

--- a/src/events/WebComponentCustomEvents.js
+++ b/src/events/WebComponentCustomEvents.js
@@ -36,7 +36,5 @@ export const logInEvent = webComponentCustomEvent("editor-logIn");
 
 export const signUpEvent = webComponentCustomEvent("editor-signUp");
 
-export const quizReadyEvent = webComponentCustomEvent("editor-quizReady");
-
 export const themeUpdatedEvent = (detail) =>
   webComponentCustomEvent("editor-themeUpdated", detail);

--- a/src/redux/InstructionsSlice.js
+++ b/src/redux/InstructionsSlice.js
@@ -28,9 +28,7 @@ export const selectInstructionSteps = createSelector(
       return loadedSteps || [];
     }
     if (typeof projectInstructions === "string") {
-      return [
-        { quiz: false, title: "", markdown_content: projectInstructions },
-      ];
+      return [{ title: "", markdown_content: projectInstructions }];
     }
     return projectInstructions || [];
   },

--- a/src/redux/InstructionsSlice.test.js
+++ b/src/redux/InstructionsSlice.test.js
@@ -8,12 +8,12 @@ describe("selectInstructionSteps", () => {
     };
 
     expect(selectInstructionSteps(state)).toEqual([
-      { quiz: false, title: "", markdown_content: "# Title" },
+      { title: "", markdown_content: "# Title" },
     ]);
   });
 
   test("Uses an authored steps array from project instructions as-is", () => {
-    const steps = [{ quiz: false, title: "Step 1", content: "<p>Go</p>" }];
+    const steps = [{ title: "Step 1", content: "<p>Go</p>" }];
     const state = {
       editor: { project: { instructions: steps } },
       instructions: { permitOverride: true, project: { steps: [] } },

--- a/src/redux/reducers/instructionsReducers.test.js
+++ b/src/redux/reducers/instructionsReducers.test.js
@@ -15,7 +15,7 @@ test("Sets step number correctly", () => {
 test("Sets instructions including step position correctly", () => {
   let state = { currentStepPosition: 0 };
 
-  const step = { quiz: false, title: "Step 1", content: "Do something!" };
+  const step = { title: "Step 1", content: "Do something!" };
   const instructions = {
     currentStepPosition: 7,
     project: {
@@ -30,7 +30,7 @@ test("Sets instructions including step position correctly", () => {
 test("Keeps original step position if no progress", () => {
   let state = { currentStepPosition: 0 };
 
-  const step = { quiz: false, title: "Step 1", content: "Do something!" };
+  const step = { title: "Step 1", content: "Do something!" };
   const instructions = {
     project: {
       steps: [step],


### PR DESCRIPTION
Related to https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1681

We're working on instructions so I'm looking for ways we can make them easier to work with.

The project site no longer uses quizzes in the editor so we can remove support for them.

Discussed in https://raspberrypifoundation.slack.com/archives/C13FSSVDG/p1786109551819919