### PR TITLE
Docs for host integration - usage of Autosave and SidebarPlugins

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,9 @@ yarn exec cypress open
 ## Further Reading (relative links)
 - `README.md`
 - `docs/WebComponent.md`
+- `docs/host-integration/README.md`
+- `docs/host-integration/SidebarPlugins.md`
+- `docs/host-integration/AutosaveFlush.md`
 - `docs/HTML.md`
 - `docs/PythonDependencies.md`
 - `docs/Deployment.md`

--- a/README.md
+++ b/README.md
@@ -172,8 +172,12 @@ The host page is able to communicate with the web component via custom methods p
 - `rerunCode`: stops the current code run and starts another code run in the editor
 - `stopCode`: stops the current code run
 - `codeChangedSinceInitialLoad`: getter that returns whether the current project files differ from the initial load by file count, name, extension, or content.
+- `setSidebarPlugins(plugins)` / `sidebarPlugins`: register host-owned sidebar panels (see [Sidebar plugins](./docs/host-integration/SidebarPlugins.md))
+- `shouldFlushBeforeNavigation` / `flushPendingAutoSave()` / `hasPendingAutoSave`: ask whether a save is needed before leave, and force-flush pending autosave (see [Autosave flush](./docs/host-integration/AutosaveFlush.md))
 
 This allows the host page to query the current code in the editor and to control code runs from outside the web component, for example.
+
+Deeper host guides live under [docs/host-integration](./docs/host-integration/README.md).
 
 ### Offline support
 

