### PR TITLE
Fix: don't show one person's project to the next person on a shared computer

### DIFF
--- a/src/containers/WebComponentLoader.jsx
+++ b/src/containers/WebComponentLoader.jsx
@@ -18,6 +18,7 @@ import { useProject } from "../hooks/useProject";
 import { useEmbeddedMode } from "../hooks/useEmbeddedMode";
 import { useProjectPersistence } from "../hooks/useProjectPersistence";
 import { useSyncUserFromLocalStorage } from "../hooks/useSyncUserFromLocalStorage";
+import useSyncCurrentUserId from "../hooks/useSyncCurrentUserId";
 import { SettingsContext } from "../utils/settings";
 import { useCookies } from "react-cookie";
 import NewFileModal from "../components/Modals/NewFileModal";
@@ -81,6 +82,7 @@ const WebComponentLoader = (props) => {
   const [projectIdentifier, setProjectIdentifier] = useState(identifier);
   localStorage.setItem("authKey", authKey);
   const user = useSelector((state) => state.auth.user);
+  useSyncCurrentUserId(user);
   const project = useSelector((state) => state.editor.project);
   const projectOwner = useSelector((state) => state.editor.project.user_name);
   const loading = useSelector((state) => state.editor.loading);

--- a/src/hooks/useSyncCurrentUserId.js
+++ b/src/hooks/useSyncCurrentUserId.js
@@ -1,8 +1,5 @@
 import { setCurrentUser } from "../utils/apiCallHandler";
 
-// Sync during render, not in an effect: effects run child-before-parent, so a
-// descendant's request effect could otherwise fire with a renewed token before
-// this ancestor effect updates the association, missing the cache for that load.
 const useSyncCurrentUserId = (user) => {
   const accessToken = user?.access_token || null;
   const userId = user?.profile?.user ?? user?.profile?.sub ?? null;

--- a/src/hooks/useSyncCurrentUserId.js
+++ b/src/hooks/useSyncCurrentUserId.js
@@ -5,7 +5,7 @@ import { setCurrentUser } from "../utils/apiCallHandler";
 // this ancestor effect updates the association, missing the cache for that load.
 const useSyncCurrentUserId = (user) => {
   const accessToken = user?.access_token || null;
-  const userId = user?.profile?.sub || user?.profile?.user || null;
+  const userId = user?.profile?.user ?? user?.profile?.sub ?? null;
 
   setCurrentUser(accessToken, userId);
 };

--- a/src/hooks/useSyncCurrentUserId.js
+++ b/src/hooks/useSyncCurrentUserId.js
@@ -1,0 +1,13 @@
+import { setCurrentUser } from "../utils/apiCallHandler";
+
+// Sync during render, not in an effect: effects run child-before-parent, so a
+// descendant's request effect could otherwise fire with a renewed token before
+// this ancestor effect updates the association, missing the cache for that load.
+const useSyncCurrentUserId = (user) => {
+  const accessToken = user?.access_token || null;
+  const userId = user?.profile?.sub || user?.profile?.user || null;
+
+  setCurrentUser(accessToken, userId);
+};
+
+export default useSyncCurrentUserId;

--- a/src/hooks/useSyncCurrentUserId.test.js
+++ b/src/hooks/useSyncCurrentUserId.test.js
@@ -1,0 +1,52 @@
+import { renderHook } from "@testing-library/react";
+import useSyncCurrentUserId from "./useSyncCurrentUserId";
+import { setCurrentUser } from "../utils/apiCallHandler";
+
+vi.mock("../utils/apiCallHandler", () => ({
+  setCurrentUser: vi.fn(),
+}));
+
+describe("useSyncCurrentUserId", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sets the current user from the access token and OIDC subject", () => {
+    const user = {
+      access_token: "token-123",
+      profile: { sub: "sub-1", user: "user-1" },
+    };
+
+    renderHook(() => useSyncCurrentUserId(user));
+
+    expect(setCurrentUser).toHaveBeenCalledWith("token-123", "sub-1");
+  });
+
+  it("falls back to profile.user when sub is missing", () => {
+    const user = { access_token: "token-123", profile: { user: "user-1" } };
+
+    renderHook(() => useSyncCurrentUserId(user));
+
+    expect(setCurrentUser).toHaveBeenCalledWith("token-123", "user-1");
+  });
+
+  it("clears the current user when logged out", () => {
+    renderHook(() => useSyncCurrentUserId(null));
+
+    expect(setCurrentUser).toHaveBeenCalledWith(null, null);
+  });
+
+  it("re-syncs when the access token changes", () => {
+    const { rerender } = renderHook(({ user }) => useSyncCurrentUserId(user), {
+      initialProps: {
+        user: { access_token: "token-123", profile: { sub: "sub-1" } },
+      },
+    });
+
+    rerender({
+      user: { access_token: "token-456", profile: { sub: "sub-1" } },
+    });
+
+    expect(setCurrentUser).toHaveBeenCalledWith("token-456", "sub-1");
+  });
+});

