### PR TITLE
fix: clean up preview page

### DIFF
--- a/cypress/e2e/spec-wc-pyodide.cy.js
+++ b/cypress/e2e/spec-wc-pyodide.cy.js
@@ -8,6 +8,7 @@ import {
   getPythonConsoleOutput,
   getTextOutputTab,
   makeNewFile,
+  openFilePanel,
   runCode,
   runProject,
   setCodeEditorContent,
@@ -75,12 +76,14 @@ describe("Running the code with pyodide", () => {
 
   it("runs a simple program to write to a file", () => {
     runCode('with open("output.txt", "w") as f:\n\tf.write("Hello world")');
+    openFilePanel();
     getFileButtonByName("output.txt").click();
     getEditorShadow().find(".cm-editor").should("contain", "Hello world");
   });
 
   it("errors when trying to write to an existing file in 'x' mode", () => {
     runCode('with open("output.txt", "w") as f:\n\tf.write("Hello world")');
+    openFilePanel();
     getFileButtonByName("output.txt").should("be.visible");
     runCode('with open("output.txt", "x") as f:\n\tf.write("Something else")');
     getErrorMessage().should(
@@ -94,6 +97,7 @@ describe("Running the code with pyodide", () => {
     setCodeEditorContent(
       'with open("output.txt", "a") as f:\n\tf.write("Hello again world")',
     );
+    openFilePanel();
     getFileButtonByName("output.txt").click();
     getEditorShadow()
       .findByRole("button", { name: /run/i })
@@ -110,6 +114,7 @@ describe("Running the code with pyodide", () => {
   it("runs a program with multiple files", () => {
     setCodeEditorContent(`from my_number import NUMBER\nprint(NUMBER)\n`);
 
+    openFilePanel();
     makeNewFile("my_number.py");
 
     setCodeEditorContent(`NUMBER = 42\n`);
@@ -122,6 +127,7 @@ describe("Running the code with pyodide", () => {
   it("reloads imported local files between code runs", () => {
     setCodeEditorContent(`from helper import b\nb()`);
 
+    openFilePanel();
     makeNewFile("helper.py");
 
     setCodeEditorContent(`def b():\n  print('one')`);

--- a/cypress/e2e/spec-wc-pyodide.cy.js
+++ b/cypress/e2e/spec-wc-pyodide.cy.js
@@ -8,7 +8,7 @@ import {
   getPythonConsoleOutput,
   getTextOutputTab,
   makeNewFile,
-  openFilePanel,
+  ensureFilePanelOpen,
   runCode,
   runProject,
   setCodeEditorContent,
@@ -76,14 +76,14 @@ describe("Running the code with pyodide", () => {
 
   it("runs a simple program to write to a file", () => {
     runCode('with open("output.txt", "w") as f:\n\tf.write("Hello world")');
-    openFilePanel();
+    ensureFilePanelOpen();
     getFileButtonByName("output.txt").click();
     getEditorShadow().find(".cm-editor").should("contain", "Hello world");
   });
 
   it("errors when trying to write to an existing file in 'x' mode", () => {
     runCode('with open("output.txt", "w") as f:\n\tf.write("Hello world")');
-    openFilePanel();
+    ensureFilePanelOpen();
     getFileButtonByName("output.txt").should("be.visible");
     runCode('with open("output.txt", "x") as f:\n\tf.write("Something else")');
     getErrorMessage().should(
@@ -97,7 +97,7 @@ describe("Running the code with pyodide", () => {
     setCodeEditorContent(
       'with open("output.txt", "a") as f:\n\tf.write("Hello again world")',
     );
-    openFilePanel();
+    ensureFilePanelOpen();
     getFileButtonByName("output.txt").click();
     getEditorShadow()
       .findByRole("button", { name: /run/i })
@@ -114,7 +114,7 @@ describe("Running the code with pyodide", () => {
   it("runs a program with multiple files", () => {
     setCodeEditorContent(`from my_number import NUMBER\nprint(NUMBER)\n`);
 
-    openFilePanel();
+    ensureFilePanelOpen();
     makeNewFile("my_number.py");
 
     setCodeEditorContent(`NUMBER = 42\n`);
@@ -127,7 +127,7 @@ describe("Running the code with pyodide", () => {
   it("reloads imported local files between code runs", () => {
     setCodeEditorContent(`from helper import b\nb()`);
 
-    openFilePanel();
+    ensureFilePanelOpen();
     makeNewFile("helper.py");
 
     setCodeEditorContent(`def b():\n  print('one')`);

--- a/cypress/helpers/editor.js
+++ b/cypress/helpers/editor.js
@@ -127,12 +127,10 @@ export const dragEditorResizeHandle = (
 export const dragSidebarResizeHandle = ({ deltaX = 80 } = {}) =>
   dragHandle(() => getSidebarResizeHandle(), { deltaX, deltaY: 0 });
 
-// The sidebar option toggles, so only click it when the panel is closed. Which
-// panel opens by default depends on the host's attributes, so tests that need
-// the file list should call this rather than assume it is already showing.
-export const openFilePanel = () =>
+export const ensureFilePanelOpen = () =>
   getFilePanelButton().then(($button) => {
-    if (!$button.hasClass("sidebar__bar-option--selected")) {
+    const alreadyOpen = $button.hasClass("sidebar__bar-option--selected");
+    if (!alreadyOpen) {
       cy.wrap($button).click();
     }
   });

--- a/cypress/helpers/editor.js
+++ b/cypress/helpers/editor.js
@@ -34,6 +34,9 @@ export const getFileButtonByName = (filename) =>
 const getSettingsButton = () =>
   getEditorShadow().find("[title='Settings']").first();
 
+const getFilePanelButton = () =>
+  getEditorShadow().find("[title='Project files']").first();
+
 export const getProgramInput = () =>
   getEditorShadow().findByRole("textbox", { name: "Text input" });
 
@@ -124,8 +127,15 @@ export const dragEditorResizeHandle = (
 export const dragSidebarResizeHandle = ({ deltaX = 80 } = {}) =>
   dragHandle(() => getSidebarResizeHandle(), { deltaX, deltaY: 0 });
 
+// The sidebar option toggles, so only click it when the panel is closed. Which
+// panel opens by default depends on the host's attributes, so tests that need
+// the file list should call this rather than assume it is already showing.
 export const openFilePanel = () =>
-  getEditorShadow().find("[title='Project files']").click();
+  getFilePanelButton().then(($button) => {
+    if (!$button.hasClass("sidebar__bar-option--selected")) {
+      cy.wrap($button).click();
+    }
+  });
 
 export const checkEditorInitialized = () => {
   getEditorShadow().findByRole("button", { name: /run/i }).should("be.visible");

--- a/web-component.html
+++ b/web-component.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width" />
@@ -7,6 +7,10 @@
     <title>Editor Web component</title>
     <script type="module" src="/src/web-component.jsx"></script>
     <style>
+      * {
+        box-sizing: border-box;
+      }
+
       body {
         margin: 0;
         block-size: 100dvh;
@@ -39,7 +43,7 @@
         flex-wrap: wrap;
         gap: 0.5rem 1rem;
         padding: 1rem;
-        border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+        border-block-end: 1px solid gainsboro;
       }
 
       .sample-projects-bar a {
@@ -48,16 +52,15 @@
       }
 
       .debug {
-        margin: 1rem;
-        padding: 1rem;
-        background-color: WhiteSmoke;
-
         display: flex;
         flex-direction: column;
         align-items: flex-start;
         gap: 0.5rem;
+        padding: 1rem;
+        border-block-start: 1px solid gainsboro;
+        overflow-x: auto;
 
-        * {
+        > * {
           margin: 0;
         }
 
@@ -81,9 +84,9 @@
       </div>
       <div id="editor-component"></div>
       <div class="debug">
+        <button id="run-button">Run code</button>
         <p id="results"></p>
         <p id="project-identifier"></p>
-        <button id="run-button">Run code</button>
       </div>
     </main>
 

--- a/web-component.html
+++ b/web-component.html
@@ -134,11 +134,13 @@
           newWebComp.setAttribute("with_projectbar", "true");
           newWebComp.setAttribute("with_sidebar", "true");
           newWebComp.setAttribute("friendly_errors_enabled", "true");
+          newWebComp.setAttribute("editable_instructions", "true");
           // see "Offline support" section in README for more details
           newWebComp.setAttribute("offline_enabled", "true");
           newWebComp.setAttribute(
             "sidebar_options",
             JSON.stringify([
+              "projects",
               "instructions",
               "file",
               "images",

--- a/web-component.html
+++ b/web-component.html
@@ -7,63 +7,85 @@
     <title>Editor Web component</title>
     <script type="module" src="/src/web-component.jsx"></script>
     <style>
-      #root {
-        min-block-size: 100dvh;
-      }
       body {
-        display: flex;
-        flex-direction: column;
-        block-size: 100dvh;
         margin: 0;
+        block-size: 100dvh;
+        font-family: sans-serif;
       }
+
+      main {
+        block-size: 100%;
+        display: grid;
+        grid-template-rows: auto 1fr auto;
+      }
+
       #editor-component {
-        flex: 1 1 auto;
         display: flex;
-        min-block-size: 0;
       }
+
+      .editor-wc {
+        flex: 1;
+        display: flex;
+      }
+
+      ::part(editor-root) {
+        flex: 1;
+        block-size: 100%;
+      }
+
       .sample-projects-bar {
         flex: 0 0 auto;
         display: flex;
-        align-items: center;
-        gap: 12px;
-        padding: 10px 12px;
-        border-bottom: 1px solid rgba(0, 0, 0, 0.12);
-        background: #fff;
-        color: #111;
-        font-size: 14px;
-        font-family: sans-serif;
-        line-height: 1.4;
+        flex-wrap: wrap;
+        gap: 0.5rem 1rem;
+        padding: 1rem;
+        border-bottom: 1px solid rgba(0, 0, 0, 0.1);
       }
+
       .sample-projects-bar a {
         color: #005fb8;
         text-decoration: underline;
       }
-      .editor-wc {
-        flex: 1 1 auto;
+
+      .debug {
+        margin: 1rem;
+        padding: 1rem;
+        background-color: WhiteSmoke;
+
         display: flex;
-      }
-      ::part(editor-root) {
-        display: block;
-        flex: 1 1 auto;
-        max-block-size: 100dvh;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.5rem;
+
+        * {
+          margin: 0;
+        }
+
+        p:empty {
+          display: none;
+        }
       }
     </style>
   </head>
   <body>
-    <div class="sample-projects-bar" id="sample-projects-bar">
-      <span>Load Sample Projects:</span>
-      <a href="?project=blank-html-starter" >blank-html-starter</a>
-      <a href="?project=cool-html">cool-html</a>
-      <a href="?project=blank-python-starter">blank-python-starter</a>
-      <a href="?project=cool-python" >cool-python</a>
-      <a href="?project=python-plotly">python-plotly</a>
-      <a href="?project=cool-scratch">cool-scratch</a>
-      <a href="?project=astro-pi">astro-pi</a>
-    </div>
-    <div id="editor-component"></div>
-    <p id="results"></p>
-    <p id="project-identifier"></p>
-    <button id="run-button">Run code</button>
+    <main>
+      <div class="sample-projects-bar" id="sample-projects-bar">
+        <span>Load Sample Projects:</span>
+        <a href="?project=blank-html-starter">blank-html-starter</a>
+        <a href="?project=cool-html">cool-html</a>
+        <a href="?project=blank-python-starter">blank-python-starter</a>
+        <a href="?project=cool-python">cool-python</a>
+        <a href="?project=python-plotly">python-plotly</a>
+        <a href="?project=cool-scratch">cool-scratch</a>
+        <a href="?project=astro-pi">astro-pi</a>
+      </div>
+      <div id="editor-component"></div>
+      <div class="debug">
+        <p id="results"></p>
+        <p id="project-identifier"></p>
+        <button id="run-button">Run code</button>
+      </div>
+    </main>
 
     <script>
       const loadSampleProjectByName = async (projectName) => {
@@ -75,84 +97,85 @@
         return await res.text();
       };
 
+      document.addEventListener("DOMContentLoaded", async (e) => {
+        const queryParams = new URLSearchParams(window.location.search);
+        const projectName = queryParams.get("project");
+        const initialProject =
+          projectName && (await loadSampleProjectByName(projectName));
 
-    document.addEventListener("DOMContentLoaded", async (e) => {
-      const queryParams = new URLSearchParams(window.location.search);
-      const projectName = queryParams.get("project")
-      const initialProject = projectName && await loadSampleProjectByName(projectName);
+        let webComp;
 
-      let webComp;
-
-      // subscribe to the 'codeChanged' custom event which is pushed by the project react component
-      document.addEventListener("editor-codeChanged", function (e) {
-        const code = webComp.editorCode;
-      });
-
-      document.addEventListener("editor-runCompleted", (e) => {
-        document.getElementById("results").innerText = JSON.stringify(e.detail);
-      });
-
-      document.addEventListener("editor-projectIdentifierChanged", (e) => {
-        document.getElementById("project-identifier").innerText = e.detail;
-      });
-
-      const sampleBar = document.getElementById("sample-projects-bar");
-      const editorContainer = document.getElementById("editor-component");
-
-      const createWebComponent = (initialProject = null) => {
-        const initialProjectObject = initialProject
-          ? JSON.parse(initialProject)
-          : null;
-        const newWebComp = document.createElement("editor-wc");
-
-        newWebComp.setAttribute("with_projectbar", "true");
-        newWebComp.setAttribute("with_sidebar", "true");
-        newWebComp.setAttribute("friendly_errors_enabled", "true");
-        // see "Offline support" section in README for more details
-        newWebComp.setAttribute("offline_enabled", "true");
-        newWebComp.setAttribute(
-          "sidebar_options",
-          JSON.stringify([
-            "instructions",
-            "file",
-            "images",
-            "download",
-            "settings",
-            "info",
-          ]),
-        );
-
-        newWebComp.setAttribute("code", "");
-        newWebComp.setAttribute("class", "editor-wc");
-        newWebComp.setAttribute("host_styles", JSON.stringify([]));
-        const scratchApiEndpoint = new URL(
-          ".",
-          window.location.href,
-        ).href.replace(/\/$/, "");
-        newWebComp.setAttribute("scratch_api_endpoint", scratchApiEndpoint);
-
-        queryParams.forEach((value, key) => {
-          newWebComp.setAttribute(key, value);
+        // subscribe to the 'codeChanged' custom event which is pushed by the project react component
+        document.addEventListener("editor-codeChanged", function (e) {
+          const code = webComp.editorCode;
         });
 
-        if (initialProject) {
-          newWebComp.setAttribute(
-            "sense_hat_always_enabled",
-            initialProjectObject.sense_hat_always_enabled || false,
+        document.addEventListener("editor-runCompleted", (e) => {
+          document.getElementById("results").innerText = JSON.stringify(
+            e.detail,
           );
-          newWebComp.setAttribute("initial_project", initialProject);
-        }
+        });
 
-        return newWebComp;
-      };
+        document.addEventListener("editor-projectIdentifierChanged", (e) => {
+          document.getElementById("project-identifier").innerText = e.detail;
+        });
 
-      webComp = createWebComponent(initialProject);
-      editorContainer.prepend(webComp);
-      
-      document.getElementById("run-button").onclick = (event) => {
-        webComp.rerunCode();
-      };
-    });
-  </script>
+        const editorContainer = document.getElementById("editor-component");
+
+        const createWebComponent = (initialProject = null) => {
+          const initialProjectObject = initialProject
+            ? JSON.parse(initialProject)
+            : null;
+          const newWebComp = document.createElement("editor-wc");
+
+          newWebComp.setAttribute("with_projectbar", "true");
+          newWebComp.setAttribute("with_sidebar", "true");
+          newWebComp.setAttribute("friendly_errors_enabled", "true");
+          // see "Offline support" section in README for more details
+          newWebComp.setAttribute("offline_enabled", "true");
+          newWebComp.setAttribute(
+            "sidebar_options",
+            JSON.stringify([
+              "instructions",
+              "file",
+              "images",
+              "download",
+              "settings",
+              "info",
+            ]),
+          );
+
+          newWebComp.setAttribute("code", "");
+          newWebComp.setAttribute("class", "editor-wc");
+          newWebComp.setAttribute("host_styles", JSON.stringify([]));
+          const scratchApiEndpoint = new URL(
+            ".",
+            window.location.href,
+          ).href.replace(/\/$/, "");
+          newWebComp.setAttribute("scratch_api_endpoint", scratchApiEndpoint);
+
+          queryParams.forEach((value, key) => {
+            newWebComp.setAttribute(key, value);
+          });
+
+          if (initialProject) {
+            newWebComp.setAttribute(
+              "sense_hat_always_enabled",
+              initialProjectObject.sense_hat_always_enabled || false,
+            );
+            newWebComp.setAttribute("initial_project", initialProject);
+          }
+
+          return newWebComp;
+        };
+
+        webComp = createWebComponent(initialProject);
+        editorContainer.prepend(webComp);
+
+        document.getElementById("run-button").onclick = (event) => {
+          webComp.rerunCode();
+        };
+      });
+    </script>
   </body>
 </html>

--- a/web-component.html
+++ b/web-component.html
@@ -7,6 +7,8 @@
     <title>Editor Web component</title>
     <script type="module" src="/src/web-component.jsx"></script>
     <style>
+      @import url("https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100..900;1,100..900&display=swap");
+
       * {
         box-sizing: border-box;
       }
@@ -14,7 +16,7 @@
       body {
         margin: 0;
         block-size: 100dvh;
-        font-family: sans-serif;
+        font-family: "Roboto", sans-serif;
       }
 
       main {


### PR DESCRIPTION
## Tidy up the web component preview page

Cosmetic cleanup of the local demo page at `web-component.html` — no changes to the editor itself.

- Restructure the layout as a `main` CSS grid, and group the debug output (results, project identifier, run button) into its own panel
- Rewrite the styles: consistent `rem` spacing, logical properties, `box-sizing`
- Enable the `projects` sidebar panel and `editable_instructions` so both can be previewed locally
- Re-indent the inline script to standard Prettier formatting
- Open the file panel explicitly in the pyodide e2e specs, they relied on it being the sidebar's default panel, which `editable_instructions` changes

Best reviewed with whitespace changes hidden — most of the line count is the script re-indent.

<img width="248" height="292" alt="Screenshot 2026-08-11 at 15 58 12" src="https://github.com/user-attachments/assets/f03b2d83-3ff9-4926-aa5b-d292d04f7dbc" />

## Why 

- Makes the preview more responsive (particularly the picker and the debug menu)
- Prettier and cleaner
- Shows more panels


https://github.com/user-attachments/assets/6ed199c9-38bb-4225-a765-49a747f9e62d

