### PR TITLE
Revert @codemirror/language bump to fix syntax highlighting

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@codemirror/lang-html": "^6.1.2",
     "@codemirror/lang-javascript": "^6.2.1",
     "@codemirror/lang-python": "6.1.2",
-    "@codemirror/language": "^6.12.4",
+    "@codemirror/language": "^6.2.1",
     "@codemirror/view": "^6.3.0",
     "@hello-pangea/dnd": "^16.2.0",
     "@juggle/resize-observer": "^3.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -661,7 +661,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@codemirror/language@npm:^6.0.0, @codemirror/language@npm:^6.4.0, @codemirror/language@npm:^6.6.0":
+"@codemirror/language@npm:^6.0.0, @codemirror/language@npm:^6.2.1, @codemirror/language@npm:^6.4.0, @codemirror/language@npm:^6.6.0":
   version: 6.10.3
   resolution: "@codemirror/language@npm:6.10.3"
   dependencies:
@@ -672,20 +672,6 @@ __metadata:
     "@lezer/lr": "npm:^1.0.0"
     style-mod: "npm:^4.0.0"
   checksum: 10/75869ca19c76998cc9be76f02061b6212d389b29647cf72505a06495fba3b330003f9952ddf8762bcaa2bf4defd39fd4f240d05b3df0b28c1c4415a025bc257c
-  languageName: node
-  linkType: hard
-
-"@codemirror/language@npm:^6.12.4":
-  version: 6.12.4
-  resolution: "@codemirror/language@npm:6.12.4"
-  dependencies:
-    "@codemirror/state": "npm:^6.0.0"
-    "@codemirror/view": "npm:^6.23.0"
-    "@lezer/common": "npm:^1.5.0"
-    "@lezer/highlight": "npm:^1.0.0"
-    "@lezer/lr": "npm:^1.0.0"
-    style-mod: "npm:^4.0.0"
-  checksum: 10/6a9af11337d15036761ad959dceba4cfd054cdfae84afa4d54534927d277591a57c2b581f66df4428510dd06c641151aa699ab1dc7c338d923ac06a219d83bc6
   languageName: node
   linkType: hard
 
@@ -1543,13 +1529,6 @@ __metadata:
   version: 1.2.3
   resolution: "@lezer/common@npm:1.2.3"
   checksum: 10/dad24e353e4e67d88b203191361ca1dff26c01c2b7b4ae829b668a1d115929334d077217367683e39180c0556510ed2066ea8ddba2b079be7c08a7152208cc87
-  languageName: node
-  linkType: hard
-
-"@lezer/common@npm:^1.5.0":
-  version: 1.5.2
-  resolution: "@lezer/common@npm:1.5.2"
-  checksum: 10/62c0a0ce431cb14bfa6cded04e24a05efa566e9260314bb3f3cf547d501efa1db5c83fc9a7871f8e0b6a4030212840f0e6567433168960c7c83bb3ffbeef8b99
   languageName: node
   linkType: hard
 
@@ -2577,7 +2556,7 @@ __metadata:
     "@codemirror/lang-html": "npm:^6.1.2"
     "@codemirror/lang-javascript": "npm:^6.2.1"
     "@codemirror/lang-python": "npm:6.1.2"
-    "@codemirror/language": "npm:^6.12.4"
+    "@codemirror/language": "npm:^6.2.1"
     "@codemirror/view": "npm:^6.3.0"
     "@hello-pangea/dnd": "npm:^16.2.0"
     "@juggle/resize-observer": "npm:^3.3.1"


### PR DESCRIPTION
This breaks syntax highlighting

This reverts commit c75ac5289d5a7ed43e7e02fedade852fae0ad4c4 / #1624 

Will make an issue to investigate