### PR TITLE
Experiment to add additional project instructions collapse button

### DIFF
--- a/public/translations/en-US.json
+++ b/public/translations/en-US.json
@@ -308,8 +308,10 @@
   },
   "sidebar": {
     "collapse": "Collapse sidebar",
+    "collapseInstructions": "Collapse project instructions",
     "download": "Download project",
     "expand": "Expand sidebar",
+    "expandInstructions": "Open project instructions",
     "file": "Project files",
     "images": "Image gallery",
     "settings": "Settings",

--- a/public/translations/en.json
+++ b/public/translations/en.json
@@ -308,8 +308,10 @@
   },
   "sidebar": {
     "collapse": "Collapse sidebar",
+    "collapseInstructions": "Collapse project instructions",
     "download": "Download project",
     "expand": "Expand sidebar",
+    "expandInstructions": "Open project instructions",
     "file": "Project files",
     "images": "Image gallery",
     "settings": "Settings",

--- a/src/assets/stylesheets/Project.scss
+++ b/src/assets/stylesheets/Project.scss
@@ -50,6 +50,32 @@
     overflow: hidden;
   }
 
+  .project-bar-row {
+    display: flex;
+    align-items: stretch;
+    gap: var(--project-wrapper-grid-gap, #{$space-0-5});
+
+    .project-bar {
+      flex: 1 1 auto;
+      min-inline-size: 0;
+    }
+  }
+
+  .project-bar-row__expand {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+    box-sizing: border-box;
+    padding: $space-0-5;
+    border-radius: $space-0-5;
+    background-color: var(--editor-color-layer-3);
+    border: 1px solid var(--editor-color-outline);
+
+    .rpf-button {
+      border: none;
+    }
+  }
+
   .proj-editor-wrapper {
     display: flex;
     flex: 0 1 auto;

--- a/src/assets/stylesheets/Sidebar.scss
+++ b/src/assets/stylesheets/Sidebar.scss
@@ -122,7 +122,39 @@
 
 .sidebar__panel-heading {
   margin: 0;
+  min-inline-size: 0;
   @include font-size-1-5(regular);
+}
+
+.sidebar__panel-heading-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-0-5);
+
+  .rpf-button {
+    border: none;
+  }
+}
+
+.sidebar__panel-collapse {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  flex-shrink: 0;
+  margin: 0;
+  border: 1px solid var(--sidebar-border);
+  border-radius: var(--space-1);
+  padding: var(--space-1);
+  color: var(--editor-color-text);
+
+  svg {
+    margin: 0;
+  }
+
+  &:hover {
+    background-color: var(--sidebar-option-hover);
+  }
 }
 
 .sidebar__panel-header {

--- a/src/components/Editor/Project/Project.jsx
+++ b/src/components/Editor/Project/Project.jsx
@@ -10,6 +10,7 @@ import { showSavedMessage } from "../../../utils/Notifications";
 import ProjectBar from "../../ProjectBar/ProjectBar";
 import ScratchProjectBar from "../../ProjectBar/ScratchProjectBar";
 import Sidebar from "../../Menus/Sidebar/Sidebar";
+import SidebarExpandButton from "../../Menus/Sidebar/SidebarExpandButton";
 import EditorInput from "../EditorInput/EditorInput";
 import ResizableWithHandle from "../../../utils/ResizableWithHandle";
 import { useContainerMinWidth } from "../../../hooks/useContainerMinWidth";
@@ -69,12 +70,20 @@ const Project = (props) => {
           />
         )}
         <div className="project-wrapper" ref={containerRef}>
