### PR TITLE
Allow removing all instruction steps

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@codemirror/view": "^6.3.0",
     "@hello-pangea/dnd": "^16.2.0",
     "@juggle/resize-observer": "^3.3.1",
-    "@raspberrypifoundation/design-system-react": "^2.10.3",
+    "@raspberrypifoundation/design-system-react": "^2.10.4",
     "@raspberrypifoundation/python-friendly-error-messages": "0.8.0",
     "@raspberrypifoundation/rpf-markdown-core": "^0.1.4",
     "@react-three/drei": "^10.0.0",

--- a/public/translations/en.json
+++ b/public/translations/en.json
@@ -123,10 +123,20 @@
     "edit": "Edit",
     "view": "View",
     "removeStepModal": {
-      "heading": "Remove instruction step?",
-      "warning": "Are you sure you want to delete this instructions step? You will not be able to get this back.",
+      "heading": "Remove instructions?",
+      "warning": "You will not be able to get deleted instructions back.",
+      "studentsWarning": "Students who have already started working on this project will still be able to see the instructions as they were when they started.",
+      "scopeLegend": "What do you want to remove?",
+      "scope": {
+        "currentStep": "Remove current step only",
+        "allSteps": "Remove all steps"
+      },
+      "confirm": {
+        "currentStep": "Remove current step",
+        "allSteps": "Remove all steps"
+      },
       "cancel": "Cancel",
-      "removeStep": "Remove step"
+      "removeInstructions": "Remove instructions"
     }
   },
   "projectsPanel": {

--- a/public/translations/en.json
+++ b/public/translations/en.json
@@ -153,10 +153,20 @@
     "edit": "Edit",
     "view": "View",
     "removeStepModal": {
-      "heading": "Remove instruction step?",
-      "warning": "Are you sure you want to delete this instructions step? You will not be able to get this back.",
+      "heading": "Remove instructions?",
+      "warning": "You will not be able to get deleted instructions back.",
+      "studentsWarning": "Students who have already started working on this project will still be able to see the instructions as they were when they started.",
+      "scopeLegend": "What do you want to remove?",
+      "scope": {
+        "currentStep": "Remove current step only",
+        "allSteps": "Remove all steps"
+      },
+      "confirm": {
+        "currentStep": "Remove current step",
+        "allSteps": "Remove all steps"
+      },
       "cancel": "Cancel",
-      "removeStep": "Remove step"
+      "removeInstructions": "Remove instructions"
     }
   },
   "projectsPanel": {

--- a/src/assets/stylesheets/Instructions.scss
+++ b/src/assets/stylesheets/Instructions.scss
@@ -401,3 +401,13 @@
     }
   }
 }
+
+.modal-content--remove-step {
+  .modal-content__body {
+    row-gap: var(--space-2);
+  }
+
+  .rpf-fieldset {
+    margin-block-end: 0;
+  }
+}

--- a/src/assets/stylesheets/Instructions.scss
+++ b/src/assets/stylesheets/Instructions.scss
@@ -414,3 +414,13 @@
     }
   }
 }
+
+.modal-content--remove-step {
+  .modal-content__body {
+    row-gap: var(--space-2);
+  }
+
+  .rpf-fieldset {
+    margin-block-end: 0;
+  }
+}

--- a/src/assets/stylesheets/InternalStyles.scss
+++ b/src/assets/stylesheets/InternalStyles.scss
@@ -110,6 +110,14 @@
 
   // Design System
 
+  // Form controls
+  --rpf-input-background-color: var(--editor-color-layer-3);
+  --rpf-input-border-colour: var(--editor-color-text);
+  --rpf-input-color: var(--editor-color-text);
+  --rpf-input-outline-color: var(--editor-color-theme);
+  --rpf-label-hint-color: var(--editor-color-text-secondary);
+  --rpf-label-text-color: var(--editor-color-text);
+
   // Link (.rpf-link)
 
   --link-color: var(--editor-color-theme);

--- a/src/assets/stylesheets/Modal.scss
+++ b/src/assets/stylesheets/Modal.scss
@@ -27,11 +27,6 @@
   display: flex;
   flex-direction: column;
 
