### PR TITLE
keep Scratch block pills whole when instructions wrap

### DIFF
--- a/src/assets/stylesheets/Instructions.scss
+++ b/src/assets/stylesheets/Instructions.scss
@@ -17,6 +17,10 @@
     }
   }
 
+  code[class*="block3"] {
+    display: inline-block;
+  }
+
   @media (prefers-contrast: more) {
     code[class*="block3"] {
       color: var(--rpf-black);


### PR DESCRIPTION
closes https://github.com/RaspberryPiFoundation/digital-editor-issues/issues/1801

Video:
https://github.com/user-attachments/assets/4dfbdc6a-4a70-4781-9446-9a8c4991d828

Edit:
Added a small margin between blocks so they didn't stack -
<img width="507" height="600" alt="Screenshot 2026-09-14 at 09 07 09" src="https://github.com/user-attachments/assets/867e678f-2494-4713-8e74-0977571a5984" />