-          {withProjectbar &&
-            (isCodeEditorScratchProject ? (
-              <ScratchProjectBar nameEditable={nameEditable} />
-            ) : (
-              <ProjectBar nameEditable={nameEditable} />
-            ))}
+          {withProjectbar && (
+            <div className="project-bar-row">
+              {withSidebar && (
+                <SidebarExpandButton
+                  allowMobileView={!isCodeEditorScratchProject}
+                />
+              )}
+              {isCodeEditorScratchProject ? (
+                <ScratchProjectBar nameEditable={nameEditable} />
+              ) : (
+                <ProjectBar nameEditable={nameEditable} />
+              )}
+            </div>
+          )}
           {!loading && !isCodeEditorScratchProject && (
             <div className="proj-editor-wrapper">
               <ResizableWithHandle

--- a/src/components/Menus/Sidebar/InstructionsPanel/InstructionsPanel.jsx
+++ b/src/components/Menus/Sidebar/InstructionsPanel/InstructionsPanel.jsx
@@ -1,13 +1,13 @@
 /* eslint-disable jsx-a11y/anchor-has-content */
 // This is disabled because the empty anchor tag is used for translation and will have content when rendered.
 
-import React, { useRef, useState } from "react";
+import { Button } from "@raspberrypifoundation/design-system-react";
+import { useRef, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { useDispatch, useSelector } from "react-redux";
 import { Tab, TabList, TabPanel, Tabs } from "react-tabs";
-import SidebarPanel from "../SidebarPanel";
-
-
+import BinIcon from "../../../../assets/icons/bin.svg";
+import DoubleArrowLeft from "../../../../assets/icons/double_arrow_left.svg";
 import PlusIcon from "../../../../assets/icons/plus.svg";
 import demoInstructions from "../../../../assets/markdown/demoInstructions.md?raw";
 import "../../../../assets/stylesheets/Instructions.scss?inline";
@@ -18,19 +18,16 @@ import {
 } from "../../../../redux/InstructionsSlice";
 import {
   insertStepAfter,
-  removeStepAt,
-  updateStepMarkdown,
   REMOVE_ALL_STEPS,
   REMOVE_CURRENT_STEP,
+  removeStepAt,
+  updateStepMarkdown,
 } from "../../../../utils/instructionSteps";
 import populateMarkdownTemplate from "../../../../utils/populateMarkdownTemplate";
-import { Button } from "@raspberrypifoundation/design-system-react";
 import RemoveInstructionStepModal from "../../../Modals/RemoveInstructionStepModal";
+import SidebarPanel from "../SidebarPanel";
 import InstructionsStep from "./InstructionsStep/InstructionsStep";
 import ProgressBar from "./ProgressBar/ProgressBar";
-import BinIcon from "../../../../assets/icons/bin.svg";
-import DoubleArrowLeft from "../../../../assets/icons/double_arrow_left.svg";
-import EditorButton from "../../../Button/Button";
 
 const INSTRUCTIONS_GUIDE_URL =
   "https://help.editor.raspberrypi.org/hc/en-us/articles/52495086715028-How-to-write-project-instructions";
@@ -127,21 +124,15 @@ const InstructionsPanel = ({ toggleOption, isMobile }) => {
       heading={t("instructionsPanel.projectSteps")}
       headingPrefix={
         !isMobile && toggleOption ? (
-           <Button
-                  className="sidebar__panel-collapse"
-                  icon={"keyboard_double_arrow_left"}
-                  iconOnly
-                  text={t("sidebar.collapseInstructions")}
-                  onClick={collapsePanel}
-                  size="small"
-                  type="tertiary"
-                />
-          // <EditorButton
-          //   className="sidebar__panel-collapse"
-          //   ButtonIcon={DoubleArrowLeft}
-          //   title={t("sidebar.collapseInstructions")}
-          //   onClickHandler={collapsePanel}
-          // />
+          <Button
+            className="sidebar__panel-collapse"
+            icon={<DoubleArrowLeft />}
+            iconOnly
+            text={t("sidebar.collapseInstructions")}
+            onClick={collapsePanel}
+            size="small"
+            type="tertiary"
+          />
         ) : undefined
       }
       buttons={

--- a/src/components/Menus/Sidebar/InstructionsPanel/InstructionsPanel.jsx
+++ b/src/components/Menus/Sidebar/InstructionsPanel/InstructionsPanel.jsx
@@ -7,6 +7,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { Tab, TabList, TabPanel, Tabs } from "react-tabs";
 import SidebarPanel from "../SidebarPanel";
 
+
 import PlusIcon from "../../../../assets/icons/plus.svg";
 import demoInstructions from "../../../../assets/markdown/demoInstructions.md?raw";
 import "../../../../assets/stylesheets/Instructions.scss?inline";
@@ -28,11 +29,13 @@ import RemoveInstructionStepModal from "../../../Modals/RemoveInstructionStepMod
 import InstructionsStep from "./InstructionsStep/InstructionsStep";
 import ProgressBar from "./ProgressBar/ProgressBar";
 import BinIcon from "../../../../assets/icons/bin.svg";
+import DoubleArrowLeft from "../../../../assets/icons/double_arrow_left.svg";
+import EditorButton from "../../../Button/Button";
 
 const INSTRUCTIONS_GUIDE_URL =
   "https://help.editor.raspberrypi.org/hc/en-us/articles/52495086715028-How-to-write-project-instructions";
 
-const InstructionsPanel = () => {
+const InstructionsPanel = ({ toggleOption, isMobile }) => {
   const [tabIndex, setTabIndex] = useState(0);
   const [showRemoveStepModal, setShowRemoveStepModal] = useState(false);
   const [removeScope, setRemoveScope] = useState(REMOVE_CURRENT_STEP);
@@ -110,11 +113,37 @@ const InstructionsPanel = () => {
 
   const panelRef = useRef(null);
 
+  const collapsePanel = () => {
+    toggleOption("instructions");
+    if (window.plausible) {
+      window.plausible("Collapse file pane");
+    }
+  };
+
   return (
     <SidebarPanel
       defaultWidth="30vw"
       panelRef={panelRef}
       heading={t("instructionsPanel.projectSteps")}
+      headingPrefix={
+        !isMobile && toggleOption ? (
+           <Button
+                  className="sidebar__panel-collapse"
+                  icon={"keyboard_double_arrow_left"}
+                  iconOnly
+                  text={t("sidebar.collapseInstructions")}
+                  onClick={collapsePanel}
+                  size="small"
+                  type="tertiary"
+                />
+          // <EditorButton
+          //   className="sidebar__panel-collapse"
+          //   ButtonIcon={DoubleArrowLeft}
+          //   title={t("sidebar.collapseInstructions")}
+          //   onClickHandler={collapsePanel}
+          // />
+        ) : undefined
+      }
       buttons={
         instructionsEditable && !hasInstructions
           ? [

--- a/src/components/Menus/Sidebar/InstructionsPanel/InstructionsPanel.test.jsx
+++ b/src/components/Menus/Sidebar/InstructionsPanel/InstructionsPanel.test.jsx
@@ -42,6 +42,44 @@ const selectRemoveModalScope = (scope) =>
     fireEvent.click(removeModalScopeRadio(scope));
   });
 
+describe("The panel header collapse button", () => {
+  const renderPanel = (props = {}) =>
+    renderWithProviders(<InstructionsPanel {...props} />, {
+      preloadedState: {
+        editor: {
+          project: { instructions: [{ markdown_content: "instructions" }] },
+          instructionsEditable: true,
+        },
+        instructions: { permitOverride: true, currentStepPosition: 0 },
+      },
+    });
+
+  test("is not rendered when the panel cannot be toggled", () => {
+    renderPanel();
+
+    expect(
+      screen.queryByTitle("sidebar.collapseInstructions"),
+    ).not.toBeInTheDocument();
+  });
+
+  test("is not rendered on mobile", () => {
+    renderPanel({ toggleOption: vi.fn(), isMobile: true });
+
+    expect(
+      screen.queryByTitle("sidebar.collapseInstructions"),
+    ).not.toBeInTheDocument();
+  });
+
+  test("closes the instructions panel when clicked", () => {
+    const toggleOption = vi.fn();
+    renderPanel({ toggleOption });
+
+    fireEvent.click(screen.getByTitle("sidebar.collapseInstructions"));
+
+    expect(toggleOption).toHaveBeenCalledWith("instructions");
+  });
+});
+
 describe("When instructionsEditable changes from false to true", () => {
   test("does not leave the rendered preview above the edit/view tabs", () => {
     const { container, store } = renderWithProviders(<InstructionsPanel />, {

--- a/src/components/Menus/Sidebar/Sidebar.jsx
+++ b/src/components/Menus/Sidebar/Sidebar.jsx
@@ -212,6 +212,8 @@ const Sidebar = ({
     } else if (!optionIsAvailable) {
       setOption(nextDefaultOption);
       dispatch(setSidebarOption(nextDefaultOption));
+    } else {
+      setOption(selectedSidebarOption);
     }
   }, [dispatch, nextDefaultOption, optionIsAvailable, selectedSidebarOption]);
 
@@ -245,7 +247,7 @@ const Sidebar = ({
     >
       <SidebarBar
         menuOptions={menuOptions}
-        option={activeOption}
+        activeOption={activeOption}
         toggleOption={toggleOption}
         instructions={instructionsSteps}
         allowMobileView={allowMobileView}
@@ -253,6 +255,7 @@ const Sidebar = ({
       {activeOption && (
         <CustomSidebarPanel
           isMobile={isMobile}
+          toggleOption={toggleOption}
           {...(optionDict.panelProps || {})}
         />
       )}

--- a/src/components/Menus/Sidebar/SidebarBar.jsx
+++ b/src/components/Menus/Sidebar/SidebarBar.jsx
@@ -16,7 +16,7 @@ import { MOBILE_MEDIA_QUERY } from "../../../utils/mediaQueryBreakpoints";
 const SidebarBar = (props) => {
   const {
     menuOptions,
-    option,
+    activeOption,
     toggleOption,
     instructions = false,
     allowMobileView = true,
@@ -59,7 +59,7 @@ const SidebarBar = (props) => {
   };
 
   const collapsePopOut = () => {
-    toggleOption(option);
+    toggleOption(activeOption);
     if (window.plausible) {
       window.plausible("Collapse file pane");
     }
@@ -81,7 +81,7 @@ const SidebarBar = (props) => {
   return (
     <div
       className={classNames("sidebar__bar", {
-        "sidebar__bar--selected": option,
+        "sidebar__bar--selected": activeOption,
       })}
     >
       <div className={`sidebar__bar-options--top`}>
@@ -95,7 +95,7 @@ const SidebarBar = (props) => {
             key={i}
             Icon={menuOption.icon}
             title={menuOption.title}
-            isActive={option === menuOption.name}
+            isActive={activeOption === menuOption.name}
             toggleOption={toggleOption}
             name={menuOption.name}
           />
@@ -107,13 +107,13 @@ const SidebarBar = (props) => {
             key={i}
             Icon={menuOption.icon}
             title={menuOption.title}
-            isActive={option === menuOption.name}
+            isActive={activeOption === menuOption.name}
             toggleOption={toggleOption}
             name={menuOption.name}
           />
         ))}
         {!isMobile &&
-          (option ? (
+          (activeOption ? (
             <div className="sidebar__bar-option-wrapper">
               <Button
                 className="sidebar__bar-option"

--- a/src/components/Menus/Sidebar/SidebarExpandButton.jsx
+++ b/src/components/Menus/Sidebar/SidebarExpandButton.jsx
@@ -1,0 +1,64 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { useDispatch, useSelector } from "react-redux";
+import { useTranslation } from "react-i18next";
+import { useMediaQuery } from "react-responsive";
+
+import DoubleArrowRight from "../../../assets/icons/double_arrow_right.svg";
+import { Button } from "@raspberrypifoundation/design-system-react";
+
+import { setSidebarOption } from "../../../redux/EditorSlice";
+import { selectInstructionSteps } from "../../../redux/InstructionsSlice";
+import { MOBILE_MEDIA_QUERY } from "../../../utils/mediaQueryBreakpoints";
+
+// Sits alongside the project bar and reopens the project instructions panel
+// while the sidebar is collapsed. The equivalent collapse control lives in the
+// instructions panel header.
+const SidebarExpandButton = ({ allowMobileView = true }) => {
+  const dispatch = useDispatch();
+  const { t } = useTranslation();
+  const selectedSidebarOption = useSelector(
+    (state) => state.editor.selectedSidebarOption,
+  );
+  const instructionsEditable = useSelector(
+    (state) => state.editor.instructionsEditable,
+  );
+  const instructionsSteps = useSelector(selectInstructionSteps);
+  const viewportIsMobile = useMediaQuery({ query: MOBILE_MEDIA_QUERY });
+  const isMobile = allowMobileView && viewportIsMobile;
+
+  const hasInstructions = instructionsSteps && instructionsSteps.length > 0;
+  const instructionsAvailable = instructionsEditable || hasInstructions;
+  const isCollapsed = selectedSidebarOption === null;
+
+  if (isMobile || !isCollapsed || !instructionsAvailable) {
+    return null;
+  }
+
+  const expandPanel = () => {
+    dispatch(setSidebarOption("instructions"));
+    if (window.plausible) {
+      window.plausible("Expand file pane");
+    }
+  };
+
+  return (
+    <div className="project-bar-row__expand">
+      <Button
+        className="sidebar__panel-collapse"
+        icon={"keyboard_double_arrow_right"}
+        iconOnly
+        text={t("sidebar.expandInstructions")}
+        onClick={expandPanel}
+        size="small"
+        type="tertiary"
+      />
+    </div>
+  );
+};
+
+SidebarExpandButton.propTypes = {
+  allowMobileView: PropTypes.bool,
+};
+
+export default SidebarExpandButton;

--- a/src/components/Menus/Sidebar/SidebarExpandButton.jsx
+++ b/src/components/Menus/Sidebar/SidebarExpandButton.jsx
@@ -46,7 +46,7 @@ const SidebarExpandButton = ({ allowMobileView = true }) => {
     <div className="project-bar-row__expand">
       <Button
         className="sidebar__panel-collapse"
-        icon={"keyboard_double_arrow_right"}
+        icon={<DoubleArrowRight />}
         iconOnly
         text={t("sidebar.expandInstructions")}
         onClick={expandPanel}

--- a/src/components/Menus/Sidebar/SidebarExpandButton.test.jsx
+++ b/src/components/Menus/Sidebar/SidebarExpandButton.test.jsx
@@ -1,0 +1,83 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import configureStore from "redux-mock-store";
+import { Provider } from "react-redux";
+
+import SidebarExpandButton from "./SidebarExpandButton";
+import { setSidebarOption } from "../../../redux/EditorSlice";
+
+const renderButton = (editorState = {}, instructionsState = {}, props = {}) => {
+  const mockStore = configureStore([]);
+  const store = mockStore({
+    editor: {
+      project: { components: [] },
+      ...editorState,
+    },
+    instructions: instructionsState,
+  });
+
+  return {
+    store,
+    ...render(
+      <Provider store={store}>
+        <SidebarExpandButton {...props} />
+      </Provider>,
+    ),
+  };
+};
+
+describe("SidebarExpandButton", () => {
+  test("is hidden while the sidebar panel is open", () => {
+    renderButton({ selectedSidebarOption: "instructions" });
+
+    expect(
+      screen.queryByTitle("sidebar.expandInstructions"),
+    ).not.toBeInTheDocument();
+  });
+
+  test("is hidden before a sidebar option has been stored", () => {
+    renderButton({ instructionsEditable: true });
+
+    expect(
+      screen.queryByTitle("sidebar.expandInstructions"),
+    ).not.toBeInTheDocument();
+  });
+
+  test("is hidden when the project has no instructions to show", () => {
+    renderButton({ selectedSidebarOption: null, instructionsEditable: false });
+
+    expect(
+      screen.queryByTitle("sidebar.expandInstructions"),
+    ).not.toBeInTheDocument();
+  });
+
+  test("is shown when the panel is collapsed and instructions are editable", () => {
+    renderButton({ selectedSidebarOption: null, instructionsEditable: true });
+
+    expect(
+      screen.queryByTitle("sidebar.expandInstructions"),
+    ).toBeInTheDocument();
+  });
+
+  test("is shown when the panel is collapsed and the project has steps", () => {
+    renderButton(
+      { selectedSidebarOption: null, instructionsEditable: false },
+      { project: { steps: [{ content: "<p>step 0</p>" }] } },
+    );
+
+    expect(
+      screen.queryByTitle("sidebar.expandInstructions"),
+    ).toBeInTheDocument();
+  });
+
+  test("opens the instructions panel when clicked", () => {
+    const { store } = renderButton({
+      selectedSidebarOption: null,
+      instructionsEditable: true,
+    });
+
+    fireEvent.click(screen.getByTitle("sidebar.expandInstructions"));
+
+    expect(store.getActions()).toEqual([setSidebarOption("instructions")]);
+  });
+});

--- a/src/components/Menus/Sidebar/SidebarPanel.jsx
+++ b/src/components/Menus/Sidebar/SidebarPanel.jsx
@@ -13,6 +13,7 @@ const SidebarPanel = (props) => {
     className,
     buttons,
     headerContent,
+    headingPrefix,
     panelRef,
     defaultWidth = "320px",
   } = props;
@@ -24,7 +25,10 @@ const SidebarPanel = (props) => {
   const panelContent = (
     <>
       <div className="sidebar__panel-header">
-        <h2 className="sidebar__panel-heading">{heading}</h2>
+        <div className="sidebar__panel-heading-row">
+          {headingPrefix}
+          <h2 className="sidebar__panel-heading">{heading}</h2>
+        </div>
         {buttons && !buttonsIsEmptyArray && (
           <div className="sidebar__panel-buttons">{buttons}</div>
         )}
@@ -65,6 +69,7 @@ SidebarPanel.propTypes = {
   className: PropTypes.string,
   buttons: PropTypes.arrayOf(PropTypes.node),
   headerContent: PropTypes.node,
+  headingPrefix: PropTypes.node,
 };
 
 export default SidebarPanel;


### PR DESCRIPTION
The instruction panel collapse button (double arrow) is easily missed. This PR adds an additional button next to the projects instructions header. 

✨ **This has had very little design input so is currently here in draft form for prototyping reasons**. ✨ 

<img width="1072" height="875" alt="Screenshot 2026-09-09 at 15 58 59" src="https://github.com/user-attachments/assets/1b4134c7-06c1-4410-aed3-d4d13028267f" />
<img width="1294" height="878" alt="Screenshot 2026-09-09 at 15 59 17" src="https://github.com/user-attachments/assets/f8381fc6-ab67-4a28-a390-a216593b83d2" />
