### PR TITLE
Add block text highlighting in instruction panel

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,19 +1,3 @@
 {
-  "presets": ["react-app"],
-  "plugins": [
-    [
-      "prismjs",
-      {
-        "languages": ["javascript", "css", "python", "html"],
-        "plugins": [
-          "line-numbers",
-          "line-highlight",
-          "highlight-keywords",
-          "normalize-whitespace"
-        ],
-        "theme": "twilight",
-        "css": true
-      }
-    ]
-  ]
+  "presets": ["react-app"]
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -20,7 +20,13 @@ module.exports = {
       "<rootDir>/node_modules/jest-transform-stub",
   },
   transformIgnorePatterns: [
-    "[/\\\\]node_modules[/\\\\](?!three).+\\.(js|jsx|mjs|cjs|ts|tsx)$",
+    // Ignore everything under node_modules except the packages listed below,
+    // which Jest has to transform because they are "type": "module" with no
+    // CommonJS entry point: rpf-markdown-core's CJS build requires marked and
+    // scratchblocks/index.js, so their raw `export` syntax would otherwise
+    // reach the CJS loader. A nested copy (rpf-markdown-core/node_modules/
+    // scratchblocks) is also exempted.
+    "^(?!.*[/\\\\]node_modules[/\\\\](?:three|marked|scratchblocks)[/\\\\]).*[/\\\\]node_modules[/\\\\].+\\.(js|jsx|mjs|cjs|ts|tsx)$",
     "^.+\\.module\\.(css|sass|scss)$",
   ],
   modulePaths: [],

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@juggle/resize-observer": "^3.3.1",
     "@raspberrypifoundation/design-system-react": "^2.9.2",
     "@raspberrypifoundation/python-friendly-error-messages": "0.8.0",
+    "@raspberrypifoundation/rpf-markdown-core": "^0.1.2",
     "@react-three/drei": "^10.0.0",
     "@react-three/fiber": "^9.6.1",
     "@reduxjs/toolkit": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "js-convert-case": "^4.2.0",
     "jszip": "^3.10.1",
     "jszip-utils": "^0.1.0",
-    "marked": "^15.0.6",
     "mime-types": "^2.1.35",
     "node-html-parser": "^6.1.5",
     "oidc-client": "^1.11.5",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,6 @@
     "@vitejs/plugin-react": "^6",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^29.1.2",
-    "babel-plugin-prismjs": "^2.1.0",
     "babel-preset-react-app": "^10.0.1",
     "browserslist": "^4.28.6",
     "browserslist-to-esbuild": "^2.1.1",

--- a/src/assets/stylesheets/Instructions.scss
+++ b/src/assets/stylesheets/Instructions.scss
@@ -8,48 +8,14 @@
 .project-instructions {
   block-size: 100%;
 
-  code.block3control {
-    background-color: var(--scratch-control-primary);
-  }
-  code.block3events {
-    background-color: var(--scratch-events-primary);
-  }
-  code.block3extensions {
-    background-color: var(--scratch-pen-primary);
-  }
-  code.block3looks {
-    background-color: var(--scratch-looks-primary);
-  }
-  code.block3motion {
-    background-color: var(--scratch-motion-primary);
-  }
-  code.block3myblocks {
-    background-color: var(--scratch-more-primary);
-  }
-  code.block3operators {
-    background-color: var(--scratch-operators-primary);
-  }
-  code.block3sensing {
-    background-color: var(--scratch-sensing-primary);
-  }
-  code.block3sound {
-    background-color: var(--scratch-sounds-primary);
-  }
-  code.block3variables {
-    background-color: var(--scratch-data-primary);
+  @each $block, $category in $scratch-block-categories {
+    code.block3#{$block} {
+      background-color: var(--scratch-#{$category}-primary);
+    }
   }
 
   @media (prefers-contrast: more) {
-    code.block3control,
-    code.block3events,
-    code.block3extensions,
-    code.block3looks,
-    code.block3motion,
-    code.block3myblocks,
-    code.block3operators,
-    code.block3sensing,
-    code.block3sound,
-    code.block3variables {
+    code[class*="block3"] {
       color: var(--rpf-black);
     }
   }
@@ -416,10 +382,10 @@
 }
 
 .--dark .project-instructions {
-  pre {
-    background-color: $rpf-grey-850;
-  }
-  code {
+  // Exclude scratchblocks references, otherwise this would tie on specificity
+  // with their category colours above and win by coming later in the file.
+  pre,
+  code:not([class*="block3"]) {
     background-color: $rpf-grey-850;
   }
 }

--- a/src/assets/stylesheets/_scratch_colours.scss
+++ b/src/assets/stylesheets/_scratch_colours.scss
@@ -1,5 +1,21 @@
 // Scratch block category colours, sourced from
 // @RaspberryPiFoundation/scratch-gui's src/lib/settings/color-mode/*/index.js
+
+// scratchblocks names its categories differently to scratch-gui, so map the
+// `code.block3<key>` class it emits onto the `--scratch-<value>-primary` var.
+$scratch-block-categories: (
+  "control": "control",
+  "events": "events",
+  "extensions": "pen",
+  "looks": "looks",
+  "motion": "motion",
+  "myblocks": "more",
+  "operators": "operators",
+  "sensing": "sensing",
+  "sound": "sounds",
+  "variables": "data",
+);
+
 .project-instructions {
   --scratch-motion-primary: #4c97ff;
   --scratch-looks-primary: #9966ff;

--- a/src/components/Menus/Sidebar/InstructionsPanel/InstructionsPanel.test.jsx
+++ b/src/components/Menus/Sidebar/InstructionsPanel/InstructionsPanel.test.jsx
@@ -4,15 +4,11 @@ import { setInstructionsEditable } from "../../../../redux/EditorSlice";
 import { setCurrentStepPosition } from "../../../../redux/InstructionsSlice";
 import { act } from "react";
 import Modal from "react-modal";
-import Prism from "prismjs";
 import { scratchblocksInit } from "../../../../utils/scratchblocks";
 import { renderWithProviders } from "../../../../utils/renderWithProviders";
 
 window.HTMLElement.prototype.scrollTo = jest.fn();
-jest.mock("prismjs", () => ({
-  ...jest.requireActual("prismjs"),
-  highlightElement: jest.fn(),
-}));
+
 jest.mock("../../../../utils/scratchblocks", () => ({
   scratchblocksInit: jest.fn(),
 }));
@@ -283,11 +279,6 @@ describe("When instructions are not editable", () => {
 
     test("Renders the progress bar", () => {
       expect(screen.queryByRole("progressbar")).toBeInTheDocument();
-    });
-
-    test("Applies syntax highlighting to step content", () => {
-      const codeElement = document.getElementsByClassName("language-python")[0];
-      expect(Prism.highlightElement).toHaveBeenCalledWith(codeElement);
     });
   });
 

--- a/src/components/Menus/Sidebar/InstructionsPanel/InstructionsStep/InstructionsStep.jsx
+++ b/src/components/Menus/Sidebar/InstructionsPanel/InstructionsStep/InstructionsStep.jsx
@@ -1,21 +1,14 @@
 import React, { useEffect, useRef } from "react";
-import { marked } from "marked";
+import { processEditorProject } from "@raspberrypifoundation/rpf-markdown-core";
 import Prism from "prismjs";
 import { quizReadyEvent } from "../../../../../events/WebComponentCustomEvents";
 import { scratchblocksInit } from "../../../../../utils/scratchblocks";
-
-const markdownRenderer = new marked.Renderer();
-markdownRenderer.link = function (data) {
-  return `<a href="${data.href}" target="_blank" rel="noreferrer"
-    }">${data.text}</a>`;
-};
-marked.setOptions({ renderer: markdownRenderer });
 
 const getStepHtml = (step) => {
   if (step.content !== undefined) {
     return step.content;
   }
-  return marked.parse(step.markdown_content ?? "");
+  return processEditorProject(step.markdown_content ?? "");
 };
 
 const applySyntaxHighlighting = (container) => {
@@ -29,6 +22,14 @@ const applySyntaxHighlighting = (container) => {
     } else {
       Prism.highlightElement(element);
     }
+  });
+};
+
+const applyExternalLinkAttributes = (container) => {
+  container.querySelectorAll("a[href]").forEach((link) => {
+    if (link.getAttribute("href").startsWith("#")) return;
+    link.setAttribute("target", "_blank");
+    link.setAttribute("rel", "noreferrer");
   });
 };
 
@@ -64,6 +65,7 @@ const InstructionsStep = ({
     stepContent.current.parentElement?.scrollTo({ top: 0 });
     stepContent.current.innerHTML = getStepHtml(step);
     applySyntaxHighlighting(stepContent.current);
+    applyExternalLinkAttributes(stepContent.current);
 
     if (isScratchProject) {
       scratchblocksInit(language, stepContent.current);

--- a/src/components/Menus/Sidebar/InstructionsPanel/InstructionsStep/InstructionsStep.jsx
+++ b/src/components/Menus/Sidebar/InstructionsPanel/InstructionsStep/InstructionsStep.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from "react";
 import { processEditorProject } from "@raspberrypifoundation/rpf-markdown-core";
-import Prism from "prismjs";
+import Prism from "../../../../../utils/prism";
 import { quizReadyEvent } from "../../../../../events/WebComponentCustomEvents";
 import { scratchblocksInit } from "../../../../../utils/scratchblocks";
 
@@ -17,11 +17,7 @@ const applySyntaxHighlighting = (container) => {
   );
 
   codeElements.forEach((element) => {
-    if (window.syntaxHighlight) {
-      window.syntaxHighlight.highlightElement(element);
-    } else {
-      Prism.highlightElement(element);
-    }
+    Prism.highlightElement(element);
   });
 };
 
@@ -41,23 +37,6 @@ const InstructionsStep = ({
   language,
 }) => {
   const stepContent = useRef();
-
-  useEffect(() => {
-    Prism.manual = true;
-    if (Prism.plugins.NormalizeWhitespace) {
-      Prism.plugins.NormalizeWhitespace.setDefaults({
-        "remove-indent": false,
-        "remove-initial-line-feed": true,
-        "left-trim": false,
-      });
-      Prism.hooks.add("before-sanity-check", function (env) {
-        if (!env.code) return;
-
-        // Remove multiple leading blank lines (empty or whitespace-only)
-        env.code = env.code.replace(/^(?:\s*\n)+/, "");
-      });
-    }
-  }, []);
 
   useEffect(() => {
     if (!stepContent.current || !step) return;

--- a/src/components/Menus/Sidebar/InstructionsPanel/InstructionsStep/InstructionsStep.jsx
+++ b/src/components/Menus/Sidebar/InstructionsPanel/InstructionsStep/InstructionsStep.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useRef } from "react";
 import { processEditorProject } from "@raspberrypifoundation/rpf-markdown-core";
 import Prism from "../../../../../utils/prism";
-import { quizReadyEvent } from "../../../../../events/WebComponentCustomEvents";
 import { scratchblocksInit } from "../../../../../utils/scratchblocks";
 
 const getStepHtml = (step) => {

--- a/src/components/Menus/Sidebar/InstructionsPanel/InstructionsStep/InstructionsStep.test.jsx
+++ b/src/components/Menus/Sidebar/InstructionsPanel/InstructionsStep/InstructionsStep.test.jsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import Prism from "prismjs";
+import Prism from "../../../../../utils/prism";
 import InstructionsStep from "./InstructionsStep";
 import { scratchblocksInit } from "../../../../../utils/scratchblocks";
 
@@ -65,23 +65,6 @@ describe("Syntax highlighting", () => {
 
     const codeElement = document.getElementsByClassName("language-python")[0];
     expect(Prism.highlightElement).toHaveBeenCalledWith(codeElement);
-  });
-
-  test("Uses window.syntaxHighlight when defined", () => {
-    window.syntaxHighlight = { highlightElement: vi.fn() };
-
-    render(
-      <InstructionsStep
-        step={{ content: "<code class='language-python'>print(1)</code>" }}
-      />,
-    );
-
-    const codeElement = document.getElementsByClassName("language-python")[0];
-    expect(window.syntaxHighlight.highlightElement).toHaveBeenCalledWith(
-      codeElement,
-    );
-
-    delete window.syntaxHighlight;
   });
 });
 

--- a/src/components/Menus/Sidebar/InstructionsPanel/InstructionsStep/InstructionsStep.test.jsx
+++ b/src/components/Menus/Sidebar/InstructionsPanel/InstructionsStep/InstructionsStep.test.jsx
@@ -47,6 +47,39 @@ describe("When the step has markdown_content", () => {
   });
 });
 
+describe("When markdown attaches a class to inline code", () => {
+  const renderMarkdown = (markdown_content) =>
+    render(<InstructionsStep step={{ markdown_content }} />).container;
+
+  const scratchBlockClasses = [
+    "block3control",
+    "block3events",
+    "block3extensions",
+    "block3looks",
+    "block3motion",
+    "block3myblocks",
+    "block3operators",
+    "block3sensing",
+    "block3sound",
+    "block3variables",
+  ];
+
+  test.each(scratchBlockClasses)("Applies %s to the code element", (name) => {
+    const container = renderMarkdown(`\`Move\`{:class="${name}"}`);
+
+    const code = container.querySelector("code");
+    expect(code).toHaveClass(name);
+    expect(code).toHaveTextContent("Move");
+  });
+
+  test("Consumes the attribute syntax instead of rendering it", () => {
+    const container = renderMarkdown('`Motion`{:class="block3motion"}');
+
+    expect(container.textContent).toContain("Motion");
+    expect(container.textContent).not.toContain("{:class");
+  });
+});
+
 describe("When there is no step", () => {
   test("Renders without crashing", () => {
     const { container } = render(<InstructionsStep step={undefined} />);

--- a/src/containers/WebComponentLoader.jsx
+++ b/src/containers/WebComponentLoader.jsx
@@ -204,24 +204,6 @@ const WebComponentLoader = (props) => {
     dispatch(setOfflineEnabled(offlineEnabled));
   }, [offlineEnabled, dispatch]);
 
-  useEffect(() => {
-    // Create a script element to save the existing Prism object if there is one
-    const script = document.createElement("script");
-    script.textContent = `
-      if (window.Prism) {
-        window.syntaxHighlight = window.Prism;
-      }
-    `;
-
-    // Append the script to the document body
-    document.body.appendChild(script);
-
-    // Clean up the script when the component unmounts
-    return () => {
-      document.body.removeChild(script);
-    };
-  }, []);
-
   const renderSuccessState = () => (
     <>
       <SettingsContext.Provider

--- a/src/containers/WebComponentLoader.test.jsx
+++ b/src/containers/WebComponentLoader.test.jsx
@@ -57,7 +57,6 @@ const user = { access_token: "my_token" };
 describe("When initially rendered", () => {
   beforeEach(() => {
     document.dispatchEvent = jest.fn();
-    window.Prism = jest.fn();
     const mockStore = configureStore([]);
     const initialState = {
       editor: {
@@ -101,10 +100,6 @@ describe("When initially rendered", () => {
         detail: { user_name: "Joe Bloggs" },
       }),
     );
-  });
-
-  test("It saves window.Prism to window.syntaxHighlight", () => {
-    expect(window.syntaxHighlight).toEqual(window.Prism);
   });
 
   test("it sets the language in i18n", () => {

--- a/src/utils/prism.js
+++ b/src/utils/prism.js
@@ -1,0 +1,28 @@
+// Prism's languages and plugins used to be injected by babel-plugin-prismjs
+// but stopped running during the Vite migration.
+// Registering them here keeps the set explicit and independent of the build
+// pipeline.
+import Prism from "prismjs";
+import "prismjs/components/prism-python";
+import "prismjs/plugins/normalize-whitespace/prism-normalize-whitespace";
+import "prismjs/plugins/line-numbers/prism-line-numbers";
+import "prismjs/plugins/line-highlight/prism-line-highlight";
+import "prismjs/plugins/highlight-keywords/prism-highlight-keywords";
+
+Prism.manual = true;
+
+Prism.plugins.NormalizeWhitespace?.setDefaults({
+  "remove-indent": false,
+  "remove-initial-line-feed": true,
+  "left-trim": false,
+});
+
+// Remove multiple leading blank lines (empty or whitespace-only), which would
+// otherwise render as blank rows and be counted by the line-numbers plugin.
+Prism.hooks.add("before-sanity-check", (env) => {
+  if (!env.code) return;
+
+  env.code = env.code.replace(/^(?:\s*\n)+/, "");
+});
+
+export default Prism;

--- a/src/utils/prism.test.js
+++ b/src/utils/prism.test.js
@@ -1,0 +1,57 @@
+import { processEditorProject } from "@raspberrypifoundation/rpf-markdown-core";
+import Prism from "./prism";
+
+describe("Prism setup", () => {
+  test.each(["python", "javascript", "css", "markup"])(
+    "Registers the %s language",
+    (language) => {
+      expect(Prism.languages[language]).toBeDefined();
+    },
+  );
+
+  test.each(["lineNumbers", "lineHighlight", "NormalizeWhitespace"])(
+    "Registers the %s plugin",
+    (plugin) => {
+      expect(Prism.plugins[plugin]).toBeDefined();
+    },
+  );
+
+  test("Does not highlight the document automatically", () => {
+    expect(Prism.manual).toBe(true);
+  });
+});
+
+describe("Highlighting code blocks from rpf-markdown-core", () => {
+  const highlight = (markdown) => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    container.innerHTML = processEditorProject(markdown);
+    container
+      .querySelectorAll(".language-python")
+      .forEach((element) => Prism.highlightElement(element));
+    return container;
+  };
+
+  const code = "print(1)\nprint(2)\nprint(3)";
+
+  test("Adds line numbers and a line highlight when the fence asks for them", () => {
+    const container = highlight(
+      "```python line_numbers=true line_highlights=2-3\n" + code + "\n```",
+    );
+
+    expect(
+      container.querySelectorAll(".line-numbers-rows > span"),
+    ).toHaveLength(3);
+    expect(container.querySelector(".line-highlight")).toHaveAttribute(
+      "data-range",
+      "2-3",
+    );
+  });
+
+  test("Leaves a plain fence without line numbers or a line highlight", () => {
+    const container = highlight("```python\n" + code + "\n```");
+
+    expect(container.querySelector(".line-numbers-rows")).toBeNull();
+    expect(container.querySelector(".line-highlight")).toBeNull();
+  });
+});

--- a/src/utils/prism.test.js
+++ b/src/utils/prism.test.js
@@ -32,6 +32,10 @@ describe("Highlighting code blocks from rpf-markdown-core", () => {
     return container;
   };
 
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
   const code = "print(1)\nprint(2)\nprint(3)";
 
   test("Adds line numbers and a line highlight when the fence asks for them", () => {

--- a/vite.config.js
+++ b/vite.config.js
@@ -143,6 +143,13 @@ export default defineConfig(async ({ mode }) => {
       }),
       analyzePlugin,
     ],
+    optimizeDeps: {
+      exclude: [
+        "prismjs/plugins/line-numbers/prism-line-numbers",
+        "prismjs/plugins/line-highlight/prism-line-highlight",
+        "prismjs/plugins/highlight-keywords/prism-highlight-keywords",
+      ],
+    },
     server: {
       host: true,
       port: 3011,

--- a/vite.lib.js
+++ b/vite.lib.js
@@ -56,26 +56,7 @@ const resolveViteBase = (mode, env) => {
 };
 
 const editorVitePlugins = (react, svgr, nodePolyfills) => [
-  react({
-    babel: {
-      plugins: [
-        [
-          "prismjs",
-          {
-            languages: ["javascript", "css", "python", "html"],
-            plugins: [
-              "line-numbers",
-              "line-highlight",
-              "highlight-keywords",
-              "normalize-whitespace",
-            ],
-            theme: "twilight",
-            css: true,
-          },
-        ],
-      ],
-    },
-  }),
+  react(),
   svgr({
     include: "**/src/assets/icons/**/*.svg",
     svgrOptions: { exportType: "default" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4398,7 +4398,6 @@ __metadata:
     axios: "npm:^1.15.2"
     babel-eslint: "npm:^10.1.0"
     babel-jest: "npm:^29.1.2"
-    babel-plugin-prismjs: "npm:^2.1.0"
     babel-preset-react-app: "npm:^10.0.1"
     browserslist: "npm:^4.28.6"
     browserslist-to-esbuild: "npm:^2.1.1"
@@ -7044,15 +7043,6 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.4.0 || ^8.0.0-0 <8.0.0
   checksum: 10/150233571072b6b3dfe946242da39cba8587b7f908d1c006f7545fc88b0e3c3018d445739beb61e7a75835f0c2751dbe884a94ff9b245ec42369d9267e0e1b3f
-  languageName: node
-  linkType: hard
-
-"babel-plugin-prismjs@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "babel-plugin-prismjs@npm:2.1.0"
-  peerDependencies:
-    prismjs: ^1.18.0
-  checksum: 10/3536d5480d7d9898f2094ae40994c879dfdf602b7a3065d2848f4b1a48315a8e01fd32847050f6138a8a91fbaeb5017ebe89c5aef375d3c46d72a8cb02247d25
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4379,6 +4379,7 @@ __metadata:
     "@juggle/resize-observer": "npm:^3.3.1"
     "@raspberrypifoundation/design-system-react": "npm:^2.9.2"
     "@raspberrypifoundation/python-friendly-error-messages": "npm:0.8.0"
+    "@raspberrypifoundation/rpf-markdown-core": "npm:^0.1.2"
     "@react-three/drei": "npm:^10.0.0"
     "@react-three/fiber": "npm:^9.6.1"
     "@react-three/test-renderer": "npm:^9.0.0"
@@ -4496,6 +4497,19 @@ __metadata:
   version: 0.8.0
   resolution: "@raspberrypifoundation/python-friendly-error-messages@npm:0.8.0"
   checksum: 10/87b5a2d576cb2127a9d1882a0b5ff91c0d3cb528fee29859c034b859d3de64179e9163769a78a29e6f29da43c7fd2f2f4de1b4ec9dd6fa83372ae10e4b7de319
+  languageName: node
+  linkType: hard
+
+"@raspberrypifoundation/rpf-markdown-core@npm:^0.1.2":
+  version: 0.1.2
+  resolution: "@raspberrypifoundation/rpf-markdown-core@npm:0.1.2"
+  dependencies:
+    happy-dom: "npm:^20.9.0"
+    marked: "npm:^17.0.5"
+    marked-gfm-heading-id: "npm:^4.1.4"
+    prismjs: "npm:^1.30.0"
+    scratchblocks: "npm:^3.6.4"
+  checksum: 10/ab0688d2c6a04d74c7f707d245ef87c94e514edefdad819aebdf10ab5c5c6d55fa9ef09ae4e58e50a28536d96c5e2774289e14ca189d0bae235f92eba758fe44
   languageName: node
   linkType: hard
 
@@ -5772,6 +5786,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/node@npm:>=20.0.0":
+  version: 26.1.2
+  resolution: "@types/node@npm:26.1.2"
+  dependencies:
+    undici-types: "npm:~8.3.0"
+  checksum: 10/2dd6d75b80c006deab4e381acc8cb2e3d634f10141f05fd6cadaabddd80a95f04aef7b00a574bd8fd5e08e940b899c23b91dd09a70b11a34a2762203b5eea25e
+  languageName: node
+  linkType: hard
+
 "@types/offscreencanvas@npm:^2019.6.4, @types/offscreencanvas@npm:~2019.7.0":
   version: 2019.7.3
   resolution: "@types/offscreencanvas@npm:2019.7.3"
@@ -5960,6 +5983,22 @@ __metadata:
   version: 0.5.24
   resolution: "@types/webxr@npm:0.5.24"
   checksum: 10/780afba558f73588922c2e71a6dcffd29d132179c5ddf290e9e5fe43a8a5eedd34dc7395209c19c06aa7a916cd2230a9d6f3f3afb2c7a9f6c820dc1f775f266a
+  languageName: node
+  linkType: hard
+
+"@types/whatwg-mimetype@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "@types/whatwg-mimetype@npm:3.0.2"
+  checksum: 10/609607beeaa8b50b9e00541d8f571880d651b26b6b006103370099aba00784037de54433627c9fe775a5558e3d1fc09c2a48f54c8af91988e9bebeaf6a698eeb
+  languageName: node
+  linkType: hard
+
+"@types/ws@npm:^8.18.1":
+  version: 8.18.1
+  resolution: "@types/ws@npm:8.18.1"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10/1ce05e3174dcacf28dae0e9b854ef1c9a12da44c7ed73617ab6897c5cbe4fccbb155a20be5508ae9a7dde2f83bd80f5cf3baa386b934fc4b40889ec963e94f3a
   languageName: node
   linkType: hard
 
@@ -7478,6 +7517,15 @@ __metadata:
   version: 1.1.2
   resolution: "buffer-from@npm:1.1.2"
   checksum: 10/0448524a562b37d4d7ed9efd91685a5b77a50672c556ea254ac9a6d30e3403a517d8981f10e565db24e8339413b43c97ca2951f10e399c6125a0d8911f5679bb
+  languageName: node
+  linkType: hard
+
+"buffer-image-size@npm:^0.6.4":
+  version: 0.6.4
+  resolution: "buffer-image-size@npm:0.6.4"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10/82d4ca9bc8e71c9c0cbc74191d3613100d0a20dd21da018c6f373d7dc88ec4a9225eebe06c44a982de074f695402e81ab8a8daa40afce36b915042fa9fb32c52
   languageName: node
   linkType: hard
 
@@ -9794,6 +9842,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"entities@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "entities@npm:7.0.1"
+  checksum: 10/3c0c58d869c45148463e96d21dee2d1b801bd3fe4cf47aa470cd26dfe81d59e9e0a9be92ae083fa02fa441283c883a471486e94538dcfb8544428aa80a55271b
+  languageName: node
+  linkType: hard
+
 "entities@npm:^8.0.0":
   version: 8.0.0
   resolution: "entities@npm:8.0.0"
@@ -11495,6 +11550,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"github-slugger@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "github-slugger@npm:2.0.0"
+  checksum: 10/2fb15d78262eeba1e68671f048c62d05ed21e51281cccc7b1c9e8e089e8510b3037fb648b8ba27290e60534df2cb251312a1e7e813204495df621220192fd600
+  languageName: node
+  linkType: hard
+
 "gl-mat4@npm:^1.2.0":
   version: 1.2.0
   resolution: "gl-mat4@npm:1.2.0"
@@ -11923,6 +11985,21 @@ __metadata:
   version: 1.10.3
   resolution: "growl@npm:1.10.3"
   checksum: 10/89dfce783f6fb5cabbc053f8071560ff998a004214b497935ec051cf4ab96014cf74dd4f38ea56e7236dc34454b1382a225f90283b2eb09ffa4aa134365c5626
+  languageName: node
+  linkType: hard
+
+"happy-dom@npm:^20.9.0":
+  version: 20.11.1
+  resolution: "happy-dom@npm:20.11.1"
+  dependencies:
+    "@types/node": "npm:>=20.0.0"
+    "@types/whatwg-mimetype": "npm:^3.0.2"
+    "@types/ws": "npm:^8.18.1"
+    buffer-image-size: "npm:^0.6.4"
+    entities: "npm:^7.0.1"
+    whatwg-mimetype: "npm:^3.0.0"
+    ws: "npm:^8.21.0"
+  checksum: 10/a07d892f1fefe843cf3fcb0ed4ecb782fd1014c1ac27048f27f874f5d6b91ec0c25a777532145d0c041f524fd851d8ce5bf9779fc6f1ba0fed8b67d7ab96095f
   languageName: node
   linkType: hard
 
@@ -14872,12 +14949,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"marked-gfm-heading-id@npm:^4.1.4":
+  version: 4.1.4
+  resolution: "marked-gfm-heading-id@npm:4.1.4"
+  dependencies:
+    github-slugger: "npm:^2.0.0"
+  peerDependencies:
+    marked: ">=13 <19"
+  checksum: 10/c653d2398f9602119ac8baf4bc7a251b11be916a6e0b5c1ecc0001f97ad80bcb01a3d07101ebd49d1ac9ffc891a72c7315388e44a1bef13d28da8f62c9665be2
+  languageName: node
+  linkType: hard
+
 "marked@npm:^15.0.6":
   version: 15.0.6
   resolution: "marked@npm:15.0.6"
   bin:
     marked: bin/marked.js
   checksum: 10/81c6949655fa6bf0478ab73896cc4be8b7f8b5b755aa1fbfc7cbe3f936cda201dd94dddd09e842e57fffc099c72bef5fe49ec0fa5d7560ee81cc5240860094ce
+  languageName: node
+  linkType: hard
+
+"marked@npm:^17.0.5":
+  version: 17.0.6
+  resolution: "marked@npm:17.0.6"
+  bin:
+    marked: bin/marked.js
+  checksum: 10/46dac9481c028b6ab36f093084842f5c020329eb5529fa96ed22112f1f3a79b51b2f2c169a8b104b28c3ed09842ef372260dee08946fb1f7b1c70a7fb6f5cdc0
   languageName: node
   linkType: hard
 
@@ -16671,6 +16768,13 @@ __metadata:
   version: 1.29.0
   resolution: "prismjs@npm:1.29.0"
   checksum: 10/2080db382c2dde0cfc7693769e89b501ef1bfc8ff4f8d25c07fd4c37ca31bc443f6133d5b7c145a73309dc396e829ddb7cc18560026d862a887ae08864ef6b07
+  languageName: node
+  linkType: hard
+
+"prismjs@npm:^1.30.0":
+  version: 1.30.0
+  resolution: "prismjs@npm:1.30.0"
+  checksum: 10/6b48a2439a82e5c6882f48ebc1564c3890e16463ba17ac10c3ad4f62d98dea5b5c915b172b63b83023a70ad4f5d7be3e8a60304420db34a161fae69dd4e3e2da
   languageName: node
   linkType: hard
 
@@ -18497,6 +18601,13 @@ __metadata:
   version: 1.0.7
   resolution: "scratch-translate-extension-languages@npm:1.0.7"
   checksum: 10/0caf8422bfc33eeddcd9498695af28b1e83b899777271fb60eb1b8be139608f7c098dc969240907f29daf4dcd71ecdffec5848e9bc30d17ea49f86da7e550ca3
+  languageName: node
+  linkType: hard
+
+"scratchblocks@npm:^3.6.4":
+  version: 3.7.1
+  resolution: "scratchblocks@npm:3.7.1"
+  checksum: 10/f86cf05ccf61036d49cc90e127be2cca373648fdee970e0d95da5ab82433b145261103d8ab95f8d7ab2b9a434c52ee87f61e7f6195b920617ecbe5f37bd0c220
   languageName: node
   linkType: hard
 
@@ -20435,6 +20546,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"undici-types@npm:~8.3.0":
+  version: 8.3.0
+  resolution: "undici-types@npm:8.3.0"
+  checksum: 10/6681d2837ac75a75ac1cc46090aa2b8ddc7c6b8ecc295a6cdb06838752a730da3d8afeecf05e5ab7903160eafad3a8b6ffa1927e5ded260590f4d4fef18646d5
+  languageName: node
+  linkType: hard
+
 "undici@npm:^5.25.4":
   version: 5.29.0
   resolution: "undici@npm:5.29.0"
@@ -21462,6 +21580,21 @@ __metadata:
     utf-8-validate:
       optional: true
   checksum: 10/8c4d2b06dc65381b6bfab1f2e584275dabd30a99a5ce058b4dc76f3d03fad1921cef3a21d8f53127d30a808cfd1864aa2fe6890a5d43359f682457315baec873
+  languageName: node
+  linkType: hard
+
+"ws@npm:^8.21.0":
+  version: 8.21.1
+  resolution: "ws@npm:8.21.1"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 10/8493bc543072763d7bacffb2282c9d7954dc5c599c9df4c2d15f91c217f63e293a33ffc70756e3f2bf8c5d85bc6069ad7d9983c382d4713c807b083ffb1b1719
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4443,7 +4443,6 @@ __metadata:
     jsdom: "npm:^29.1.1"
     jszip: "npm:^3.10.1"
     jszip-utils: "npm:^0.1.0"
-    marked: "npm:^15.0.6"
     mime-types: "npm:^2.1.35"
     mock-match-media: "npm:^0.4.3"
     node-html-parser: "npm:^6.1.5"
@@ -14957,15 +14956,6 @@ __metadata:
   peerDependencies:
     marked: ">=13 <19"
   checksum: 10/c653d2398f9602119ac8baf4bc7a251b11be916a6e0b5c1ecc0001f97ad80bcb01a3d07101ebd49d1ac9ffc891a72c7315388e44a1bef13d28da8f62c9665be2
-  languageName: node
-  linkType: hard
-
-"marked@npm:^15.0.6":
-  version: 15.0.6
-  resolution: "marked@npm:15.0.6"
-  bin:
-    marked: bin/marked.js
-  checksum: 10/81c6949655fa6bf0478ab73896cc4be8b7f8b5b755aa1fbfc7cbe3f936cda201dd94dddd09e842e57fffc099c72bef5fe49ec0fa5d7560ee81cc5240860094ce
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1690

## Block-type text highlighting
- Used [rpf-markdown-core](https://github.com/RaspberryPiFoundation/rpf-markdown-core) (built by the Code Club team) for rendering instructions, chosen for its inline Kramdown class support.
- Refactored the css file so that they apply to both light and dark mode without breaking others. 

| Before   | After |
| -------- | ------- |
| <img width="392" height="349" alt="Screenshot 2026-08-10 at 17 02 22" src="https://github.com/user-attachments/assets/907a3a46-c871-4128-8f2d-081a9293edcf" />  | <img width="395" height="364" alt="Screenshot 2026-08-10 at 17 04 13" src="https://github.com/user-attachments/assets/8ac0b8f3-9a34-45ae-b134-334f8a98454a" />    |

## Prism and other fixes
- While doing this work, I found Prism had stopped working possibly due to the partial Vite migration. Prism provides syntax highlighting, line numbering and line highlighting in code blocks of instructions. Classroom and ExpCS instructions don't use these currently, but CCP instructions do (and CCP team also noticed this when running projects site locally along with latest editor-ui).
   <img width="360" alt="Screenshot 2026-08-10 at 17 02 57" src="https://github.com/user-attachments/assets/6d134da6-0bb3-476f-8c80-08a3cacb9456" />

- The existing `vite.lib.js` configured `babel-plugin-prismjs` via @vitejs/plugin-react's babel option. But the plugin-react v6 no longer has, so the config was ignored. Replaced with explicit imports in src/utils/prism.js. 
- In dev environment, `vite-plugin-node-polyfills` prepends a shim banner to every pre-bundled dependency without terminating the last statement. Prism's plugin files start with (function(){…})(), so it was parsed as an argument to the shim and then short-circuited away, resulting in line-numbers and line-highlight not registered. Worked around with optimizeDeps.exclude in vite.config.js. 
- Jest couldn't load any test importing rpf-markdown-core. Its CJS build requires marked and scratchblocks, both ESM-only with no CommonJS entry. Updated transformIgnorePatterns to exempt both, matched against the full path so the nested rpf-markdown-core/node_modules/scratchblocks copy is also covered.

## Can our users use any other features that the rpf-markdown-core provides?
- Not yet. There are some styling issues with others which we need to address first. 
- CCP team is also open to collaboration if we require certain set of functionalities from or improvements to the library.

| Spacing issues   | issues with dark mode |
| -------- | ------- |
| <img width="400" height="580" alt="Screenshot 2026-08-10 at 17 04 34" src="https://github.com/user-attachments/assets/8b5e80ff-5f78-4857-9adc-21d5ee06387c" /> | <img width="400" alt="Screenshot 2026-08-10 at 17 19 52" src="https://github.com/user-attachments/assets/044320f4-70ee-4017-8b4f-4b5c95753e14" /> |
    