### PR TITLE
Simpler inline syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@juggle/resize-observer": "^3.3.1",
     "@raspberrypifoundation/design-system-react": "^2.9.2",
     "@raspberrypifoundation/python-friendly-error-messages": "0.8.0",
-    "@raspberrypifoundation/rpf-markdown-core": "^0.1.2",
+    "@raspberrypifoundation/rpf-markdown-core": "^0.1.4",
     "@react-three/drei": "^10.0.0",
     "@react-three/fiber": "^9.6.1",
     "@reduxjs/toolkit": "^1.6.2",

--- a/src/assets/stylesheets/_scratch_colours.scss
+++ b/src/assets/stylesheets/_scratch_colours.scss
@@ -1,8 +1,8 @@
 // Scratch block category colours, sourced from
 // @RaspberryPiFoundation/scratch-gui's src/lib/settings/color-mode/*/index.js
 
-// scratchblocks names its categories differently to scratch-gui, so map the
-// `code.block3<key>` class it emits onto the `--scratch-<value>-primary` var.
+// key:value pairs for mapping each `code.block3<key>` class 
+// onto the matching `--scratch-<value>-primary colour variables
 $scratch-block-categories: (
   "control": "control",
   "events": "events",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4379,7 +4379,7 @@ __metadata:
     "@juggle/resize-observer": "npm:^3.3.1"
     "@raspberrypifoundation/design-system-react": "npm:^2.9.2"
     "@raspberrypifoundation/python-friendly-error-messages": "npm:0.8.0"
-    "@raspberrypifoundation/rpf-markdown-core": "npm:^0.1.2"
+    "@raspberrypifoundation/rpf-markdown-core": "npm:^0.1.4"
     "@react-three/drei": "npm:^10.0.0"
     "@react-three/fiber": "npm:^9.6.1"
     "@react-three/test-renderer": "npm:^9.0.0"
@@ -4498,16 +4498,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@raspberrypifoundation/rpf-markdown-core@npm:^0.1.2":
-  version: 0.1.2
-  resolution: "@raspberrypifoundation/rpf-markdown-core@npm:0.1.2"
+"@raspberrypifoundation/rpf-markdown-core@npm:^0.1.4":
+  version: 0.1.4
+  resolution: "@raspberrypifoundation/rpf-markdown-core@npm:0.1.4"
   dependencies:
     happy-dom: "npm:^20.9.0"
     marked: "npm:^17.0.5"
     marked-gfm-heading-id: "npm:^4.1.4"
     prismjs: "npm:^1.30.0"
     scratchblocks: "npm:^3.6.4"
-  checksum: 10/ab0688d2c6a04d74c7f707d245ef87c94e514edefdad819aebdf10ab5c5c6d55fa9ef09ae4e58e50a28536d96c5e2774289e14ca189d0bae235f92eba758fe44
+  checksum: 10/b43e91495ae756c4ebfb6e4936ad77fe4f02d3c6bbc6f376c7dfa16eab6b3ef1901842aab98cdf1ebc488e8e3d4591c4227e3186a13c85016fcb7855781e0344
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1700

## Changes in this repo
- Upgraded rpf-markdown-core to v0.1.4 for below changes

## Changes implemented in rpf-markdown-core 
- Bug fix:
  - With two adjacent `<code>...</code>` spans where only the second had a {:class="..."} annotation, the match jumped from the first `<code>` all the way to the second `</code>`, incorrectly applying the class to the first span and swallowing everything in between.
  - Example: `styled` should be blue, not `plain`. 
  ```markdown
  Some `plain` code and `styled`{:class="block3motion"} text.
  ```
  <img width="394" height="94" alt="Screenshot 2026-08-11 at 13 09 17" src="https://github.com/user-attachments/assets/c7cccc28-b80a-468b-9843-9c9a198e424c" />

   - Fix: replaced [\s\S]*? with (?:(?!<\/code>)[\s\S])*? so the match is anchored to the nearest closing tag.

- Friendly syntax implemented:
  - These are now equivalent:
  ```markdown
  `Looks`{:class="block3looks"} // existing syntax
  ```
  ```markdown
  `Looks`{:block-type="looks"} // new, simpler syntax
  ```
- See more details in https://github.com/RaspberryPiFoundation/rpf-markdown-core/pull/32

## Example
```markdown
Create a new turtle called `bob`. 

You can use `Motion`{:class="block3motion"}, `Looks`{:class="block3looks"} and `Control`{:block-type="control"} blocks for this project. 
```
| Before | After |
|--|--|
| <img width="411" height="321" alt="Screenshot 2026-08-12 at 10 30 06" src="https://github.com/user-attachments/assets/d84c4aed-52bb-4165-bfb4-b6a23dd254d9" /> | <img width="422" height="313" alt="Screenshot 2026-08-12 at 10 29 13" src="https://github.com/user-attachments/assets/6bc65e12-4046-49d5-b3c0-690e61cb36f2" /> |

- All the block-type highlighting currently supported:
  - Input:
    ```markdown
      `Motion`{:class="block3motion"}
      `Looks`{:class="block3looks"}
      `Sound`{:class="block3sound"}
      `Events`{:class="block3events"}
      `Control`{:class="block3control"}
      `Sensing`{:class="block3sensing"}
      `Operators`{:class="block3operators"}
      `Variables`{:class="block3variables"}
      `My Blocks`{:class="block3myblocks"}
      `Pen`{:class="block3extensions"}
      
      `Motion`{:block-type="motion"}
      `Looks`{:block-type="looks"}
      `Sound`{:block-type="sound"}
      `Events`{:block-type="events"}
      `Control`{:block-type="control"}
      `Sensing`{:block-type="sensing"}
      `Operators`{:block-type="operators"}
      `Variables`{:block-type="variables"}
      `My Blocks`{:block-type="myblocks"}
      `Pen`{:block-type="extensions"}
    ```
  - Output:
    <img width="485" height="330" alt="Screenshot 2026-08-12 at 10 46 43" src="https://github.com/user-attachments/assets/a267e472-cac2-4eb0-9f28-6b68d72f2f9a" />

