### PR TITLE
refactor: migrate instructions stepper to RPF design system

### DIFF
--- a/cypress/e2e/missionZero-wc.cy.js
+++ b/cypress/e2e/missionZero-wc.cy.js
@@ -101,7 +101,6 @@ it("confirms LEDs used when display set", () => {
     "from sense_hat import SenseHat\nsense = SenseHat()\nsense.set_pixels([[100,0,0]] * 64)",
   );
 
-  cy.scrollTo("bottom");
   getResults().should("contain", '"usedLEDs":true');
 });
 
@@ -110,7 +109,6 @@ it("doesn't show LEDs used when display is all set to 0", () => {
     "from sense_hat import SenseHat\nsense = SenseHat()\nsense.set_pixels([[0,0,0]] * 64)",
   );
 
-  cy.scrollTo("bottom");
   getResults().should("contain", '"usedLEDs":false');
 });
 

--- a/docs/host-integration/README.md
+++ b/docs/host-integration/README.md
@@ -9,18 +9,38 @@ For mounting, attributes, events, and styling, start with the
 [README](../../README.md#usage) and
 [Web Component notes](../WebComponent.md).
 
+## Sizing the component
+
+`<editor-wc>` fills the height its host gives it, so give it a definite one -
+and add `min-block-size: 0` to any flex or grid wrapper in between, or that
+wrapper will grow to fit its content instead of staying in its track.
+
+```css
+.editor-wrapper {
+  min-block-size: 0;
+}
+
+editor-wc {
+  block-size: 100%;
+}
+```
+
+Skip this and the editor still renders, but long instructions make the whole
+component grow instead of scrolling inside it. `web-component.html` is a
+working example.
+
 ## Host APIs
 
-| Guide | What it covers |
-| --- | --- |
+| Guide                                | What it covers                                                             |
+| ------------------------------------ | -------------------------------------------------------------------------- |
 | [Sidebar plugins](SidebarPlugins.md) | Add a host-owned panel (and optional header buttons) to the editor sidebar |
-| [Autosave flush](AutosaveFlush.md) | Force-save dirty work before SPA or page navigation leaves the editor |
+| [Autosave flush](AutosaveFlush.md)   | Force-save dirty work before SPA or page navigation leaves the editor      |
 
 ## Design notes
 
 Background from the feedback-panel / host-integration investigation. Useful
 context for the team; not required reading to call the APIs above.
 
-| Note | What it covers |
-| --- | --- |
+| Note                                                                         | What it covers                                                                                                                 |
+| ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
 | [Feedback panel investigation](design-notes/feedback-panel-investigation.md) | Why React-across-the-WC-boundary is unsafe, the options we considered, and what shipped (1a) vs what was only explored (Alt 4) |

--- a/src/assets/icons/chevron_left.svg
+++ b/src/assets/icons/chevron_left.svg
@@ -1,3 +1,1 @@
-<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <path d="M11.6665 15L6.6665 10L11.6665 5L12.8332 6.16667L8.99984 10L12.8332 13.8333L11.6665 15Z"/>
-</svg>
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#1f1f1f"><path d="M560-240 320-480l240-240 56 56-184 184 184 184-56 56Z"/></svg>

--- a/src/assets/icons/chevron_right.svg
+++ b/src/assets/icons/chevron_right.svg
@@ -1,3 +1,1 @@
-<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <path d="M7.83317 15L6.6665 13.8333L10.4998 10L6.6665 6.16667L7.83317 5L12.8332 10L7.83317 15Z" />
-</svg>
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#1f1f1f"><path d="M504-480 320-664l56-56 240 240-240 240-56-56 184-184Z"/></svg>

--- a/src/assets/stylesheets/Instructions.scss
+++ b/src/assets/stylesheets/Instructions.scss
@@ -21,12 +21,12 @@
   }
 
   &__content {
-    padding-block-end: var(--project-instructions-padding, $space-1);
+    padding-block-end: var(--project-instructions-padding, var(--space-2));
   }
 
   h2 {
     @include typography.style-1-5(bold);
-    margin-block-start: $space-0-5;
+    margin-block-start: var(--space-1);
   }
 
   p {
@@ -47,7 +47,7 @@
 
   table {
     border-collapse: collapse;
-    margin-block-end: $space-1-5;
+    margin-block-end: var(--space-3);
     inline-size: 100%;
 
     tr {
@@ -55,7 +55,7 @@
     }
 
     td {
-      padding: $space-0-5 $space-1-5;
+      padding: var(--space-1) var(--space-3);
     }
   }
 
@@ -72,9 +72,9 @@
     background-color: var(--code-background-color, #{$rpf-grey-700});
     border: 1px solid var(--code-block-border-color, #{$rpf-grey-600});
     border-radius: 8px;
-    padding: $space-0-5 $space-1;
+    padding: var(--space-1) var(--space-2);
     overflow: auto;
-    margin: $space-1 0;
+    margin: var(--space-2) 0;
     scrollbar-color: var(--code-block-scrollbar-color, auto);
 
     code {
@@ -87,7 +87,7 @@
   .c-project-code {
     background-color: $rpf-grey-700;
     border-radius: 8px;
-    margin: $space-1 0 $space-1-5 0;
+    margin: var(--space-2) 0 var(--space-3) 0;
 
     pre {
       margin: 0;
@@ -120,7 +120,7 @@
   .c-code-filename {
     font-family: var(--editor-font-family-monospace);
     margin: 0;
-    padding: $space-0-5 $space-1;
+    padding: var(--space-1) var(--space-2);
     color: $rpf-white;
     background-color: $rpf-grey-800;
     border-start-start-radius: 8px;
@@ -129,15 +129,15 @@
   }
 
   .line-numbers {
-    padding-inline-start: $space-3;
-    padding-inline-end: $space-1;
+    padding-inline-start: var(--space-6);
+    padding-inline-end: var(--space-2);
   }
 
   .line-numbers-rows {
     border-color: $rpf-text-secondary-dark;
 
     span::before {
-      padding-inline-end: $space-0-5;
+      padding-inline-end: var(--space-1);
       color: $rpf-text-secondary-dark;
     }
   }
@@ -241,7 +241,7 @@
   }
 
   .c-project-task {
-    margin-block-end: $space-2-5;
+    margin-block-end: var(--space-5);
 
     p {
       margin: 0;
@@ -258,19 +258,19 @@
   .c-project-callout {
     background-color: $rpf-blue-100;
     border-inline-start: 4px solid $rpf-blue-800;
-    padding: $space-0-5 $space-1;
+    padding: var(--space-1) var(--space-2);
     display: flex;
     flex-direction: column;
-    gap: $space-0-5;
-    margin: $space-1-5 0;
+    gap: var(--space-1);
+    margin: var(--space-3) 0;
 
     h3 {
       @include typography.style-1(bold);
 
       margin: 0;
-      padding-inline-start: $space-2;
+      padding-inline-start: var(--space-4);
       background-repeat: no-repeat;
-      background-position: inline-start $space-0-5 center;
+      background-position: inline-start var(--space-1) center;
     }
 
     p {
@@ -300,10 +300,10 @@
     display: flex;
     align-items: flex-start;
     align-self: stretch;
-    padding: $space-1;
+    padding: var(--space-2);
     border-radius: 8px;
     border: 1px solid var(--rpf-grey-150);
-    margin-block-end: $space-1-5;
+    margin-block-end: var(--space-3);
 
     pre {
       background-color: $rpf-white;
@@ -323,11 +323,11 @@
 
   .project-instructions__empty {
     background-color: var(--editor-color-layer-1);
-    border-radius: $space-0-5;
+    border-radius: var(--space-1);
     display: flex;
     flex-direction: column;
-    gap: $space-1-5;
-    padding: $space-1;
+    gap: var(--space-3);
+    padding: var(--space-2);
   }
 
   .project-instructions__empty-text {

--- a/src/assets/stylesheets/Instructions.scss
+++ b/src/assets/stylesheets/Instructions.scss
@@ -387,15 +387,7 @@
     .instructions-panel__step-actions {
       display: flex;
       margin-block-start: var(--space-2);
-      gap: $space-1;
-
-      .instructions-panel__add-step-button {
-        flex-grow: 1;
-      }
-
-      .instructions-panel__remove-step-button {
-        flex: 0 0 auto;
-      }
+      gap: var(--space-2);
     }
 
     textarea {

--- a/src/assets/stylesheets/Instructions.scss
+++ b/src/assets/stylesheets/Instructions.scss
@@ -378,7 +378,6 @@
     }
 
     .react-tabs__tab-panel {
-      margin-block-end: var(--space-1);
       .project-instructions {
         padding-inline: var(--space-1);
       }
@@ -397,7 +396,6 @@
       color: var(--editor-color-text);
       border: none;
       block-size: 100%;
-      overflow-block: scroll;
       padding: var(--space-1);
       resize: none;
     }

--- a/src/assets/stylesheets/InternalStyles.scss
+++ b/src/assets/stylesheets/InternalStyles.scss
@@ -138,14 +138,19 @@
     );
 
     --rpf-button-background-color-focus: var(--editor-color-theme);
-    --rpf-button-background-color-disabled: var(--rpf-grey-200);
-    --rpf-button-color-disabled: var(--editor-color-layer-3);
-    --rpf-button-color-disabled-focus: var(--editor-color-theme);
+    --rpf-button-background-color-disabled: var(--rpf-grey-500);
+
+    &:disabled {
+      --rpf-button-text-color: var(--rpf-grey-900);
+    }
   }
 
   .rpf-button--secondary {
-    // This is actually the background color, quirk of the Design System
+    // There are actually the background colors, quirk of the Design System
     --rpf-button-text-color: transparent;
     --rpf-button-danger-text-color: transparent;
+    &:disabled {
+      --rpf-button-text-color: transparent;
+    }
   }
 }

--- a/src/assets/stylesheets/InternalStyles.scss
+++ b/src/assets/stylesheets/InternalStyles.scss
@@ -124,6 +124,19 @@
       white 30%
     );
 
+    --rpf-button-danger-text-color: var(--rpf-black);
+    --rpf-button-danger-background-color: var(--rpf-red-400);
+    --rpf-button-danger-background-color-hover: color-mix(
+      in srgb,
+      var(--rpf-button-danger-background-color),
+      white 15%
+    );
+    --rpf-button-danger-background-color-active: color-mix(
+      in srgb,
+      var(--rpf-button-danger-background-color),
+      white 30%
+    );
+
     --rpf-button-background-color-focus: var(--editor-color-theme);
     --rpf-button-background-color-disabled: var(--rpf-grey-200);
     --rpf-button-color-disabled: var(--editor-color-layer-3);
@@ -133,5 +146,6 @@
   .rpf-button--secondary {
     // This is actually the background color, quirk of the Design System
     --rpf-button-text-color: transparent;
+    --rpf-button-danger-text-color: transparent;
   }
 }

--- a/src/assets/stylesheets/ProgressBar.scss
+++ b/src/assets/stylesheets/ProgressBar.scss
@@ -7,7 +7,7 @@
   justify-content: center;
   margin: auto;
   gap: var(--space-2);
-  padding-block: var(--space-1);
+  padding: var(--space-1) var(--space-1-5);
 
   .progress-container {
     flex: 1;

--- a/src/assets/stylesheets/ProgressBar.scss
+++ b/src/assets/stylesheets/ProgressBar.scss
@@ -6,8 +6,8 @@
   align-items: center;
   justify-content: center;
   margin: auto;
-  gap: $space-1;
-  padding-block: $space-0-5;
+  gap: var(--space-2);
+  padding-block: var(--space-2);
 
   .progress-container {
     flex: 1;
@@ -15,24 +15,12 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: $space-0-25;
+    gap: var(--space-0-5);
+    font-weight: var(--font-weight-bold);
   }
 
   progress {
     inline-size: 100%;
-  }
-
-  .btn-outer {
-    padding: $space-0-5;
-  }
-
-  .btn {
-    border-radius: var(--step-buttons-radius, var(--space-1));
-    &:hover,
-    &:focus,
-    &:active {
-      border-radius: var(--step-buttons-radius, var(--space-1));
-    }
   }
 }
 

--- a/src/assets/stylesheets/ProgressBar.scss
+++ b/src/assets/stylesheets/ProgressBar.scss
@@ -7,7 +7,7 @@
   justify-content: center;
   margin: auto;
   gap: var(--space-2);
-  padding-block: var(--space-2);
+  padding-block: var(--space-1);
 
   .progress-container {
     flex: 1;
@@ -15,7 +15,6 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: var(--space-0-5);
     font-weight: var(--font-weight-bold);
   }
 

--- a/src/assets/stylesheets/Sidebar.scss
+++ b/src/assets/stylesheets/Sidebar.scss
@@ -135,7 +135,8 @@
 }
 
 .sidebar__panel-content {
-  flex: 1;
+  flex: 1 1 0px;
+  min-block-size: 0;
   padding: var(--space-2);
   overflow-y: auto;
 }

--- a/src/assets/stylesheets/Sidebar.scss
+++ b/src/assets/stylesheets/Sidebar.scss
@@ -147,13 +147,8 @@
   gap: var(--space-2);
 }
 
+// Just the seam between the footer and the content above it - everything
+// inside the footer is styled by whatever component the panel renders there.
 .sidebar__panel-footer {
   border-block-start: 1px solid var(--sidebar-border);
-  inset-block-end: 0px;
-  inline-size: 100%;
-  inline-size: -moz-available;
-  inline-size: -webkit-stretch;
-  inline-size: stretch;
-  padding-inline: var(--space-1-5);
-  border-end-end-radius: 8px;
 }

--- a/src/assets/stylesheets/Sidebar.scss
+++ b/src/assets/stylesheets/Sidebar.scss
@@ -154,6 +154,6 @@
   inline-size: -moz-available;
   inline-size: -webkit-stretch;
   inline-size: stretch;
-  padding-inline: var(--space-2);
+  padding-inline: var(--space-1-5);
   border-end-end-radius: 8px;
 }

--- a/src/components/Menus/Sidebar/InstructionsPanel/InstructionsPanel.jsx
+++ b/src/components/Menus/Sidebar/InstructionsPanel/InstructionsPanel.jsx
@@ -21,7 +21,7 @@ import {
   updateStepMarkdown,
 } from "../../../../utils/instructionSteps";
 import populateMarkdownTemplate from "../../../../utils/populateMarkdownTemplate";
-import DesignSystemButton from "../../../DesignSystemButton/DesignSystemButton";
+import { Button } from "@raspberrypifoundation/design-system-react";
 import RemoveInstructionStepModal from "../../../Modals/RemoveInstructionStepModal";
 import InstructionsStep from "./InstructionsStep/InstructionsStep";
 import ProgressBar from "./ProgressBar/ProgressBar";
@@ -96,14 +96,12 @@ const InstructionsPanel = () => {
       buttons={
         instructionsEditable && !hasInstructions
           ? [
-              <DesignSystemButton
+              <Button
                 type="primary"
                 icon={<PlusIcon />}
                 text={t("instructionsPanel.emptyState.addInstructions")}
                 onClick={addInstructions}
-                fill={true}
-                textAlways={true}
-                small={true}
+                fullWidth
               />,
             ]
           : []
@@ -144,17 +142,16 @@ const InstructionsPanel = () => {
               </Tabs>
               {onEditTab && (
                 <div className="instructions-panel__step-actions">
-                  <DesignSystemButton
+                  <Button
                     type="secondary"
-                    className="instructions-panel__add-step-button"
                     text={t("instructionsPanel.addStep")}
                     icon={<PlusIcon />}
                     iconPosition="right"
                     onClick={addStep}
+                    fullWidth
                   />
-                  <DesignSystemButton
+                  <Button
                     type="secondary"
-                    className="instructions-panel__remove-step-button"
                     variant="danger"
                     title={t("instructionsPanel.removeStep")}
                     icon={<BinIcon />}
@@ -201,14 +198,14 @@ const InstructionsPanel = () => {
       {showRemoveStepModal && (
         <RemoveInstructionStepModal
           buttons={[
-            <DesignSystemButton
+            <Button
               type="primary"
               key="remove"
               variant="danger"
               text={t("instructionsPanel.removeStepModal.removeStep")}
               onClick={confirmRemoveStep}
             />,
-            <DesignSystemButton
+            <Button
               type="secondary"
               key="cancel"
               text={t("instructionsPanel.removeStepModal.cancel")}

--- a/src/components/Menus/Sidebar/InstructionsPanel/ProgressBar/ProgressBar.jsx
+++ b/src/components/Menus/Sidebar/InstructionsPanel/ProgressBar/ProgressBar.jsx
@@ -6,8 +6,8 @@ import {
 } from "../../../../../redux/InstructionsSlice";
 import ChevronLeft from "../../../../../assets/icons/chevron_left.svg";
 import ChevronRight from "../../../../../assets/icons/chevron_right.svg";
-import Button from "../../../../Button/Button";
 
+import { Button } from "@raspberrypifoundation/design-system-react";
 import "../../../../../assets/stylesheets/ProgressBar.scss?inline";
 import { useTranslation } from "react-i18next";
 
@@ -46,9 +46,9 @@ const ProgressBar = ({ panelRef }) => {
     <>
       <div className="progress-bar">
         <Button
-          className={"btn--secondary btn--small"}
-          onClickHandler={goToPreviousStep}
-          ButtonIcon={ChevronLeft}
+          onClick={goToPreviousStep}
+          icon=<ChevronLeft />
+          iconOnly
           disabled={currentStepPosition === 0}
           title={t("instructionsPanel.previousStep")}
         />
@@ -65,9 +65,9 @@ const ProgressBar = ({ panelRef }) => {
         </div>
 
         <Button
-          className={"btn--secondary btn--small"}
-          onClickHandler={goToNextStep}
-          ButtonIcon={ChevronRight}
+          onClick={goToNextStep}
+          icon=<ChevronRight />
+          iconOnly
           disabled={currentStepPosition === numberOfSteps - 1}
           title={t("instructionsPanel.nextStep")}
         />

--- a/src/components/Menus/Sidebar/InstructionsPanel/ProgressBar/ProgressBar.jsx
+++ b/src/components/Menus/Sidebar/InstructionsPanel/ProgressBar/ProgressBar.jsx
@@ -51,6 +51,7 @@ const ProgressBar = ({ panelRef }) => {
           iconOnly
           disabled={currentStepPosition === 0}
           title={t("instructionsPanel.previousStep")}
+          size="small"
         />
         <div className="progress-container">
           <p className="step-counter">
@@ -70,6 +71,7 @@ const ProgressBar = ({ panelRef }) => {
           iconOnly
           disabled={currentStepPosition === numberOfSteps - 1}
           title={t("instructionsPanel.nextStep")}
+          size="small"
         />
       </div>
     </>

--- a/src/components/Menus/Sidebar/SidebarPanel.jsx
+++ b/src/components/Menus/Sidebar/SidebarPanel.jsx
@@ -38,22 +38,14 @@ const SidebarPanel = (props) => {
   return isMobile ? (
     <div
       data-testid="sidebar__panel"
-      className={classNames(
-        "sidebar__panel",
-        className,
-        Footer && "sidebar__panel--with-footer",
-      )}
+      className={classNames("sidebar__panel", className)}
     >
       {panelContent}
     </div>
   ) : (
     <ResizableWithHandle
       data-testid="sidebar__panel"
-      className={classNames(
-        "sidebar__panel",
-        className,
-        Footer && "sidebar__panel--with-footer",
-      )}
+      className={classNames("sidebar__panel", className)}
       defaultWidth={defaultWidth}
       defaultHeight="100%"
       handleDirection="right"

--- a/web-component.html
+++ b/web-component.html
@@ -27,6 +27,7 @@
 
       #editor-component {
         display: flex;
+        min-block-size: 0;
       }
 
       .editor-wc {


### PR DESCRIPTION
> [!CAUTION]
> Need to check with CCP first with @rammodhvadia 

## Summary

Migrates the instructions panel stepper (progress bar) to use the RPF design system Button component and spacing tokens, and fills in the dark mode gaps that surfaced for the danger and disabled button states.

**Design note:**
Decided to keep the smaller buttons to reduce space taken up for teacher, student and on projects site

## Changes

- Replace the `DesignSystemButton` in `ProgressBar` with RPF Button
- Migrate instructions panel spacing to RPF design system tokens
- Add dark mode theming for the RPF Button danger variant
- Add dark mode styles for disabled RPF Buttons
- Update the chevron left/right icons to match

## Screenshots

<img width="589" height="183" alt="Screenshot 2026-08-14 at 11 10 50" src="https://github.com/user-attachments/assets/8bac070c-88e2-4ce0-b1e4-3e2b7511d73f" />
<img width="521" height="152" alt="Screenshot 2026-08-14 at 11 11 08" src="https://github.com/user-attachments/assets/c2a20e82-6527-4ec2-becf-3af735b8828c" />



<img width="594" height="284" alt="Screenshot 2026-08-13 at 17 38 01" src="https://github.com/user-attachments/assets/dff7054b-d1aa-4ba6-9574-0127279cf4cd" />
<img width="600" height="303" alt="Screenshot 2026-08-13 at 17 38 11" src="https://github.com/user-attachments/assets/f6df6a15-024b-4df3-8a4b-66ec5e984221" />
