### PR TITLE
Revert "Bump version to v0.36.4"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raspberrypifoundation/editor-ui",
-  "version": "0.36.4",
+  "version": "0.36.3",
   "private": true,
   "dependencies": {
     "@babel/core": "^7.17.10",


### PR DESCRIPTION
Reverts RaspberryPiFoundation/editor-ui#1601

There was nothing to release... oops