### PR TITLE
Improve instruction headings

### DIFF
--- a/src/assets/stylesheets/Instructions.scss
+++ b/src/assets/stylesheets/Instructions.scss
@@ -24,8 +24,18 @@
     padding-block-end: var(--project-instructions-padding, var(--space-2));
   }
 
+  h1 {
+    @include typography.style-2(bold);
+    margin-block-start: var(--space-1);
+  }
+
   h2 {
     @include typography.style-1-5(bold);
+    margin-block-start: var(--space-1);
+  }
+
+  h3 {
+    @include typography.style-1(bold);
     margin-block-start: var(--space-1);
   }
 


### PR DESCRIPTION
closes https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/420
With these changes we get [1750](https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1750) for free

Updated heading sizes:
<img width="436" height="546" alt="image" src="https://github.com/user-attachments/assets/760efa7f-79c1-4acc-ac77-8db2996e8a6d" />