-  label,
-  legend {
-    font-weight: $font-weight-bold;
-  }
-
   input[type="text"] {
     @include font-size-1(regular);
     inline-size: 100%;
@@ -143,7 +138,7 @@
   .modal-overlay {
     background-color: rgba(0, 0, 0, 0.5);
 
-    input {
+    input[type="text"] {
       border: 2px solid $rpf-white;
       background-color: $rpf-grey-700;
       color: inherit;
@@ -175,7 +170,7 @@
   .modal-overlay {
     background-color: rgba(67, 69, 76, 0.5);
 
-    input {
+    input[type="text"] {
       border: 2px solid $rpf-grey-100;
 
       &:focus-visible {

--- a/src/assets/stylesheets/Modal.scss
+++ b/src/assets/stylesheets/Modal.scss
@@ -154,6 +154,11 @@
     }
   }
   .modal-content {
+    --rpf-input-background-color: var(--editor-color-layer-3);
+    --rpf-input-border-colour: var(--editor-color-text);
+    --rpf-input-color: var(--editor-color-text);
+    --rpf-input-outline-color: var(--editor-color-theme);
+
     background-color: $rpf-grey-700;
   }
 

--- a/src/assets/stylesheets/Modal.scss
+++ b/src/assets/stylesheets/Modal.scss
@@ -154,11 +154,6 @@
     }
   }
   .modal-content {
-    --rpf-input-background-color: var(--editor-color-layer-3);
-    --rpf-input-border-colour: var(--editor-color-text);
-    --rpf-input-color: var(--editor-color-text);
-    --rpf-input-outline-color: var(--editor-color-theme);
-
     background-color: $rpf-grey-700;
   }
 

--- a/src/assets/stylesheets/Modal.scss
+++ b/src/assets/stylesheets/Modal.scss
@@ -95,6 +95,10 @@
 .modal-content__input-section {
   display: flex;
   flex-direction: column;
+
+  label {
+    font-weight: $font-weight-bold;
+  }
 }
 
 .modal-content__buttons {

--- a/src/components/Menus/Sidebar/InstructionsPanel/InstructionsPanel.jsx
+++ b/src/components/Menus/Sidebar/InstructionsPanel/InstructionsPanel.jsx
@@ -19,6 +19,8 @@ import {
   insertStepAfter,
   removeStepAt,
   updateStepMarkdown,
+  REMOVE_ALL_STEPS,
+  REMOVE_CURRENT_STEP,
 } from "../../../../utils/instructionSteps";
 import populateMarkdownTemplate from "../../../../utils/populateMarkdownTemplate";
 import { Button } from "@raspberrypifoundation/design-system-react";
@@ -33,6 +35,7 @@ const INSTRUCTIONS_GUIDE_URL =
 const InstructionsPanel = () => {
   const [tabIndex, setTabIndex] = useState(0);
   const [showRemoveStepModal, setShowRemoveStepModal] = useState(false);
+  const [removeScope, setRemoveScope] = useState(REMOVE_CURRENT_STEP);
   const instructionsEditable = useSelector(
     (state) => state.editor?.instructionsEditable,
   );
@@ -83,9 +86,25 @@ const InstructionsPanel = () => {
     dispatch(setCurrentStepPosition(currentStepPosition + 1));
   };
 
-  const confirmRemoveStep = () => {
-    dispatch(setProjectInstructions(removeStepAt(steps, currentStepPosition)));
-    dispatch(setCurrentStepPosition(Math.max(currentStepPosition - 1, 0)));
+  const confirmRemoveText = hasMultipleSteps
+    ? t(`instructionsPanel.removeStepModal.confirm.${removeScope}`)
+    : t("instructionsPanel.removeStepModal.removeInstructions");
+
+  const openRemoveStepModal = () => {
+    setRemoveScope(REMOVE_CURRENT_STEP);
+    setShowRemoveStepModal(true);
+  };
+
+  const confirmRemove = () => {
+    if (removeScope === REMOVE_ALL_STEPS) {
+      dispatch(setProjectInstructions([]));
+      dispatch(setCurrentStepPosition(0));
+    } else {
+      dispatch(
+        setProjectInstructions(removeStepAt(steps, currentStepPosition)),
+      );
+      dispatch(setCurrentStepPosition(Math.max(currentStepPosition - 1, 0)));
+    }
     setShowRemoveStepModal(false);
   };
 
@@ -100,6 +119,7 @@ const InstructionsPanel = () => {
         instructionsEditable && !hasInstructions
           ? [
               <Button
+                key="add-instructions"
                 type="primary"
                 icon={<PlusIcon />}
                 text={t("instructionsPanel.emptyState.addInstructions")}
@@ -170,7 +190,7 @@ const InstructionsPanel = () => {
                     variant="danger"
                     title={t("instructionsPanel.removeStep")}
                     icon={<BinIcon />}
-                    onClick={() => setShowRemoveStepModal(true)}
+                    onClick={openRemoveStepModal}
                   />
                 </div>
               )}
@@ -217,8 +237,8 @@ const InstructionsPanel = () => {
               type="primary"
               key="remove"
               variant="danger"
-              text={t("instructionsPanel.removeStepModal.removeStep")}
-              onClick={confirmRemoveStep}
+              text={confirmRemoveText}
+              onClick={confirmRemove}
             />,
             <Button
               type="secondary"
@@ -229,6 +249,9 @@ const InstructionsPanel = () => {
           ]}
           isOpen={showRemoveStepModal}
           setShowModal={setShowRemoveStepModal}
+          showScopeOptions={hasMultipleSteps}
+          removeScope={removeScope}
+          setRemoveScope={setRemoveScope}
         />
       )}
     </SidebarPanel>

--- a/src/components/Menus/Sidebar/InstructionsPanel/InstructionsPanel.jsx
+++ b/src/components/Menus/Sidebar/InstructionsPanel/InstructionsPanel.jsx
@@ -19,6 +19,8 @@ import {
   insertStepAfter,
   removeStepAt,
   updateStepMarkdown,
+  REMOVE_ALL_STEPS,
+  REMOVE_CURRENT_STEP,
 } from "../../../../utils/instructionSteps";
 import populateMarkdownTemplate from "../../../../utils/populateMarkdownTemplate";
 import { Button } from "@raspberrypifoundation/design-system-react";
@@ -30,6 +32,7 @@ import BinIcon from "../../../../assets/icons/bin.svg";
 const InstructionsPanel = () => {
   const [tabIndex, setTabIndex] = useState(0);
   const [showRemoveStepModal, setShowRemoveStepModal] = useState(false);
+  const [removeScope, setRemoveScope] = useState(REMOVE_CURRENT_STEP);
   const instructionsEditable = useSelector(
     (state) => state.editor?.instructionsEditable,
   );
@@ -80,9 +83,25 @@ const InstructionsPanel = () => {
     dispatch(setCurrentStepPosition(currentStepPosition + 1));
   };
 
-  const confirmRemoveStep = () => {
-    dispatch(setProjectInstructions(removeStepAt(steps, currentStepPosition)));
-    dispatch(setCurrentStepPosition(Math.max(currentStepPosition - 1, 0)));
+  const confirmRemoveText = hasMultipleSteps
+    ? t(`instructionsPanel.removeStepModal.confirm.${removeScope}`)
+    : t("instructionsPanel.removeStepModal.removeInstructions");
+
+  const openRemoveStepModal = () => {
+    setRemoveScope(REMOVE_CURRENT_STEP);
+    setShowRemoveStepModal(true);
+  };
+
+  const confirmRemove = () => {
+    if (removeScope === REMOVE_ALL_STEPS) {
+      dispatch(setProjectInstructions([]));
+      dispatch(setCurrentStepPosition(0));
+    } else {
+      dispatch(
+        setProjectInstructions(removeStepAt(steps, currentStepPosition)),
+      );
+      dispatch(setCurrentStepPosition(Math.max(currentStepPosition - 1, 0)));
+    }
     setShowRemoveStepModal(false);
   };
 
@@ -97,6 +116,7 @@ const InstructionsPanel = () => {
         instructionsEditable && !hasInstructions
           ? [
               <Button
+                key="add-instructions"
                 type="primary"
                 icon={<PlusIcon />}
                 text={t("instructionsPanel.emptyState.addInstructions")}
@@ -155,7 +175,7 @@ const InstructionsPanel = () => {
                     variant="danger"
                     title={t("instructionsPanel.removeStep")}
                     icon={<BinIcon />}
-                    onClick={() => setShowRemoveStepModal(true)}
+                    onClick={openRemoveStepModal}
                   />
                 </div>
               )}
@@ -202,8 +222,8 @@ const InstructionsPanel = () => {
               type="primary"
               key="remove"
               variant="danger"
-              text={t("instructionsPanel.removeStepModal.removeStep")}
-              onClick={confirmRemoveStep}
+              text={confirmRemoveText}
+              onClick={confirmRemove}
             />,
             <Button
               type="secondary"
@@ -214,6 +234,9 @@ const InstructionsPanel = () => {
           ]}
           isOpen={showRemoveStepModal}
           setShowModal={setShowRemoveStepModal}
+          showScopeOptions={hasMultipleSteps}
+          removeScope={removeScope}
+          setRemoveScope={setRemoveScope}
         />
       )}
     </SidebarPanel>

--- a/src/components/Menus/Sidebar/InstructionsPanel/InstructionsPanel.test.jsx
+++ b/src/components/Menus/Sidebar/InstructionsPanel/InstructionsPanel.test.jsx
@@ -29,6 +29,19 @@ const fakeScratchblocksInit = (_locale, container) => {
   });
 };
 
+const openRemoveModal = () =>
+  act(() => {
+    fireEvent.click(screen.getByTitle("instructionsPanel.removeStep"));
+  });
+
+const removeModalScopeRadio = (scope) =>
+  screen.getByLabelText(`instructionsPanel.removeStepModal.scope.${scope}`);
+
+const selectRemoveModalScope = (scope) =>
+  act(() => {
+    fireEvent.click(removeModalScopeRadio(scope));
+  });
+
 describe("When instructionsEditable changes from false to true", () => {
   test("does not leave the rendered preview above the edit/view tabs", () => {
     const { container, store } = renderWithProviders(<InstructionsPanel />, {
@@ -213,7 +226,9 @@ describe("When instructionsEditable is true", () => {
 
       act(() => {
         fireEvent.click(
-          screen.getByText("instructionsPanel.removeStepModal.removeStep"),
+          screen.getByText(
+            "instructionsPanel.removeStepModal.confirm.currentStep",
+          ),
         );
       });
 
@@ -221,6 +236,69 @@ describe("When instructionsEditable is true", () => {
         { markdown_content: "first" },
       ]);
       expect(store.getState().instructions.currentStepPosition).toBe(0);
+    });
+
+    test("The confirmation modal offers a scope choice, defaulting to the current step", () => {
+      openRemoveModal();
+
+      expect(removeModalScopeRadio("currentStep")).toBeChecked();
+      expect(removeModalScopeRadio("allSteps")).not.toBeChecked();
+      expect(
+        screen.getByText("instructionsPanel.removeStepModal.studentsWarning"),
+      ).toBeInTheDocument();
+    });
+
+    test("Selecting the remove all steps option relabels the confirm button", () => {
+      openRemoveModal();
+      selectRemoveModalScope("allSteps");
+
+      expect(removeModalScopeRadio("allSteps")).toBeChecked();
+      expect(
+        screen.getByText("instructionsPanel.removeStepModal.confirm.allSteps"),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText(
+          "instructionsPanel.removeStepModal.confirm.currentStep",
+        ),
+      ).not.toBeInTheDocument();
+    });
+
+    test("Confirming with the remove all steps option clears the instructions and resets the step position", () => {
+      act(() => {
+        store.dispatch(setCurrentStepPosition(1));
+      });
+
+      openRemoveModal();
+      selectRemoveModalScope("allSteps");
+
+      act(() => {
+        fireEvent.click(
+          screen.getByText(
+            "instructionsPanel.removeStepModal.confirm.allSteps",
+          ),
+        );
+      });
+
+      expect(store.getState().editor.project.instructions).toEqual([]);
+      expect(store.getState().instructions.currentStepPosition).toBe(0);
+      expect(
+        screen.getByText("instructionsPanel.emptyState.addInstructions"),
+      ).toBeInTheDocument();
+    });
+
+    test("Removing the current step is always the default, even after previously choosing to remove all steps", () => {
+      openRemoveModal();
+      selectRemoveModalScope("allSteps");
+
+      act(() => {
+        fireEvent.click(
+          screen.getByText("instructionsPanel.removeStepModal.cancel"),
+        );
+      });
+
+      openRemoveModal();
+
+      expect(removeModalScopeRadio("currentStep")).toBeChecked();
     });
   });
 
@@ -255,12 +333,29 @@ describe("When instructionsEditable is true", () => {
       ).toBeInTheDocument();
     });
 
+    test("Does not offer the scope choice", () => {
+      openRemoveModal();
+
+      expect(
+        screen.queryByLabelText(
+          "instructionsPanel.removeStepModal.scope.currentStep",
+        ),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "instructionsPanel.removeStepModal.removeInstructions",
+        ),
+      ).toBeInTheDocument();
+    });
+
     test("Confirming removal of the only step falls back to the empty state", () => {
       fireEvent.click(screen.getByTitle("instructionsPanel.removeStep"));
 
       act(() => {
         fireEvent.click(
-          screen.getByText("instructionsPanel.removeStepModal.removeStep"),
+          screen.getByText(
+            "instructionsPanel.removeStepModal.removeInstructions",
+          ),
         );
       });
 

--- a/src/components/Menus/Sidebar/InstructionsPanel/InstructionsPanel.test.jsx
+++ b/src/components/Menus/Sidebar/InstructionsPanel/InstructionsPanel.test.jsx
@@ -27,6 +27,19 @@ const fakeScratchblocksInit = (_locale, container) => {
   });
 };
 
+const openRemoveModal = () =>
+  act(() => {
+    fireEvent.click(screen.getByTitle("instructionsPanel.removeStep"));
+  });
+
+const removeModalScopeRadio = (scope) =>
+  screen.getByLabelText(`instructionsPanel.removeStepModal.scope.${scope}`);
+
+const selectRemoveModalScope = (scope) =>
+  act(() => {
+    fireEvent.click(removeModalScopeRadio(scope));
+  });
+
 describe("When instructionsEditable changes from false to true", () => {
   test("does not leave the rendered preview above the edit/view tabs", () => {
     const { container, store } = renderWithProviders(<InstructionsPanel />, {
@@ -199,7 +212,9 @@ describe("When instructionsEditable is true", () => {
 
       act(() => {
         fireEvent.click(
-          screen.getByText("instructionsPanel.removeStepModal.removeStep"),
+          screen.getByText(
+            "instructionsPanel.removeStepModal.confirm.currentStep",
+          ),
         );
       });
 
@@ -207,6 +222,69 @@ describe("When instructionsEditable is true", () => {
         { markdown_content: "first" },
       ]);
       expect(store.getState().instructions.currentStepPosition).toBe(0);
+    });
+
+    test("The confirmation modal offers a scope choice, defaulting to the current step", () => {
+      openRemoveModal();
+
+      expect(removeModalScopeRadio("currentStep")).toBeChecked();
+      expect(removeModalScopeRadio("allSteps")).not.toBeChecked();
+      expect(
+        screen.getByText("instructionsPanel.removeStepModal.studentsWarning"),
+      ).toBeInTheDocument();
+    });
+
+    test("Selecting the remove all steps option relabels the confirm button", () => {
+      openRemoveModal();
+      selectRemoveModalScope("allSteps");
+
+      expect(removeModalScopeRadio("allSteps")).toBeChecked();
+      expect(
+        screen.getByText("instructionsPanel.removeStepModal.confirm.allSteps"),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText(
+          "instructionsPanel.removeStepModal.confirm.currentStep",
+        ),
+      ).not.toBeInTheDocument();
+    });
+
+    test("Confirming with the remove all steps option clears the instructions and resets the step position", () => {
+      act(() => {
+        store.dispatch(setCurrentStepPosition(1));
+      });
+
+      openRemoveModal();
+      selectRemoveModalScope("allSteps");
+
+      act(() => {
+        fireEvent.click(
+          screen.getByText(
+            "instructionsPanel.removeStepModal.confirm.allSteps",
+          ),
+        );
+      });
+
+      expect(store.getState().editor.project.instructions).toEqual([]);
+      expect(store.getState().instructions.currentStepPosition).toBe(0);
+      expect(
+        screen.getByText("instructionsPanel.emptyState.addInstructions"),
+      ).toBeInTheDocument();
+    });
+
+    test("Removing the current step is always the default, even after previously choosing to remove all steps", () => {
+      openRemoveModal();
+      selectRemoveModalScope("allSteps");
+
+      act(() => {
+        fireEvent.click(
+          screen.getByText("instructionsPanel.removeStepModal.cancel"),
+        );
+      });
+
+      openRemoveModal();
+
+      expect(removeModalScopeRadio("currentStep")).toBeChecked();
     });
   });
 
@@ -241,12 +319,29 @@ describe("When instructionsEditable is true", () => {
       ).toBeInTheDocument();
     });
 
+    test("Does not offer the scope choice", () => {
+      openRemoveModal();
+
+      expect(
+        screen.queryByLabelText(
+          "instructionsPanel.removeStepModal.scope.currentStep",
+        ),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "instructionsPanel.removeStepModal.removeInstructions",
+        ),
+      ).toBeInTheDocument();
+    });
+
     test("Confirming removal of the only step falls back to the empty state", () => {
       fireEvent.click(screen.getByTitle("instructionsPanel.removeStep"));
 
       act(() => {
         fireEvent.click(
-          screen.getByText("instructionsPanel.removeStepModal.removeStep"),
+          screen.getByText(
+            "instructionsPanel.removeStepModal.removeInstructions",
+          ),
         );
       });
 

--- a/src/components/Modals/GeneralModal.jsx
+++ b/src/components/Modals/GeneralModal.jsx
@@ -9,6 +9,7 @@ import CloseIcon from "../../utils/CloseIcon";
 const GeneralModal = ({
   buttons = [],
   children,
+  className = "",
   defaultCallback,
   heading,
   isOpen,
@@ -30,7 +31,7 @@ const GeneralModal = ({
       <Modal
         isOpen={isOpen}
         onRequestClose={closeModal}
-        className="modal-content"
+        className={`modal-content ${className}`.trim()}
         overlayClassName="modal-overlay"
         contentLabel={heading}
         parentSelector={() =>

--- a/src/components/Modals/RemoveInstructionStepModal.jsx
+++ b/src/components/Modals/RemoveInstructionStepModal.jsx
@@ -1,26 +1,66 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
+import {
+  Fieldset,
+  RadioInput,
+} from "@raspberrypifoundation/design-system-react";
 
 import GeneralModal from "./GeneralModal";
+import {
+  REMOVE_ALL_STEPS,
+  REMOVE_CURRENT_STEP,
+} from "../../utils/instructionSteps";
 
 const RemoveInstructionStepModal = (props) => {
-  const { buttons = null, isOpen = false, setShowModal = null } = props;
+  const {
+    buttons = null,
+    isOpen = false,
+    setShowModal = null,
+    showScopeOptions = false,
+    removeScope = REMOVE_CURRENT_STEP,
+    setRemoveScope = null,
+  } = props;
 
   const { t } = useTranslation();
 
   return (
     <GeneralModal
+      className="modal-content--remove-step"
       heading={t("instructionsPanel.removeStepModal.heading")}
       text={[
         {
           type: "paragraph",
           content: t("instructionsPanel.removeStepModal.warning"),
         },
+        {
+          type: "paragraph",
+          content: t("instructionsPanel.removeStepModal.studentsWarning"),
+        },
       ]}
       buttons={buttons}
       isOpen={isOpen}
       closeModal={() => setShowModal(false)}
-    />
+    >
+      {showScopeOptions && (
+        <Fieldset
+          legendText={t("instructionsPanel.removeStepModal.scopeLegend")}
+          fullWidth
+        >
+          {[REMOVE_CURRENT_STEP, REMOVE_ALL_STEPS].map((scope) => (
+            <RadioInput
+              key={scope}
+              id={`remove-step-scope-${scope}`}
+              name="remove-step-scope"
+              value={scope}
+              label={t(`instructionsPanel.removeStepModal.scope.${scope}`)}
+              checked={removeScope === scope}
+              onChange={() => setRemoveScope(scope)}
+              fullWidth
+            />
+          ))}
+        </Fieldset>
+      )}
+    </GeneralModal>
   );
 };
 

--- a/src/utils/instructionSteps.js
+++ b/src/utils/instructionSteps.js
@@ -1,3 +1,6 @@
+export const REMOVE_CURRENT_STEP = "currentStep";
+export const REMOVE_ALL_STEPS = "allSteps";
+
 export const insertStepAfter = (steps, index, markdownContent = "") => [
   ...steps.slice(0, index + 1),
   { markdown_content: markdownContent },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2506,20 +2506,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@raspberrypifoundation/design-system-core@npm:^2.4.9":
-  version: 2.4.9
-  resolution: "@raspberrypifoundation/design-system-core@npm:2.4.9"
+"@raspberrypifoundation/design-system-core@npm:^2.4.10":
+  version: 2.4.10
+  resolution: "@raspberrypifoundation/design-system-core@npm:2.4.10"
   dependencies:
     classnames: "npm:^2.3.2"
-  checksum: 10/ae5612e19fab0ce6c58fa28f77094ef83cb05fe05caa8df3ef9b73596936352285b656458f93b375b7abfe873458e75ed6d6b9b2b1586319c03737d5f652537e
+  checksum: 10/d23850a2f04984f8f96f494481811215c1ceb24c013c95bdbe3cc94a8d6de584540e6d627839ebc4228e94682499c703328b43da202e70b374c5bd546e344e00
   languageName: node
   linkType: hard
 
-"@raspberrypifoundation/design-system-react@npm:^2.10.3":
-  version: 2.10.3
-  resolution: "@raspberrypifoundation/design-system-react@npm:2.10.3"
+"@raspberrypifoundation/design-system-react@npm:^2.10.4":
+  version: 2.10.4
+  resolution: "@raspberrypifoundation/design-system-react@npm:2.10.4"
   dependencies:
-    "@raspberrypifoundation/design-system-core": "npm:^2.4.9"
+    "@raspberrypifoundation/design-system-core": "npm:^2.4.10"
     classnames: "npm:^2.5.1"
     lucide-react: "npm:^0.553.0"
   peerDependencies:
@@ -2531,7 +2531,7 @@ __metadata:
       optional: false
     react-dom:
       optional: false
-  checksum: 10/a38bbac27b65b05f3f36376ec4d8af5d7cbaa405319a243e6c820ed09a604e7293255b034896573d989666ba8122076edf92d44aab1c14b2c99a9741fb06e53e
+  checksum: 10/f5f23416d41d524c0d0222814f3be4a87df445d305430cbaa46ce8ae598dfa754ef1e1feaec7c9b2fdededf63045482383d5076af7d4bf32cf2b2fd701f4a4ae
   languageName: node
   linkType: hard
 
@@ -2548,7 +2548,7 @@ __metadata:
     "@codemirror/view": "npm:^6.3.0"
     "@hello-pangea/dnd": "npm:^16.2.0"
     "@juggle/resize-observer": "npm:^3.3.1"
-    "@raspberrypifoundation/design-system-react": "npm:^2.10.3"
+    "@raspberrypifoundation/design-system-react": "npm:^2.10.4"
     "@raspberrypifoundation/python-friendly-error-messages": "npm:0.8.0"
     "@raspberrypifoundation/rpf-markdown-core": "npm:^0.1.4"
     "@react-three/drei": "npm:^10.0.0"


### PR DESCRIPTION
> [!WARNING]
> Merge after https://github.com/RaspberryPiFoundation/editor-standalone/pull/1075/changes#r3902526352

## Summary

Teachers can remove either the current instruction step or every step in the project. The modal defaults to the current step, so removing everything requires an explicit choice.

When the project has only one step, the scope options are hidden and the existing "Remove instructions" action remains.

Fixes https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1705

## Implementation

- Add Design System `Fieldset` and `RadioInput` controls to the removal modal.
- Reset the scope to the current step whenever the modal opens.
- Change the confirmation text to match the selected scope.
- Add the all-steps removal path and cover both scopes with tests.
- Upgrade Design System React to 2.10.4 for themeable radio dots and transparent fieldsets.
- Stop broad modal input selectors from overriding Design System controls.
- Allow `GeneralModal` callers to supply a class name.

The companion standalone change supplies the dark Design System tokens when the modal is portalled into the host application: https://github.com/RaspberryPiFoundation/editor-standalone/pull/1075

## Checks

- `yarn lint`
- `yarn stylelint`
- 1,080 unit tests
- Production build

## Screenshot

https://github.com/user-attachments/assets/e699f105-fb2e-436f-86ee-61a21d812d34
