### PR TITLE
Remove CCP heading styles

### DIFF
--- a/src/assets/stylesheets/Instructions.scss
+++ b/src/assets/stylesheets/Instructions.scss
@@ -84,43 +84,6 @@
     }
   }
 
-  // Steps in CCP style
-  [id^="step-"] {
-    @include typography.style-1(bold);
-
-    background: #ecf8ee;
-    border-radius: $space-0-5;
-    color: #276d32;
-    display: inline-block;
-    margin: $space-1-5 0 0 0;
-    padding: $space-0-25 $space-0-5;
-  }
-
-  // "Now run your code" in CCP style
-  #now-run-your-code {
-    @include typography.style-1(bold);
-
-    padding-inline-start: $space-2-5;
-    margin-block-start: $space-2;
-    position: relative;
-
-    &::before {
-      content: "";
-      position: absolute;
-      inset-inline-start: 0;
-      inset-block-start: 50%;
-      transform: translateY(-50%);
-      block-size: $space-2;
-      inline-size: $space-2;
-      border-radius: $space-0-5;
-      background-color: #ecf8ee;
-      background-image: url("../play_filled.svg");
-      background-repeat: no-repeat;
-      background-position: center;
-      background-size: $space-1-5 $space-1-5;
-    }
-  }
-
   .c-project-code {
     background-color: $rpf-grey-700;
     border-radius: 8px;


### PR DESCRIPTION
Closes https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1708

## Summary
- Editor-ui web-component provides `host_styles` attribute and projects-ui already passes some styles using it, so I wanted to try this approach for moving the CCP heading styles to projects-ui. 
- Tried out this idea by pair-programming with CCP team's Ram and it worked!
- Ram will carry on with this and merge that in to projects-ui. 
- The CCP-specific styles are now removed from editor-ui and the headings are back to normal:
  <img width="415" height="509" alt="Screenshot 2026-08-12 at 16 20 32" src="https://github.com/user-attachments/assets/58165881-baf7-4622-92ca-a416ee92054b" />

## Order of things
- We merge in this PR and release new editor-ui soon.
- Projects-ui is currently not on a latest version of editor-ui which still carries the CCP-specific styles so it won't break.
- CCP team is planning to bump editor-ui to the latest version next week, so as long as Ram's PR goes in before then, it should be fine. 
