### PR TITLE
Only show scroll bars for students instructions when needed

### DIFF
--- a/src/assets/stylesheets/Instructions.scss
+++ b/src/assets/stylesheets/Instructions.scss
@@ -6,7 +6,10 @@
 @use "./scratch_colours" as *;
 
 .project-instructions {
-  block-size: 100%;
+  // Student preview sizes to its content so short steps are not scrollable.
+  &:has(.c-instruction-tabs) {
+    block-size: 100%;
+  }
 
   @each $block, $category in $scratch-block-categories {
     code.block3#{$block} {


### PR DESCRIPTION
## Summary
issue: [1707](https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1707)

Short project instructions no longer show a scrollbar. The bar still appears when the text is too long to fit.

<img width="1977" height="1225" alt="Screenshot of instructions without scroll bar" src="https://github.com/user-attachments/assets/c1494931-c99c-4e5f-ae6b-1cb0a20e8d0b" />
