### PR TITLE
Mirror instruction images

### DIFF
--- a/cypress/e2e/spec-wc-instructions.cy.js
+++ b/cypress/e2e/spec-wc-instructions.cy.js
@@ -1,5 +1,6 @@
 import {
   getAddStepButton,
+  getEditorShadow,
   getInstructionsEditTextarea,
 } from "../helpers/editor.js";
 
@@ -78,5 +79,47 @@ describe("editing multi-step instructions", () => {
         { markdown_content: "New step content" },
         { markdown_content: "Step two content" },
       ]);
+  });
+});
+
+describe("rendering mirrored instruction images", () => {
+  const sourceUrl =
+    "https://drive.google.com/thumbnail?id=1zWq7qCaoszwG_KnRl0UdFhYhV-B2FYQg";
+  const mirroredUrl =
+    "https://editor-assets.raspberrypi.org/instructions-assets/1zWq7qCaoszwG_KnRl0UdFhYhV-B2FYQg";
+
+  it("loads a Google Drive thumbnail from the CORP-enabled asset bucket", () => {
+    cy.intercept("GET", mirroredUrl, {
+      statusCode: 200,
+      headers: {
+        "content-type": "image/svg+xml",
+        "cross-origin-resource-policy": "cross-origin",
+      },
+      body: '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32"><rect width="32" height="32" fill="purple"/></svg>',
+    }).as("loadInstructionImage");
+
+    cy.intercept("GET", projectApiMatcher, {
+      statusCode: 200,
+      body: {
+        ...fixtureProject,
+        instructions: [
+          { markdown_content: `![Instruction diagram](${sourceUrl})` },
+        ],
+      },
+    }).as("loadProjectWithImage");
+
+    cy.visit(urlFor(projectIdentifier));
+    cy.wait("@loadProjectWithImage");
+
+    getEditorShadow().findByRole("tab", { name: "View" }).click();
+    cy.wait("@loadInstructionImage")
+      .its("response.headers")
+      .should("include", { "cross-origin-resource-policy": "cross-origin" });
+    getEditorShadow()
+      .findByRole("img", { name: "Instruction diagram" })
+      .should("have.attr", "src", mirroredUrl)
+      .should(($image) => {
+        expect($image[0].naturalWidth).to.be.greaterThan(0);
+      });
   });
 });

--- a/src/components/Menus/Sidebar/InstructionsPanel/InstructionsStep/InstructionsStep.jsx
+++ b/src/components/Menus/Sidebar/InstructionsPanel/InstructionsStep/InstructionsStep.jsx
@@ -4,6 +4,10 @@ import Prism from "../../../../../utils/prism";
 import sanitiseInstructions from "../../../../../utils/sanitiseInstructions";
 import { scratchblocksInit } from "../../../../../utils/scratchblocks";
 
+const GOOGLE_DRIVE_ORIGIN = "https://drive.google.com";
+const INSTRUCTION_ASSET_BASE_URL =
+  "https://editor-assets.raspberrypi.org/instructions-assets";
+
 const getStepHtml = (step) => {
   const html =
     step.content !== undefined
@@ -31,6 +35,28 @@ const applyExternalLinkAttributes = (container) => {
   });
 };
 
+const applyMirroredInstructionImages = (container) => {
+  container.querySelectorAll("img[src]").forEach((image) => {
+    try {
+      const sourceUrl = new URL(image.getAttribute("src"));
+      const id = sourceUrl.searchParams.get("id");
+
+      if (
+        sourceUrl.origin === GOOGLE_DRIVE_ORIGIN &&
+        sourceUrl.pathname === "/thumbnail" &&
+        id
+      ) {
+        image.setAttribute(
+          "src",
+          `${INSTRUCTION_ASSET_BASE_URL}/${encodeURIComponent(id)}`,
+        );
+      }
+    } catch {
+      // Leave relative and malformed image sources unchanged.
+    }
+  });
+};
+
 const InstructionsStep = ({
   className,
   step,
@@ -44,6 +70,7 @@ const InstructionsStep = ({
 
     stepContent.current.parentElement?.scrollTo({ top: 0 });
     stepContent.current.innerHTML = getStepHtml(step);
+    applyMirroredInstructionImages(stepContent.current);
     applySyntaxHighlighting(stepContent.current);
     applyExternalLinkAttributes(stepContent.current);
 

--- a/src/components/Menus/Sidebar/InstructionsPanel/InstructionsStep/InstructionsStep.test.jsx
+++ b/src/components/Menus/Sidebar/InstructionsPanel/InstructionsStep/InstructionsStep.test.jsx
@@ -45,6 +45,38 @@ describe("When the step has markdown_content", () => {
     expect(link).toHaveAttribute("target", "_blank");
     expect(link).toHaveAttribute("rel", "noreferrer");
   });
+
+  test("Uses the asset bucket for any Google Drive thumbnail ID", () => {
+    const id = "any-drive-file-id";
+
+    render(
+      <InstructionsStep
+        step={{
+          markdown_content: `![Diagram](https://drive.google.com/thumbnail?id=${id}&sz=w1000)`,
+        }}
+      />,
+    );
+
+    expect(screen.getByRole("img", { name: "Diagram" })).toHaveAttribute(
+      "src",
+      `https://editor-assets.raspberrypi.org/instructions-assets/${id}`,
+    );
+  });
+
+  test("Leaves images from other sources unchanged", () => {
+    const sourceUrl = "https://images.example/instruction.png";
+
+    render(
+      <InstructionsStep
+        step={{ markdown_content: `![Diagram](${sourceUrl})` }}
+      />,
+    );
+
+    expect(screen.getByRole("img", { name: "Diagram" })).toHaveAttribute(
+      "src",
+      sourceUrl,
+    );
+  });
 });
 
 describe("Sanitising step HTML", () => {


### PR DESCRIPTION
Related: https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1719

Display existing Experience CS instruction images in Code Classroom preview.
Google Drive thumbnail URLs in rendered instructions are rewritten from:
```text
https://drive.google.com/thumbnail?id=<image-id>
```
to:
```text
https://editor-assets.raspberrypi.org/instructions-assets/<image-id>
```
Other image URLs remain unchanged. The asset bucket effectively acts as the allowlist: unknown IDs return `404`.