--- a/src/hooks/useSyncCurrentUserId.test.js
+++ b/src/hooks/useSyncCurrentUserId.test.js
@@ -11,7 +11,7 @@ describe("useSyncCurrentUserId", () => {
     vi.clearAllMocks();
   });
 
-  it("sets the current user from the access token and OIDC subject", () => {
+  it("sets the current user from the access token and profile.user", () => {
     const user = {
       access_token: "token-123",
       profile: { sub: "sub-1", user: "user-1" },
@@ -19,15 +19,26 @@ describe("useSyncCurrentUserId", () => {
 
     renderHook(() => useSyncCurrentUserId(user));
 
-    expect(setCurrentUser).toHaveBeenCalledWith("token-123", "sub-1");
+    expect(setCurrentUser).toHaveBeenCalledWith("token-123", "user-1");
   });
 
-  it("falls back to profile.user when sub is missing", () => {
-    const user = { access_token: "token-123", profile: { user: "user-1" } };
+  it("falls back to profile.sub when profile.user is missing", () => {
+    const user = { access_token: "token-123", profile: { sub: "sub-1" } };
 
     renderHook(() => useSyncCurrentUserId(user));
 
-    expect(setCurrentUser).toHaveBeenCalledWith("token-123", "user-1");
+    expect(setCurrentUser).toHaveBeenCalledWith("token-123", "sub-1");
+  });
+
+  it("does not treat a falsy profile.user like 0 as missing", () => {
+    const user = {
+      access_token: "token-123",
+      profile: { user: 0, sub: "sub-1" },
+    };
+
+    renderHook(() => useSyncCurrentUserId(user));
+
+    expect(setCurrentUser).toHaveBeenCalledWith("token-123", 0);
   });
 
   it("clears the current user when logged out", () => {

--- a/src/utils/apiCallHandler.js
+++ b/src/utils/apiCallHandler.js
@@ -1,11 +1,9 @@
 import axios from "axios";
 import omit from "lodash/omit";
 
-// Set by useSyncCurrentUserId whenever this tab's own auth user changes. Module-level
-// (not localStorage, which is shared across tabs) so a second tab signing in as someone
-// else can never relabel this tab's requests: the id is only used if it's still paired
-// with the exact access token this specific request is using. Mirrors the same pattern
-// in editor-standalone's apiCallHandler/shared.js — see that file for the full reasoning.
+// Kept in memory, not localStorage (shared across tabs), and only used if
+// the access token still matches, same approach as editor-standalone's
+// apiCallHandler/shared.js.
 let currentAccessToken = null;
 let currentUserId = null;
 

--- a/src/utils/apiCallHandler.js
+++ b/src/utils/apiCallHandler.js
@@ -36,10 +36,11 @@ const ApiCallHandler = ({ reactAppApiEndpoint }) => {
         Accept: "application/json",
         Authorization: accessToken,
       };
-      // Read by the service worker to scope its offline cache per user — Authorization
-      // rotates on token renewal so it can't be used for that without fragmenting the cache
+      // Read by the service worker to scope its offline cache per user —
+      // Authorization rotates on token renewal so it can't be used for that
+      // without fragmenting the cache
       const userId = getStableUserId(accessToken);
-      if (userId) {
+      if (userId != null) {
         headersHash["X-Editor-User-Id"] = userId;
       }
       return headersHash;

--- a/src/utils/apiCallHandler.js
+++ b/src/utils/apiCallHandler.js
@@ -1,6 +1,22 @@
 import axios from "axios";
 import omit from "lodash/omit";
 
+// Set by useSyncCurrentUserId whenever this tab's own auth user changes. Module-level
+// (not localStorage, which is shared across tabs) so a second tab signing in as someone
+// else can never relabel this tab's requests: the id is only used if it's still paired
+// with the exact access token this specific request is using. Mirrors the same pattern
+// in editor-standalone's apiCallHandler/shared.js — see that file for the full reasoning.
+let currentAccessToken = null;
+let currentUserId = null;
+
+export const setCurrentUser = (accessToken, userId) => {
+  currentAccessToken = accessToken || null;
+  currentUserId = accessToken ? userId : null;
+};
+
+const getStableUserId = (accessToken) =>
+  accessToken && accessToken === currentAccessToken ? currentUserId : null;
+
 const ApiCallHandler = ({ reactAppApiEndpoint }) => {
   const host = reactAppApiEndpoint;
 
@@ -18,7 +34,17 @@ const ApiCallHandler = ({ reactAppApiEndpoint }) => {
 
   const headers = (accessToken) => {
     if (accessToken) {
-      return { Accept: "application/json", Authorization: accessToken };
+      const headersHash = {
+        Accept: "application/json",
+        Authorization: accessToken,
+      };
+      // Read by the service worker to scope its offline cache per user — Authorization
+      // rotates on token renewal so it can't be used for that without fragmenting the cache
+      const userId = getStableUserId(accessToken);
+      if (userId) {
+        headersHash["X-Editor-User-Id"] = userId;
+      }
+      return headersHash;
     } else {
       return { Accept: "application/json" };
     }

--- a/src/utils/apiCallHandler.test.js
+++ b/src/utils/apiCallHandler.test.js
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-import ApiCallHandler from "./apiCallHandler";
+import ApiCallHandler, { setCurrentUser } from "./apiCallHandler";
 
 vi.mock("axios");
 const host = "http://localhost:3009";
@@ -222,6 +222,55 @@ describe("Testing project errors API calls", () => {
         error_type: error?.errorType,
       },
       undefined,
+    );
+  });
+});
+
+describe("X-Editor-User-Id header", () => {
+  afterEach(() => {
+    setCurrentUser(null, null);
+  });
+
+  test("is added when it matches the current access token", async () => {
+    setCurrentUser(accessToken, "user-sub-123");
+    axios.get.mockImplementationOnce(() => Promise.resolve());
+
+    await readProject("hello-world-project", null, accessToken);
+
+    expect(axios.get).toHaveBeenCalledWith(
+      `${host}/api/projects/hello-world-project`,
+      {
+        headers: {
+          Accept: "application/json",
+          Authorization: accessToken,
+          "X-Editor-User-Id": "user-sub-123",
+        },
+        withCredentials: true,
+      },
+    );
+  });
+
+  test("is omitted when no current user has been set", async () => {
+    axios.get.mockImplementationOnce(() => Promise.resolve());
+
+    await readProject("hello-world-project", null, accessToken);
+
+    expect(axios.get).toHaveBeenCalledWith(
+      `${host}/api/projects/hello-world-project`,
+      { ...authHeaders, withCredentials: true },
+    );
+  });
+
+  test("is omitted when the access token does not match the current user's token", async () => {
+    // Simulates another tab signing in as someone else.
+    setCurrentUser("someone-elses-token", "someone-elses-id");
+    axios.get.mockImplementationOnce(() => Promise.resolve());
+
+    await readProject("hello-world-project", null, accessToken);
+
+    expect(axios.get).toHaveBeenCalledWith(
+      `${host}/api/projects/hello-world-project`,
+      { ...authHeaders, withCredentials: true },
     );
   });
 });

--- a/src/utils/apiCallHandler.test.js
+++ b/src/utils/apiCallHandler.test.js
@@ -250,6 +250,25 @@ describe("X-Editor-User-Id header", () => {
     );
   });
 
+  test("is added when the current user id is 0", async () => {
+    setCurrentUser(accessToken, 0);
+    axios.get.mockImplementationOnce(() => Promise.resolve());
+
+    await readProject("hello-world-project", null, accessToken);
+
+    expect(axios.get).toHaveBeenCalledWith(
+      `${host}/api/projects/hello-world-project`,
+      {
+        headers: {
+          Accept: "application/json",
+          Authorization: accessToken,
+          "X-Editor-User-Id": 0,
+        },
+        withCredentials: true,
+      },
+    );
+  });
+
   test("is omitted when no current user has been set", async () => {
     axios.get.mockImplementationOnce(() => Promise.resolve());
 
@@ -261,7 +280,7 @@ describe("X-Editor-User-Id header", () => {
     );
   });
 
-  test("is omitted when the access token does not match the current user's token", async () => {
+  test("is omitted when the token doesn't match the current user", async () => {
     // Simulates another tab signing in as someone else.
     setCurrentUser("someone-elses-token", "someone-elses-id");
     axios.get.mockImplementationOnce(() => Promise.resolve());


### PR DESCRIPTION
## Summary

related to Issue: [1579](https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1579)

Was part of https://github.com/RaspberryPiFoundation/editor-standalone/pull/1084

## What this fixes

On a shared or classroom computer, if one person opens a project and then
someone else uses the same browser afterwards, the offline cache could show
the second person the first person's project — even though they never had
access to it. This branch fixes that for the editor.

## How it works

- Each browser tab now keeps track of who is currently logged in, kept in the
  tab's own memory rather than anything shared across tabs.
- Every request the editor makes now includes a small marker saying who is
  asking. This lets the offline cache (handled in a companion fix in
  `editor-standalone`) store each person's projects separately, instead of
  in one shared pile.
- Fixed a bug where a person whose account id happened to be `0` would have
  been silently treated as "nobody," meaning that account would never get
  this protection.

## Why this repo needed its own fix

The main project-loading and saving screen (`<editor-wc>`) is driven by this
repo, not by `editor-standalone`. The original fix only covered
`editor-standalone`'s own code, so it missed the actual screen most people
use day to day. This branch applies the same fix here.

## Testing

- Unit tests cover: the marker is attached correctly, it's left off when
  nobody is logged in, it's left off if the login state hasn't caught up yet
  (rather than risk using the wrong person's marker), and the account-id-`0`
  case.
- Manual browser testing was done against the paired `editor-standalone`
  branch, which is where the offline cache itself is scoped per person.