--- a/docs/WebComponent.md
+++ b/docs/WebComponent.md
@@ -13,7 +13,7 @@ For apps embedding `<editor-wc>`, see [docs/host-integration](host-integration/R
 - [Sidebar plugins](host-integration/SidebarPlugins.md) - register a host-owned sidebar panel via `setSidebarPlugins`
 - [Autosave flush before navigation](host-integration/AutosaveFlush.md) - `shouldFlushBeforeNavigation` and `flushPendingAutoSave`
 
-Mounting, attributes, events, and styling are covered in the [README](../README.md#usage).
+Mounting, attributes, events, and styling are covered in the [README](../README.md#usage). Design notes from the feedback-panel investigation live under [host-integration/design-notes/feedback-panel-investigation.md](host-integration/design-notes/feedback-panel-investigation.md).
 
 ## WebComponent Class
 

--- a/docs/WebComponent.md
+++ b/docs/WebComponent.md
@@ -6,6 +6,15 @@ There are custom Vite config files for the component: `vite.config.js` builds `w
 
 In `web-component.html` (project root) the JavaScript output is added and the web-component mounted. Then viewing `http://localhost:3011/web-component.html` will load the page with the web component mounted.
 
+## Host integration
+
+For apps embedding `<editor-wc>`, see [docs/host-integration](host-integration/README.md):
+
+- [Sidebar plugins](host-integration/SidebarPlugins.md) - register a host-owned sidebar panel via `setSidebarPlugins`
+- [Autosave flush before navigation](host-integration/AutosaveFlush.md) - `shouldFlushBeforeNavigation` and `flushPendingAutoSave`
+
+Mounting, attributes, events, and styling are covered in the [README](../README.md#usage).
+
 ## WebComponent Class
 
 `src/web-component.jsx` defines the Web Component and mounts the React components and store.

--- a/docs/host-integration/AutosaveFlush.md
+++ b/docs/host-integration/AutosaveFlush.md
@@ -1,0 +1,174 @@
+# Autosave flush before navigation
+
+The editor autosaves while the user is editing, but saves are throttled. If the
+host navigates away (React Router, another SPA router, or a full page leave)
+before that throttle fires, unsaved edits can be lost.
+
+`<editor-wc>` exposes a small API so the host can ask “is a save needed?” and,
+if so, force a save before leaving.
+
+## When to use this
+
+**Use it when** the host controls navigation away from a mounted editor that
+may have unsaved edits. This matters most for SPA hosts: a route change often
+does not unload the page, so the browser’s normal leave hooks may not run the
+way you expect.
+
+**Do not treat it as** a replacement for normal autosave. While the user stays
+on the page, the editor’s own autosave continues to run. Flush is for leaving.
+
+The web component also listens for `pagehide` / `beforeunload` internally and
+will try to flush on a full page leave. Host-driven SPA navigation still needs
+an explicit check + flush from the host.
+
+## API
+
+All of these functions are properties available on the `<editor-wc>` element.
+
+### `shouldFlushBeforeNavigation` (getter → boolean)
+
+`true` when autosave is enabled and the project has changed since the last
+known clean state (worth saving before leave).
+
+Use this to decide whether to block navigation or call flush at all.
+
+### `flushPendingAutoSave()` → `Promise`
+
+Force-saves now: skips the normal throttle, waits for any in-flight save if
+needed, then saves. Resolves when the flush finishes; rejects if the save
+fails.
+
+Safe to call when nothing is dirty - it no-ops when autosave is disabled or
+there is nothing to save.
+
+### Related getters (optional)
+
+| Property | Meaning |
+| --- | --- |
+| `hasPendingAutoSave` | `true` when the project is dirty and there is outstanding autosave work (queued, in flight, or still inside the throttle window). A subset of `shouldFlushBeforeNavigation`: dirty alone is not enough. |
+| `codeChangedSinceInitialLoad` | Whether project files/name/instructions differ from what was loaded initially. Useful for “has the user edited?” UI; not the same as the navigation flush check. |
+
+`shouldFlushBeforeNavigation` answers “should we save before leaving?” - autosave is enabled and the project has unsaved changes.
+
+`hasPendingAutoSave` answers “is autosave already mid-pipeline?” It requires dirty *and* outstanding work (a queued save, an in-flight request, or the post-save throttle window). Dirty alone is not enough: after an edit, there can be a quiet gap (for example a debounce pause) where the project has changed but nothing is queued or in flight yet. In that window `hasPendingAutoSave` is `false` even though the user’s work is still unsaved.
+
+That is why leave handling should use `shouldFlushBeforeNavigation` + `flushPendingAutoSave`, not `hasPendingAutoSave`. Checking only `hasPendingAutoSave` would skip the flush in those quiet gaps and risk losing edits. Use `hasPendingAutoSave` only if you need to know whether autosave work is already under way (for example UI that shows a saving indicator).
+
+## Vanilla JS / HTML example
+
+```js
+const editor = document.querySelector("editor-wc");
+
+async function leaveEditor(navigate) {
+  if (editor?.shouldFlushBeforeNavigation) {
+    try {
+      await Promise.race([
+        editor.flushPendingAutoSave(),
+        // Don't wait forever if the save hangs - still allow navigation after 10s.
+        new Promise((resolve) => setTimeout(resolve, 10_000)),
+      ]);
+    } catch {
+      // Save failed - still allow navigation so the user is not stuck.
+    }
+  }
+
+  navigate();
+}
+```
+
+Check first if you want to avoid an unnecessary round trip; calling flush
+unconditionally is also fine when you are about to leave anyway.
+
+## React / SPA example
+
+Pattern used by Code Classroom (`editor-standalone`):
+
+1. A React Router blocker asks `editor.shouldFlushBeforeNavigation`.
+2. If true, navigation pauses.
+3. The host awaits `flushPendingAutoSave()` (with a timeout).
+4. Navigation proceeds whether the flush succeeded, failed, or timed out.
+
+See `editor-standalone/src/hooks/useSaveProjectBeforeNavigation.js`
+(used in `ProjectComponentLoader`).
+
+A simplified version of that pattern:
+
+```js
+import { useEffect } from "react";
+import { useBlocker } from "react-router-dom";
+
+const FLUSH_TIMEOUT_MS = 10_000;
+
+function useSaveBeforeLeave() {
+  const blocker = useBlocker(({ currentLocation, nextLocation }) => {
+    if (currentLocation.pathname === nextLocation.pathname) return false;
+    const editor = document.querySelector("editor-wc");
+    return editor?.shouldFlushBeforeNavigation ?? false;
+  });
+
+  useEffect(() => {
+    if (blocker.state !== "blocked") return;
+
+    let cancelled = false;
+    const editor = document.querySelector("editor-wc");
+    const proceed = blocker.proceed;
+
+    const done = () => {
+      if (!cancelled) proceed();
+    };
+
+    if (!editor?.flushPendingAutoSave) {
+      done();
+      return;
+    }
+
+    const flush = Promise.resolve()
+      .then(() => editor.flushPendingAutoSave())
+      .catch(() => {
+        // If the save fails, swallow the error so navigation can still proceed.
+      });
+
+    Promise.race([
+      flush,
+      // Don't wait forever if the save hangs - still allow navigation after the timeout.
+      new Promise((resolve) => setTimeout(resolve, FLUSH_TIMEOUT_MS)),
+    ]).then(done);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [blocker.state, blocker.proceed]);
+}
+```
+
+## Checking vs always flushing
+
+| Approach | When it helps |
+| --- | --- |
+| Check `shouldFlushBeforeNavigation`, flush only if true | Skip work when nothing changed; good for blockers that should stay quiet on clean navigations |
+| Always `await flushPendingAutoSave()` before leave | Simpler control flow; flush no-ops when clean |
+
+Either is fine. Classroom uses the check so the router only blocks when a save
+is actually needed.
+
+## Timeouts and failures
+
+`flushPendingAutoSave` can reject (network error, API error, and so on). A
+hung request can also leave a `await` waiting forever.
+
+Recommended host behaviour:
+
+- Race the flush against a timeout (classroom uses 10 seconds).
+- On failure or timeout, **still allow navigation** - better to risk a rare
+  lost edit than trap the user on the page.
+- Optionally surface a toast or log; do not require the user to retry before
+  leaving unless your product explicitly wants that.
+
+## Leaving the editor
+
+| Behaviour | Who should flush |
+| --- | --- |
+| Leaving the editor without a full browser page unload (e.g. SPA route change: `/projects/a` → `/projects/b`) | Host - call the API from your router blocker / navigation guard. The document stays loaded, so `pagehide` / `beforeunload` do not run and the editor’s unload listeners never fire. |
+| Leaving the editor with a full browser page unload (tab close, refresh, navigating away from the site) | Editor also listens for `pagehide` / `beforeunload` and attempts a flush. Hosts may still want `beforeunload` UX (“you have unsaved changes”) based on `shouldFlushBeforeNavigation`. |
+
+If your app can leave the editor without unloading the page (typical SPA routing), do not rely on full-page unload hooks alone - flush from the host before navigation proceeds.

--- a/docs/host-integration/AutosaveFlush.md
+++ b/docs/host-integration/AutosaveFlush.md
@@ -45,14 +45,14 @@ there is nothing to save.
 
 | Property | Meaning |
 | --- | --- |
-| `hasPendingAutoSave` | `true` when the project is dirty and there is outstanding autosave work (queued, in flight, or still inside the throttle window). A subset of `shouldFlushBeforeNavigation`: dirty alone is not enough. |
+| `hasPendingAutoSave` | `true` when the project is dirty and autosave work is already pending (queued, in-flight, or still inside the post-save throttle window). It can be `false` even when `shouldFlushBeforeNavigation` is `true` (for example right after an edit, before a save has been queued). Hosts should primarily default to `shouldFlushBeforeNavigation` when deciding whether to flush. |
 | `codeChangedSinceInitialLoad` | Whether project files/name/instructions differ from what was loaded initially. Useful for “has the user edited?” UI; not the same as the navigation flush check. |
 
 `shouldFlushBeforeNavigation` answers “should we save before leaving?” - autosave is enabled and the project has unsaved changes.
 
-`hasPendingAutoSave` answers “is autosave already mid-pipeline?” It requires dirty *and* outstanding work (a queued save, an in-flight request, or the post-save throttle window). Dirty alone is not enough: after an edit, there can be a quiet gap (for example a debounce pause) where the project has changed but nothing is queued or in flight yet. In that window `hasPendingAutoSave` is `false` even though the user’s work is still unsaved.
+`hasPendingAutoSave` answers “is the editor already saving (or about to save) the current changes?” It becomes `true` when a save has been queued, is currently in progress, or the editor is still in the short window right after a save. Right after an edit, there can be a brief pause before the editor starts that save, so the project is still dirty even when `hasPendingAutoSave` is `false`.
 
-That is why leave handling should use `shouldFlushBeforeNavigation` + `flushPendingAutoSave`, not `hasPendingAutoSave`. Checking only `hasPendingAutoSave` would skip the flush in those quiet gaps and risk losing edits. Use `hasPendingAutoSave` only if you need to know whether autosave work is already under way (for example UI that shows a saving indicator).
+That is why hosts should use `shouldFlushBeforeNavigation` + `flushPendingAutoSave` when leaving, not `hasPendingAutoSave`. Use `hasPendingAutoSave` only if you need to show save progress (for example UI that displays a “saving…” state).
 
 ## Vanilla JS / HTML example
 

--- a/docs/host-integration/README.md
+++ b/docs/host-integration/README.md
@@ -15,3 +15,12 @@ For mounting, attributes, events, and styling, start with the
 | --- | --- |
 | [Sidebar plugins](SidebarPlugins.md) | Add a host-owned panel (and optional header buttons) to the editor sidebar |
 | [Autosave flush](AutosaveFlush.md) | Force-save dirty work before SPA or page navigation leaves the editor |
+
+## Design notes
+
+Background from the feedback-panel / host-integration investigation. Useful
+context for the team; not required reading to call the APIs above.
+
+| Note | What it covers |
+| --- | --- |
+| [Feedback panel investigation](design-notes/feedback-panel-investigation.md) | Why React-across-the-WC-boundary is unsafe, the options we considered, and what shipped (1a) vs what was only explored (Alt 4) |

--- a/docs/host-integration/README.md
+++ b/docs/host-integration/README.md
@@ -1,0 +1,17 @@
+# Hosting `<editor-wc>`
+
+Guides for apps that embed the editor web component. These pages describe the
+host-facing APIs on `<editor-wc>` itself - what to call, when, and how - in
+plain JavaScript and HTML. React hosts can use the same APIs; where helpful we
+point at real usage in `editor-standalone`.
+
+For mounting, attributes, events, and styling, start with the
+[README](../../README.md#usage) and
+[Web Component notes](../WebComponent.md).
+
+## Host APIs
+
+| Guide | What it covers |
+| --- | --- |
+| [Sidebar plugins](SidebarPlugins.md) | Add a host-owned panel (and optional header buttons) to the editor sidebar |
+| [Autosave flush](AutosaveFlush.md) | Force-save dirty work before SPA or page navigation leaves the editor |

--- a/docs/host-integration/SidebarPlugins.md
+++ b/docs/host-integration/SidebarPlugins.md
@@ -28,8 +28,9 @@ on) and `with_sidebar="true"`.
 
 When the host app is a React app, only serialisable config should cross the
 web component boundary. Do not pass React components, JSX, or functions for
-the editor to render - the host and the editor should be considered separate
-React trees (when both use React), and sharing them that way breaks.
+the editor to render. Treat the host and editor as separate React trees
+(when both use React) - and avoid sharing React elements across the web
+component boundary.
 
 ```text
 Host page                          <editor-wc> (shadow DOM)

--- a/docs/host-integration/SidebarPlugins.md
+++ b/docs/host-integration/SidebarPlugins.md
@@ -245,6 +245,10 @@ function FeedbackSidebar({ children }) {
       if (editor.shadowRoot) start();
       else {
         const id = setInterval(() => {
+          if (cancelled) {
+            clearInterval(id);
+            return;
+          }
           if (editor.shadowRoot) {
             clearInterval(id);
             start();

--- a/docs/host-integration/SidebarPlugins.md
+++ b/docs/host-integration/SidebarPlugins.md
@@ -287,3 +287,7 @@ is unsafe across separate React bundles and should not be used for new work.
 
 **Built-in panels** - Plugins sit alongside `sidebar_options`. You still need
 the `with_sidebar="true"` attribute on `<editor-wc>` for the sidebar to show at all.
+
+## Further reading
+
+- Why this shape: [Feedback panel investigation](design-notes/feedback-panel-investigation.md)

--- a/docs/host-integration/SidebarPlugins.md
+++ b/docs/host-integration/SidebarPlugins.md
@@ -1,0 +1,289 @@
+# Sidebar plugins
+
+The editor features an API that allows you to add a custom panel to the editor sidebar from the host page - without forking
+`editor-ui`. The web component draws the sidebar chrome (icon, heading, empty
+mount points). Your host fills those mount points with its own UI.
+
+A concrete example is teacher feedback in Code Classroom
+(`editor-standalone`): that app registers a "feedback" plugin, then portals
+its React panel into the slots the editor exposes.
+
+## When to use this
+
+Use it when the host needs product-specific sidebar UI that does not belong
+in `editor-ui` itself (feedback, classroom tools, and similar).
+
+Do not use it for panels the editor already ships. Turn those on with the
+`sidebar_options` attribute (`"file"`, `"settings"`, `"instructions"`, and so
+on) and `with_sidebar="true"`.
+
+## How it works
+
+1. The host calls `setSidebarPlugins([...])` on `<editor-wc>` with a plain JS object.
+2. The editor re-renders and adds a sidebar icon for each plugin.
+3. When a plugin panel is open, the editor creates empty `<div>` slots inside
+   its shadow DOM.
+4. The host finds those slots and attaches its own content (portals in React,
+   or plain DOM in vanilla JS).
+
+When the host app is a React app, only serialisable config should cross the
+web component boundary. Do not pass React components, JSX, or functions for
+the editor to render - the host and the editor should be considered separate
+React trees (when both use React), and sharing them that way breaks.
+
+```text
+Host page                          <editor-wc> (shadow DOM)
+─────────                          ─────────────────────────
+setSidebarPlugins({ name, … })  →  sidebar icon + empty slot <div>s
+find slot in shadowRoot         ←  data-sidebar-plugin / …-slot
+attach host UI into the <div>   →  your panel / buttons appear
+```
+
+## API
+
+### `setSidebarPlugins(plugins)`
+
+Replaces the full list of host sidebar plugins and remounts the React app
+inside the web component.
+
+```js
+editor.setSidebarPlugins([
+  {
+    name: "feedback",
+    title: "Teacher feedback",
+    heading: "Feedback",
+    icon: "rate_review",
+    position: "top",
+    autoOpen: true,
+    slots: ["panel", "buttons"],
+  },
+]);
+```
+
+Passing `[]` clears all host plugins.
+
+### `sidebarPlugins`
+
+The current plugin list on the element. Host helpers often read this so they
+can add a plugin without wiping ones already registered:
+
+```js
+const existing = editor.sidebarPlugins || [];
+```
+
+### Plugin shape
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `name` | string | Stable id. Used as the sidebar option key and in slot selectors. Treat as unique. |
+| `title` | string | Tooltip / accessible label on the sidebar icon |
+| `heading` | string | Heading shown at the top of the open panel |
+| `icon` | string | [Material Symbols](https://fonts.google.com/icons) name (e.g. `"rate_review"`). The editor renders the icon. |
+| `position` | `"top"` \| `"bottom"` | Where the icon sits in the sidebar bar. Defaults to `"top"`. |
+| `autoOpen` | boolean | If `true`, this panel opens when the editor first shows it. Only the first matching plugin wins. |
+| `slots` | `("panel" \| "buttons")[]` | Which empty mount points to create. `"panel"` is the main body; `"buttons"` is the panel header action area. |
+
+### Slot markup
+
+For a plugin with `name: "feedback"` and `slots: ["panel", "buttons"]`, the
+editor creates empty elements like:
+
+```html
+<div
+  part="sidebar-plugin-panel-container"
+  data-sidebar-plugin="feedback"
+  data-sidebar-plugin-slot="panel"
+></div>
+
+<div
+  part="sidebar-plugin-button-container"
+  data-sidebar-plugin="feedback"
+  data-sidebar-plugin-slot="buttons"
+></div>
+```
+
+These live in the **shadow DOM**, so `document.querySelector(...)` from the
+light DOM will not find them. Query `editor.shadowRoot` instead. The `part`
+attributes are there so hosts can style the containers with `::part(...)` if
+needed.
+
+Slots appear when the plugin panel is mounted (including when `autoOpen` opens
+it). They can appear and disappear as the user opens and closes panels, so do
+not query for them only once at startup - watch for changes and re-attach when
+a slot node is created or replaced.
+
+## Vanilla JS / HTML example
+
+```html
+<script src="https://editor-static.raspberrypi.org/releases/<version>/web-component.js"></script>
+
+<editor-wc with_sidebar="true" sidebar_options='["file","settings"]'></editor-wc>
+
+<script type="module">
+  await customElements.whenDefined("editor-wc");
+
+  const editor = document.querySelector("editor-wc");
+
+  editor.setSidebarPlugins([
+    {
+      name: "notes",
+      title: "Notes",
+      heading: "Notes",
+      icon: "sticky_note_2",
+      position: "top",
+      autoOpen: false,
+      slots: ["panel"],
+    },
+  ]);
+
+  // Shadow root is created when the element connects - wait if needed.
+  const waitForShadowRoot = () =>
+    new Promise((resolve) => {
+      if (editor.shadowRoot) {
+        resolve(editor.shadowRoot);
+        return;
+      }
+      const id = setInterval(() => {
+        if (editor.shadowRoot) {
+          clearInterval(id);
+          resolve(editor.shadowRoot);
+        }
+      }, 50);
+    });
+
+  const root = await waitForShadowRoot();
+
+  const attachPanel = () => {
+    const slot = root.querySelector(
+      '[data-sidebar-plugin="notes"][data-sidebar-plugin-slot="panel"]',
+    );
+    if (!slot || slot.dataset.hostAttached) return;
+
+    slot.dataset.hostAttached = "true";
+    const content = document.createElement("div");
+    content.textContent = "Host-owned notes go here.";
+    slot.appendChild(content);
+  };
+
+  // Open the panel (or set autoOpen: true) before the slot exists.
+  // Then watch - slots are created/destroyed as panels open and close.
+  new MutationObserver(attachPanel).observe(root, {
+    childList: true,
+    subtree: true,
+  });
+  attachPanel();
+</script>
+```
+
+## React example
+
+You do not need React to use this API. A React host typically:
+
+1. Builds a plain plugin object.
+2. Calls `setSidebarPlugins` once the custom element is defined.
+3. Observes the shadow root for slot nodes.
+4. Uses `createPortal` to render host components into those nodes.
+
+In `editor-standalone` that looks like:
+
+| Step | Where |
+| --- | --- |
+| Plugin config | `src/plugins/feedbackPanelPlugin.js` (`createFeedbackPanelPlugin`) |
+| Register + observe slots | `src/utils/pluginsHelper.js` (`renderSidebarPlugin`, `observeSidebarPluginSlots`) |
+| Wire-up + portals | `src/components/Editor/SchoolProject/SchoolProject.jsx` |
+
+A simplified version of that pattern:
+
+```js
+import { createPortal } from "react-dom";
+import { useEffect, useState } from "react";
+
+const plugin = {
+  name: "feedback",
+  title: "Teacher feedback",
+  heading: "Feedback",
+  icon: "rate_review",
+  position: "top",
+  autoOpen: true,
+  slots: ["panel", "buttons"],
+};
+
+function FeedbackSidebar({ children }) {
+  const [panelEl, setPanelEl] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    let observer;
+
+    customElements.whenDefined("editor-wc").then(() => {
+      const editor = document.querySelector("editor-wc");
+      if (!editor) return;
+
+      const existing = editor.sidebarPlugins || [];
+      if (!existing.some((p) => p.name === plugin.name)) {
+        editor.setSidebarPlugins([...existing, plugin]);
+      }
+
+      const tryAttach = () => {
+        const root = editor.shadowRoot;
+        if (!root || cancelled) return;
+        const slot = root.querySelector(
+          '[data-sidebar-plugin="feedback"][data-sidebar-plugin-slot="panel"]',
+        );
+        setPanelEl(slot || null);
+      };
+
+      const start = () => {
+        if (!editor.shadowRoot || cancelled) return;
+        tryAttach();
+        observer = new MutationObserver(tryAttach);
+        observer.observe(editor.shadowRoot, { childList: true, subtree: true });
+      };
+
+      // shadowRoot may not exist until connectedCallback runs
+      if (editor.shadowRoot) start();
+      else {
+        const id = setInterval(() => {
+          if (editor.shadowRoot) {
+            clearInterval(id);
+            start();
+          }
+        }, 50);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+      observer?.disconnect();
+    };
+  }, []);
+
+  return panelEl ? createPortal(children, panelEl) : null;
+}
+```
+
+`editor-standalone`'s `observeSidebarPluginSlots` also polls briefly until the
+shadow root appears (`attachShadow` does not fire light-DOM mutation observers)
+and cleans up cleanly on unmount - prefer that helper if you are in that app.
+
+## Pitfalls
+
+**Shadow DOM** - Slot nodes are not in the light DOM. Always search
+`editor.shadowRoot`.
+
+**Register by name** - `setSidebarPlugins` replaces the whole list. If you add
+plugins one at a time, merge with `sidebarPlugins` first and skip when `name`
+is already present. Re-registering the same name with a different `autoOpen`
+will not re-apply auto-open once the panel has already been shown.
+
+**Remounts** - Calling `setSidebarPlugins` remounts the React tree inside the
+web component. Prefer registering once when you know you need the plugin, not
+on every render.
+
+**Do not pass React across the boundary** - Prefer non-React slots with
+host-owned content. An older code path (`panel()` / `buttons()` functions that
+return JSX for the editor to render) still exists for transitional hosts; but this should be considered deprecated as it
+is unsafe across separate React bundles and should not be used for new work.
+
+**Built-in panels** - Plugins sit alongside `sidebar_options`. You still need
+the `with_sidebar="true"` attribute on `<editor-wc>` for the sidebar to show at all.

--- a/docs/host-integration/design-notes/feedback-panel-investigation.md
+++ b/docs/host-integration/design-notes/feedback-panel-investigation.md
@@ -1,0 +1,144 @@
+# Feedback Panel Investigation
+
+> **Design notes** from the feedback-panel investigation (also drafted in
+> [editor-ui#1538](https://github.com/RaspberryPiFoundation/editor-ui/pull/1538)).
+> They explain *why* we moved to serialisable plugin config and DOM slots.
+>
+> For the current host API, see
+> [Sidebar plugins](../SidebarPlugins.md).
+
+## Summary
+
+The classroom feedback panel is injected from `editor-standalone` into
+`editor-ui` via `<editor-wc>` (`setSidebarPlugins`). At the time of this
+investigation, the plugin contract passed React components, functions, and
+JSX from standalone's React bundle into `editor-ui`, which then rendered them
+in its own React tree (**React slots** - unsafe across separate React
+bundles).
+
+That broke when standalone moved to React 19 while editor-ui was still on
+React 18. Aligning versions fixed the crash, but the pattern remained risky.
+
+The safe pattern is **DOM slots** (empty mount `<div>`s owned by editor-ui)
+plus host portals into those nodes. Serialisable config crosses the web
+component boundary; React does not.
+
+Two spikes explored fixes: Alternative 1a (DOM slots - shipped) and
+Alternative 4 (React `<Editor />` import - explored only).
+
+## Code spikes
+
+| Spike | Outcome | Links |
+|---|---|---|
+| **1a - DOM slots + portals** | Shipped as sidebar plugins host API | [editor-ui#1532](https://github.com/RaspberryPiFoundation/editor-ui/pull/1532), [editor-standalone#996](https://github.com/RaspberryPiFoundation/editor-standalone/pull/996) |
+| **4 - React `<Editor />` import** | Explored only; not a current host contract | [editor-ui#1533](https://github.com/RaspberryPiFoundation/editor-ui/pull/1533), [editor-standalone#997](https://github.com/RaspberryPiFoundation/editor-standalone/pull/997) |
+
+## React slots vs DOM slots
+
+| Pattern | What crosses the boundary | Safe? |
+|---|---|---|
+| **React slots** | Components, element objects, functions that return JSX - editor-ui renders them in its React tree | No |
+| **DOM slots** | Plain `HTMLElement` mount points; the host portals its own React content into them | Yes |
+
+At the time of the investigation, feedback used a hybrid: editor-ui rendered
+standalone **React-slot** JSX (`panel()` / `buttons()` / icon components) to
+create mount points (unsafe), then standalone portaled the real UI into those
+DOM nodes (safe). That mix was the source of confusion.
+
+Portaling host React into a plain DOM mount point is safe as long as editor-ui
+never reconciles that content. Details: [Sidebar plugins](../SidebarPlugins.md).
+
+### What was unsafe (React slots)
+
+```js
+{
+  name: "feedback",
+  icon: FeedbackIcon,                // React component from standalone
+  buttons: () => <div ref={...} />,  // JSX from standalone's React
+  panel: () => <div ref={...} />,    // JSX from standalone's React
+  // ...
+}
+```
+
+Editor-ui called `plugin.panel()` / `plugin.buttons()` and rendered
+`plugin.icon` inside its own React tree. Separate React instances do not share
+the same internal contract (`$$typeof`, fibers, hooks dispatcher, context) -
+that mismatch caused the React 18/19 crash. Aligning both apps on React 19
+stopped the crash but did not fix the design: future version skew or hooks in
+plugin components would still break.
+
+```text
+editor-standalone React
+  |  passes React-slot functions/components
+  v
+editor-ui React  <-- crash risk: renders host React elements
+  |  creates empty <div>s
+  v
+plain DOM <div>
+  ^
+  |  standalone createPortal(FeedbackPanel)  <-- this part is fine
+editor-standalone React
+```
+
+## Alternatives considered
+
+### 1a) DOM slots + portals (shipped)
+
+Serialisable plugin config + empty DOM mount points + host portals. No
+React-slot crossing. Live API: [Sidebar plugins](../SidebarPlugins.md).
+
+| Before (React slots) | After (DOM slots) |
+|---|---|
+| `icon: FeedbackIcon`, `panel: () => <div ref=…>` | `icon: "rate_review"`, `slots: ["panel"]` |
+| Editor-ui called `plugin.panel()` - host JSX in editor-ui's tree | Editor-ui renders its own empty `<div>`s |
+| Ref callbacks on host JSX rendered inside editor-ui | Host queries shadow DOM and portals in |
+
+```text
+editor-standalone
+  │  serialisable config  ──►  setSidebarPlugins()
+  │  finds DOM slot <div>s  ◄──  PluginSlot in shadow DOM
+  └── createPortal(FeedbackPanel) ──►  into those DOM slots
+```
+
+Classroom wiring: `feedbackPanelPlugin.js`, `pluginsHelper.js`,
+`SchoolProject.jsx` in `editor-standalone`.
+
+### 1b) Formal DOM-slot API (deferred)
+
+Same DOM-slot model as 1a, but with explicit register / slot-ready /
+unregister events instead of informal shadow-DOM observation. Consider if
+discovery proves brittle or more host plugins appear.
+
+### 2) Host UI outside `editor-wc` (not chosen)
+
+Render feedback entirely in standalone around the editor. Safest boundary,
+but weaker sidebar UX and less reusable as a platform pattern.
+
+### 3) Shared React singleton / externals (avoid)
+
+Make `editor-wc` use the host's React so React slots might work. Undermines
+the self-contained script-tag embed (external consumers often have no React,
+or a different version). Prefer DOM slots (1a) or a real React import (4).
+
+### 4) React `<Editor />` import (explored)
+
+Import `<Editor />` from `editor-ui` into `editor-standalone` for one React
+tree and normal composition. External embeds would need a thin `editor-wc`
+adapter or an explicit deprecation path.
+
+The spike showed this is not “just swap the import”: React UI can share a
+tree, but runtime assets (Pyodide, html-renderer, scratch-frame) still load
+over HTTP separately. Production needs same-origin (or CDN) asset packaging,
+and Redux does not merge automatically - start with props/callbacks.
+
+Friction: transpile linked `editor-ui` source, shadow-DOM assumptions in
+runners/modals, yarn-link / Docker packaging vs today's `editor-static` model.
+
+## Recommended direction
+
+| Timeframe | Direction |
+|---|---|
+| Immediate | **1a - DOM slots** (**shipped** - [Sidebar plugins](../SidebarPlugins.md)) |
+| If staying on `editor-wc` | Evolve 1a → **1b** if DOM-slot discovery gets brittle |
+| Strategic (first-party) | **4 - React `<Editor />`** for standalone; keep `editor-wc` adapter for external hosts if decided |
+| Avoid | Investigation-time **React slots**; **3** (shared React singleton) |


### PR DESCRIPTION
## Summary

Adds documentation in `editor-ui` for two host-facing web component APIs that
hosts (including Code Classroom / `editor-standalone`) already use:

1. **Sidebar plugins** - register a host-owned sidebar panel via
   `setSidebarPlugins` (serialisable config + DOM slots; host portals content)
2. **Autosave flush** - `shouldFlushBeforeNavigation` /
   `flushPendingAutoSave` so SPA hosts can save dirty work before navigation

Guides are written for both internal and external embedders: why/when to use
each API, vanilla JS/HTML examples, and React / codebase pointers.

## What this adds

### Host guides (`docs/host-integration/`)

| File | Purpose |
| --- | --- |
| `README.md` | Index for host integration docs |
| `SidebarPlugins.md` | Plugin shape, DOM slots, vanilla + React examples, pitfalls |
| `AutosaveFlush.md` | Flush API, leave-with/without page unload, timeouts/failures |

### Design notes (optional reading)

| File | Purpose |
| --- | --- |
| `design-notes/feedback-panel-investigation.md` | Why React-across-the-WC-boundary was unsafe, React slots vs DOM slots, alternatives considered, what shipped (1a) vs explored (Alt 4) |

### Notes and links also added to..

- `README.md` - lists the new WC methods with links to the guides
- `docs/WebComponent.md` - host integration section
- `AGENTS.md` - further-reading links

